### PR TITLE
Extend the abstract state machine as an array of controllers

### DIFF
--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -51,9 +51,8 @@ proof fn consumer_property_holds<S, I>(spec: TempPred<S>)
 // To prove the above theorem, there are three proof obligations.
 
 // Proof obligation 1:
-// Producer is correct when running with the shape shifter assuming no interference.
-// In fact, this theorem is all you need if you only care about the producer, not the
-// consumer.
+// Producer is correct when running in any cluster where there is no interference.
+// This theorem is all you need if you only care about the producer, not the consumer.
 #[verifier(external_body)]
 proof fn producer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, p_index: int)
     requires

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -14,7 +14,7 @@ spec fn consumer_property<S>() -> TempPred<S>;
 spec fn producer_property<S>() -> TempPred<S>;
 
 // The inv saying that no one interferes with the producer's reconcile
-spec fn no_one_interferes_producer<S, I>(any: Seq<Controller<S, I>>) -> StatePred<S>;
+spec fn no_one_interferes_producer<S, I>(cluster: Cluster<S, I>) -> StatePred<S>;
 
 // Our goal is to prove that both producer and consumer are correct
 //    requires
@@ -33,12 +33,14 @@ spec fn no_one_interferes_producer<S, I>(any: Seq<Controller<S, I>>) -> StatePre
 // In fact, this theorem is all you need if you only care about the producer, not the
 // consumer.
 #[verifier(external_body)]
-proof fn producer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, any: Seq<Controller<S, I>>)
+proof fn producer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>)
     requires
-        spec.entails(lift_state(any_and_producer::<S, I>(any).init())),
-        spec.entails(always(lift_action(any_and_producer::<S, I>(any).next()))),
+        spec.entails(lift_state(cluster.init())),
+        forall |s| cluster.init()(s) ==> #[trigger] producer::<S, I>().init()(s),
+        spec.entails(always(lift_action(cluster.next()))),
+        forall |input, s, s_prime| #[trigger] producer::<S, I>().next(input)(s, s_prime) ==> cluster.next()(s, s_prime),
         spec.entails(producer_fairness::<S, I>()),
-        spec.entails(always(lift_state(no_one_interferes_producer::<S, I>(any)))),
+        spec.entails(always(lift_state(no_one_interferes_producer::<S, I>(cluster)))),
     ensures
         spec.entails(producer_property::<S>()),
 {}
@@ -65,7 +67,7 @@ proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>)
         spec.entails(lift_state(consumer_and_producer::<S, I>().init())),
         spec.entails(always(lift_action(consumer_and_producer::<S, I>().next()))),
     ensures
-        spec.entails(always(lift_state(no_one_interferes_producer::<S, I>(seq![consumer()])))),
+        spec.entails(always(lift_state(no_one_interferes_producer::<S, I>(consumer_and_producer::<S, I>())))),
 {}
 
 // Now we can draw the final conclusion with the lemmas above.
@@ -79,23 +81,20 @@ proof fn consumer_property_holds<S, I>(spec: TempPred<S>)
         spec.entails(producer_property::<S>()),
         spec.entails(consumer_property::<S>()),
 {
-    assert forall |ex| #[trigger] spec.satisfied_by(ex)
-    implies lift_state(any_and_producer::<S, I>(seq![consumer()]).init()).satisfied_by(ex) by {
-        assert(spec.implies(lift_state(consumer_and_producer::<S, I>().init())).satisfied_by(ex));
-        assert(seq![consumer::<S, I>()].push(producer()) =~= seq![consumer(), producer()])
+    let cluster = consumer_and_producer::<S, I>();
+
+    assert forall |s| cluster.init()(s) implies #[trigger] producer::<S, I>().init()(s) by {
+        assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
+        assert(producer::<S, I>() =~= cluster.controllers[1]);
     }
 
-    assert forall |ex| #[trigger] spec.satisfied_by(ex)
-    implies always(lift_action(any_and_producer::<S, I>(seq![consumer()]).next())).satisfied_by(ex) by {
-        assert(spec.implies(always(lift_action(consumer_and_producer::<S, I>().next()))).satisfied_by(ex));
-        assert forall |i| #[trigger] lift_action(any_and_producer::<S, I>(seq![consumer()]).next()).satisfied_by(ex.suffix(i)) by {
-            assert(lift_action(consumer_and_producer::<S, I>().next()).satisfied_by(ex.suffix(i)));
-            assert(seq![consumer::<S, I>()].push(producer()) =~= seq![consumer(), producer()])
-        }
+    assert forall |input, s, s_prime| #[trigger] producer::<S, I>().next(input)(s, s_prime) implies cluster.next()(s, s_prime) by {
+        let step = Step::ControllerStep(1, input);
+        assert(cluster.next_step(s, s_prime, step));
     }
 
     consumer_does_not_interfere_with_the_producer::<S, I>(spec);
-    producer_property_holds_if_no_interference::<S, I>(spec, seq![consumer()]);
+    producer_property_holds_if_no_interference::<S, I>(spec, cluster);
     consumer_property_holds_if_producer_property_holds::<S, I>(spec);
 }
 

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -16,6 +16,40 @@ spec fn producer_property<S>(p_index: int) -> TempPred<S>;
 // The inv saying that no one interferes with the producer's reconcile
 spec fn no_one_interferes_producer<S, I>(cluster: Cluster<S, I>, p_index: int) -> StatePred<S>;
 
+// This is our end-goal theorem: in a cluster with all the producers and the consumer,
+// all controllers are correct.
+proof fn consumer_property_holds<S, I>(spec: TempPred<S>)
+    requires
+        spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
+        spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
+        forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
+        spec.entails(consumer_fairness::<S, I>()),
+    ensures
+        forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
+        spec.entails(consumer_property::<S>()),
+{
+    let cluster = consumer_and_producers::<S, I>();
+
+    assert forall |p_index| 0 <= p_index < producers::<S, I>().len() implies #[trigger] spec.entails(producer_property::<S>(p_index)) by {
+        assert forall |s| cluster.init()(s) implies #[trigger] producers::<S, I>()[p_index].init()(s) by {
+            assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
+            assert(producers::<S, I>()[p_index] =~= cluster.controllers[p_index]);
+        }
+
+        assert forall |input, s, s_prime| #[trigger] producers::<S, I>()[p_index].next(input)(s, s_prime) implies cluster.next()(s, s_prime) by {
+            let step = Step::ControllerStep(p_index, input);
+            assert(cluster.next_step(s, s_prime, step));
+        }
+
+        consumer_does_not_interfere_with_the_producer::<S, I>(spec, p_index);
+        producer_property_holds_if_no_interference::<S, I>(spec, cluster, p_index);
+    }
+
+    consumer_property_holds_if_producer_property_holds::<S, I>(spec);
+}
+
+// To prove the above theorem, there are three proof obligations.
+
 // Proof obligation 1:
 // Producer is correct when running with the shape shifter assuming no interference.
 // In fact, this theorem is all you need if you only care about the producer, not the
@@ -59,36 +93,5 @@ proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
     ensures
         spec.entails(always(lift_state(no_one_interferes_producer::<S, I>(consumer_and_producers::<S, I>(), p_index)))),
 {}
-
-// Now we can draw the final conclusion with the lemmas above.
-proof fn consumer_property_holds<S, I>(spec: TempPred<S>)
-    requires
-        spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
-        spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
-        spec.entails(consumer_fairness::<S, I>()),
-    ensures
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
-        spec.entails(consumer_property::<S>()),
-{
-    let cluster = consumer_and_producers::<S, I>();
-
-    assert forall |p_index| 0 <= p_index < producers::<S, I>().len() implies #[trigger] spec.entails(producer_property::<S>(p_index)) by {
-        assert forall |s| cluster.init()(s) implies #[trigger] producers::<S, I>()[p_index].init()(s) by {
-            assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
-            assert(producers::<S, I>()[p_index] =~= cluster.controllers[p_index]);
-        }
-
-        assert forall |input, s, s_prime| #[trigger] producers::<S, I>()[p_index].next(input)(s, s_prime) implies cluster.next()(s, s_prime) by {
-            let step = Step::ControllerStep(p_index, input);
-            assert(cluster.next_step(s, s_prime, step));
-        }
-
-        consumer_does_not_interfere_with_the_producer::<S, I>(spec, p_index);
-        producer_property_holds_if_no_interference::<S, I>(spec, cluster, p_index);
-    }
-
-    consumer_property_holds_if_producer_property_holds::<S, I>(spec);
-}
 
 }

--- a/src/soundness/compositionality/state_machine.rs
+++ b/src/soundness/compositionality/state_machine.rs
@@ -112,9 +112,13 @@ pub spec fn producers<S, I>() -> Seq<Controller<S, I>>;
 
 pub spec fn consumer<S, I>() -> Controller<S, I>;
 
-pub spec fn producer_fairness<S, I>(p_index: int) -> TempPred<S>;
+pub open spec fn producer_fairness<S, I>(p_index: int) -> TempPred<S> {
+    tla_forall(|input: I| weak_fairness(producers()[p_index].next(input)))
+}
 
-pub spec fn consumer_fairness<S, I>() -> TempPred<S>;
+pub open spec fn consumer_fairness<S, I>() -> TempPred<S> {
+    tla_forall(|input: I| weak_fairness(consumer().next(input)))
+}
 
 pub open spec fn consumer_and_producers<S, I>() -> Cluster<S, I> {
     Cluster {

--- a/src/soundness/compositionality/state_machine.rs
+++ b/src/soundness/compositionality/state_machine.rs
@@ -114,23 +114,17 @@ pub enum Step<I> {
     StutterStep(),
 }
 
-pub spec fn producer<S, I>() -> Controller<S, I>;
+pub spec fn producers<S, I>() -> Seq<Controller<S, I>>;
 
 pub spec fn consumer<S, I>() -> Controller<S, I>;
 
-pub spec fn producer_fairness<S, I>() -> TempPred<S>;
+pub spec fn producer_fairness<S, I>(p_index: int) -> TempPred<S>;
 
 pub spec fn consumer_fairness<S, I>() -> TempPred<S>;
 
-pub open spec fn consumer_and_producer<S, I>() -> Cluster<S, I> {
+pub open spec fn consumer_and_producers<S, I>() -> Cluster<S, I> {
     Cluster {
-        controllers: seq![consumer::<S, I>(), producer::<S, I>()],
-    }
-}
-
-pub open spec fn any_and_producer<S, I>(any: Seq<Controller<S, I>>) -> Cluster<S, I> {
-    Cluster {
-        controllers: any.push(producer::<S, I>()),
+        controllers: producers::<S, I>().push(consumer::<S, I>()),
     }
 }
 

--- a/src/soundness/compositionality/state_machine.rs
+++ b/src/soundness/compositionality/state_machine.rs
@@ -10,15 +10,9 @@ verus! {
 // other controllers to be correct?
 //
 // This abstract state machine example is used to illustrate how to do compositional
-// liveness proof for controllers. There are two controllers: producer and consumer.
-// To make the proof conclusion general, the producer and consumer remain abstract
-// in this example (spec functions without body).
-//
-// The producer realizes its desired state without relying on any other controller.
-// The consumer relies on the producer to realize its desired state. For example,
-// during the consumer's state reconciliation, it might create a desired state
-// description of the producer, wait for the producer to realize the producer's
-// desired state, and then continue to work based on the producer's desired state.
+// liveness proof for controllers. There are two types controllers: (1) a consumer
+// and (2) a sequence of producers that the consumer depends on. To make the proof
+// conclusion general, the producer and consumer remain abstract in this example.
 //
 // One concrete example could be:
 // A consumer desired state description is created -> the consumer gets triggered
@@ -29,15 +23,15 @@ verus! {
 // Note that this example differs from the classic producer-consumer model where the
 // consumer does not generate anything as the producer's input.
 //
-// Our end goal is to prove the correctness (ESR) of both the producer and consumer
-// controller in a compositional way. That is, to first prove the correctness of the
+// Our end goal is to prove the correctness (ESR) of all the producer and consumer
+// controllers in a compositional way. That is, to first prove the correctness of each
 // producer (without the consumer involved), and then prove the correctness of the
-// consumer using the previous correctness conclusion, while minimizing the effort
-// to reason about the interactions between the two controllers.
+// consumer using the previous correctness conclusions, while minimizing the effort
+// to reason about the interactions between different controllers.
 //
 // The key of the proof is to reason about:
-// (1) how the consumer uses the producer to realize its own desired state, and
-// (2) how the consumer and producer do NOT interfere with each other.
+// (1) how the consumer uses the producers to realize its own desired state, and
+// (2) how the consumer and producers do NOT interfere with each other.
 
 #[verifier::reject_recursive_types(S)]
 #[verifier::reject_recursive_types(I)]


### PR DESCRIPTION
This PR makes two major changes to the abstract state machine used for demonstrating compositional proof:
(1) the abstract state machine is no longer hardcoded to two controllers, but takes a sequence of controllers
(2) the first proof obligation no longer constrains *what the cluster is*. Instead, its precondition constrains *what the cluster does* (the producer runs in the cluster and there is no interference).