### PR TITLE
Generalize the top-level theorem of the compositional proof for any cluster

### DIFF
--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -13,70 +13,158 @@ spec fn consumer_property<S>() -> TempPred<S>;
 // The top level property of the producer controller (e.g., ESR)
 spec fn producer_property<S>(p_index: int) -> TempPred<S>;
 
-// The inv saying that no one interferes with the producer's reconcile
-spec fn no_one_interferes_producer<S, I>(cluster: Cluster<S, I>, p_index: int) -> StatePred<S>;
+// The inv asserts that the controller indexed by good_citizen_id does not interfere with the consumer's reconcile
+// This invariant, if opened, should state something like:
+// forall |message| message is sent by the controller indexed by good_citizen_id ==> message does not modify object X,
+// where X is something that the consumer cares about.
+// Note that the invariant likely will not hold when good_citizen_id points to the consumer itself, that is,
+// if there are two consumers, they will interfere with each other.
+// This is not a problem because there is no reason to run two separate consumer instances at the same time.
+// However, when proving the invariant we need to be careful so that good_citizen_id does not point to another consumer.
+spec fn one_does_not_interfere_with_consumer<S, I>(cluster: Cluster<S, I>, good_citizen_id: int) -> StatePred<S>;
 
-// This is our end-goal theorem: in a cluster with all the producers and the consumer,
-// all controllers are correct.
-proof fn consumer_property_holds<S, I>(spec: TempPred<S>)
+// The inv asserts that the controller indexed by good_citizen_id does not interfere with the producer's reconcile
+spec fn one_does_not_interfere_with_producer<S, I>(cluster: Cluster<S, I>, good_citizen_id: int, p_index: int) -> StatePred<S>;
+
+// // This is our end-goal theorem: in a cluster with all the producers and the consumer,
+// // all controllers are correct.
+// proof fn consumer_property_holds<S, I>(spec: TempPred<S>)
+//     requires
+//         spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
+//         spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
+//         forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
+//         spec.entails(consumer_fairness::<S, I>()),
+//     ensures
+//         forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
+//         spec.entails(consumer_property::<S>()),
+// {
+//     let cluster = consumer_and_producers::<S, I>();
+
+//     assert forall |p_index| 0 <= p_index < producers::<S, I>().len() implies #[trigger] spec.entails(producer_property::<S>(p_index)) by {
+//         assert forall |s| cluster.init()(s) implies #[trigger] producers::<S, I>()[p_index].init()(s) by {
+//             assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
+//             assert(producers::<S, I>()[p_index] =~= cluster.controllers[p_index]);
+//         }
+
+//         // assert forall |input, s, s_prime| #[trigger] producers::<S, I>()[p_index].next(input)(s, s_prime) implies cluster.next()(s, s_prime) by {
+//         //     let step = Step::ControllerStep(p_index, input);
+//         //     assert(cluster.next_step(s, s_prime, step));
+//         // }
+
+//         consumer_does_not_interfere_with_the_producer::<S, I>(spec, p_index);
+//         producer_property_holds_if_no_interference::<S, I>(spec, cluster, p_index);
+//     }
+
+//     consumer_property_holds_if_producer_property_holds::<S, I>(spec);
+// }
+
+proof fn consumer_and_producer_properties_hold<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int, producer_ids: Seq<int>)
     requires
-        spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
-        spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
+        spec.entails(lift_state(cluster.init())),
+        spec.entails(always(lift_action(cluster.next()))),
+        // The cluster starts with the initial state of the consumer.
+        forall |s| cluster.init()(s) ==> #[trigger] consumer::<S, I>().init()(s),
+        // The cluster starts with the initial state of the producer.
+        forall |p_index: int| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
+            ==> forall |s| cluster.init()(s) ==> #[trigger] producers::<S, I>()[p_index].init()(s),
+        // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
         spec.entails(consumer_fairness::<S, I>()),
+        // The fairness condition is enough to say that each producer runs as part of the cluster's next transition.
+        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
+            ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
+        // The next five preconditions say that each consumer/producer id points to the consumer and producers
+        // in cluster.controllers.
+        0 <= consumer_id < cluster.controllers.len(),
+        producer_ids.len() == producers::<S, I>().len(),
+        forall |i| #![trigger producer_ids[i]] 0 <= i < producer_ids.len() ==> 0 <= producer_ids[i] < cluster.controllers.len(),
+        cluster.controllers[consumer_id] == consumer::<S, I>(),
+        forall |i| #![trigger producer_ids[i]] 0 <= i < producer_ids.len() ==> cluster.controllers[producer_ids[i]] == producers::<S, I>()[i],
+        // For any other controller in the cluster that is not pointed by the consumer or producer id...
+        forall |good_citizen_id: int| 0 <= good_citizen_id < cluster.controllers.len()
+            && good_citizen_id != consumer_id
+            && !(exists |i| 0 <= i < producer_ids.len() && good_citizen_id == producer_ids[i])
+            // ..., that controller does not interfere with the consumer...
+            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))
+                // ...and does not interfere with any producer.
+                && forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
+                    ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index))))
     ensures
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
         spec.entails(consumer_property::<S>()),
+        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
+            ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
 {
-    let cluster = consumer_and_producers::<S, I>();
-
     assert forall |p_index| 0 <= p_index < producers::<S, I>().len() implies #[trigger] spec.entails(producer_property::<S>(p_index)) by {
-        assert forall |s| cluster.init()(s) implies #[trigger] producers::<S, I>()[p_index].init()(s) by {
-            assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
-            assert(producers::<S, I>()[p_index] =~= cluster.controllers[p_index]);
+        let producer_id = producer_ids[p_index];
+        assert forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != producer_id
+        implies spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))) by {
+            if good_citizen_id == consumer_id {
+                consumer_does_not_interfere_with_the_producer(spec, cluster, good_citizen_id, p_index);
+            } else if exists |j| 0 <= j < producer_ids.len() && good_citizen_id == producer_ids[j] {
+                let j = choose |j| 0 <= j < producer_ids.len() && good_citizen_id == producer_ids[j];
+                assert(cluster.controllers[good_citizen_id] == producers::<S, I>()[j]);
+                producer_does_not_interfere_with_the_producer(spec, cluster, good_citizen_id, j, p_index);
+            } else {
+                assert(spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))); // this assert is just used for triggering
+                assert(spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))));
+            }
         }
-
-        assert forall |input, s, s_prime| #[trigger] producers::<S, I>()[p_index].next(input)(s, s_prime) implies cluster.next()(s, s_prime) by {
-            let step = Step::ControllerStep(p_index, input);
-            assert(cluster.next_step(s, s_prime, step));
-        }
-
-        consumer_does_not_interfere_with_the_producer::<S, I>(spec, p_index);
-        producer_property_holds_if_no_interference::<S, I>(spec, cluster, p_index);
+        producer_property_holds_if_no_interference(spec, cluster, producer_id, p_index);
     }
 
-    consumer_property_holds_if_producer_property_holds::<S, I>(spec);
+    assert forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != consumer_id
+    implies spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))) by {
+        if exists |j| 0 <= j < producer_ids.len() && good_citizen_id == producer_ids[j] {
+            let j = choose |j| 0 <= j < producer_ids.len() && good_citizen_id == producer_ids[j];
+            producer_does_not_interfere_with_the_consumer(spec, cluster, good_citizen_id, j);
+        } else {
+            assert(spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))));
+        }
+    }
+    consumer_property_holds_if_no_interference(spec, cluster, consumer_id);
 }
 
 // To prove the above theorem, there are three proof obligations.
 
 // Proof obligation 1:
 // Producer is correct when running in any cluster where there is no interference.
-// This theorem is all you need if you only care about the producer, not the consumer.
 #[verifier(external_body)]
-proof fn producer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, p_index: int)
+proof fn producer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producer_id: int, p_index: int)
     requires
         0 <= p_index < producers::<S, I>().len(),
+        0 <= producer_id < cluster.controllers.len(),
         spec.entails(lift_state(cluster.init())),
-        forall |s| cluster.init()(s) ==> #[trigger] producers::<S, I>()[p_index].init()(s),
         spec.entails(always(lift_action(cluster.next()))),
-        forall |input, s, s_prime| #[trigger] producers::<S, I>()[p_index].next(input)(s, s_prime) ==> cluster.next()(s, s_prime),
+        // The cluster starts with the initial state of the producer.
+        forall |s| cluster.init()(s) ==> #[trigger] producers::<S, I>()[p_index].init()(s),
+        // The fairness condition is enough to say that the producer runs as part of the cluster's next transition.
         spec.entails(producer_fairness::<S, I>(p_index)),
-        spec.entails(always(lift_state(no_one_interferes_producer::<S, I>(cluster, p_index)))),
+        // The next two preconditions say that no controller (except the producer itself) interferes with this producer.
+        cluster.controllers[producer_id] == producers::<S, I>()[p_index],
+        forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != producer_id
+            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))),
     ensures
         spec.entails(producer_property::<S>(p_index)),
 {}
 
 // Proof obligation 2:
-// Consumer is correct when running with the producer assuming the producer is correct.
+// Consumer is correct when running in any cluster where each producer's spec is available and there is no interference.
 #[verifier(external_body)]
-proof fn consumer_property_holds_if_producer_property_holds<S, I>(spec: TempPred<S>)
+proof fn consumer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int)
     requires
-        spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
-        spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
+        0 <= consumer_id < cluster.controllers.len(),
+        spec.entails(lift_state(cluster.init())),
+        spec.entails(always(lift_action(cluster.next()))),
+        // The cluster starts with the initial state of the consumer.
+        forall |s| cluster.init()(s) ==> #[trigger] consumer::<S, I>().init()(s),
+        // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
         spec.entails(consumer_fairness::<S, I>()),
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len() ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
+        // The next two preconditions say that no controller (except the consumer itself) interferes with this consumer.
+        cluster.controllers[consumer_id] == consumer::<S, I>(),
+        forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != consumer_id
+            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))),
+        // We directly use the temporal spec of the producers.
+        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
+            ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
     ensures
         spec.entails(consumer_property::<S>()),
 {}
@@ -84,13 +172,45 @@ proof fn consumer_property_holds_if_producer_property_holds<S, I>(spec: TempPred
 // Proof obligation 3:
 // Consumer does not interfere with the producer.
 #[verifier(external_body)]
-proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, p_index: int)
+proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
     requires
         0 <= p_index < producers::<S, I>().len(),
-        spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
-        spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
+        0 <= good_citizen_id < cluster.controllers.len(),
+        spec.entails(lift_state(cluster.init())),
+        spec.entails(always(lift_action(cluster.next()))),
+        cluster.controllers[good_citizen_id] == consumer::<S, I>(),
     ensures
-        spec.entails(always(lift_state(no_one_interferes_producer::<S, I>(consumer_and_producers::<S, I>(), p_index)))),
+        // The consumer (which is the good citizen here) never interferes with the producer.
+        spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))),
+{}
+
+
+#[verifier(external_body)]
+proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
+    requires
+        0 <= p_index < producers::<S, I>().len(),
+        0 <= good_citizen_id < cluster.controllers.len(),
+        spec.entails(lift_state(cluster.init())),
+        spec.entails(always(lift_action(cluster.next()))),
+        cluster.controllers[good_citizen_id] == producers::<S, I>()[p_index],
+    ensures
+        // The producer (which is the good citizen here) never interferes with the consumer.
+        spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))),
+{}
+
+#[verifier(external_body)]
+proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int, q_index: int)
+    requires
+        0 <= p_index < producers::<S, I>().len(),
+        0 <= q_index < producers::<S, I>().len(),
+        p_index != q_index,
+        0 <= good_citizen_id < cluster.controllers.len(),
+        spec.entails(lift_state(cluster.init())),
+        spec.entails(always(lift_action(cluster.next()))),
+        cluster.controllers[good_citizen_id] == producers::<S, I>()[p_index],
+    ensures
+        // The producer (p_index, which is the good citizen here) never interferes with the other producer (q_index).
+        spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, q_index)))),
 {}
 
 }

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -236,21 +236,6 @@ proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
 {}
 
 // Proof obligation 4:
-// Producer does not interfere with the consumer in any cluster.
-#[verifier(external_body)]
-proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
-    requires
-        0 <= p_index < producers::<S, I>().len(),
-        0 <= good_citizen_id < cluster.controllers.len(),
-        spec.entails(lift_state(cluster.init())),
-        spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers[good_citizen_id] == producers::<S, I>()[p_index],
-    ensures
-        // The producer (which is the good citizen here) never interferes with the consumer.
-        spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))),
-{}
-
-// Proof obligation 4:
 // Producer does not interfere with another producer in any cluster.
 #[verifier(external_body)]
 proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int, q_index: int)
@@ -267,6 +252,21 @@ proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
     ensures
         // The producer (p_index, which is the good citizen here) never interferes with the other producer (q_index).
         spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, q_index)))),
+{}
+
+// Proof obligation 5:
+// Producer does not interfere with the consumer in any cluster.
+#[verifier(external_body)]
+proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
+    requires
+        0 <= p_index < producers::<S, I>().len(),
+        0 <= good_citizen_id < cluster.controllers.len(),
+        spec.entails(lift_state(cluster.init())),
+        spec.entails(always(lift_action(cluster.next()))),
+        cluster.controllers[good_citizen_id] == producers::<S, I>()[p_index],
+    ensures
+        // The producer (which is the good citizen here) never interferes with the consumer.
+        spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))),
 {}
 
 }

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -37,7 +37,7 @@ pub open spec fn within_range<A>(seq: Seq<A>, index: int) -> bool {
     0 <= index < seq.len()
 }
 
-// This is our end-goal theorem: the consumer and producers are correct in any cluster
+// This is our top-level theorem: the consumer and producers are correct in any cluster
 // if the other controllers in that cluster do not interfere with the consumer or producers.
 // # Arguments:
 // * spec: the temporal predicate that represents the state machine

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -17,83 +17,34 @@ spec fn producer_property<S>(p_index: int) -> TempPred<S>;
 // This invariant, if opened, should state something like:
 // forall |message| message is sent by the controller indexed by good_citizen_id ==> message does not modify object X,
 // where X is something that the consumer cares about.
-// Note that the invariant likely will not hold when good_citizen_id points to the consumer itself, that is,
+//
+// To tell whether a message in the network is sent by a controller, our cluster state machine should attach the
+// controller id (the index) to each message sent by the controller, regardless of the controller's implementation.
+//
+// Note that the invariant likely does not hold when good_citizen_id points to the consumer itself, that is,
 // if there are two consumers, they will interfere with each other.
 // This is not a problem because there is no reason to run two separate consumer instances at the same time.
-// However, when proving the invariant we need to be careful so that good_citizen_id does not point to another consumer.
+// However, when proving the invariant we need to be careful so that good_citizen_id does not point to another
+// consumer instance.
 spec fn one_does_not_interfere_with_consumer<S, I>(cluster: Cluster<S, I>, good_citizen_id: int) -> StatePred<S>;
 
-// The inv asserts that the controller indexed by good_citizen_id does not interfere with the producer's reconcile
+// The inv asserts that the controller indexed by good_citizen_id does not interfere with the producer's reconcile,
+// similar to the one above.
 spec fn one_does_not_interfere_with_producer<S, I>(cluster: Cluster<S, I>, good_citizen_id: int, p_index: int) -> StatePred<S>;
 
-// The only reason I need this spec fun is to use it as a trigger (in the case that no one else can serve as a trigger).
+// The only reason I need this spec fun is to use it as a trigger in the case that no one else can serve as a trigger.
 pub open spec fn within_range<A>(seq: Seq<A>, index: int) -> bool {
     0 <= index < seq.len()
 }
 
-pub open spec fn consumer_and_producers<S, I>() -> Cluster<S, I> {
-    Cluster {
-        controllers: producers::<S, I>().push(consumer::<S, I>()),
-    }
-}
-
-// This is our end-goal theorem: in a cluster with all the producers and the consumer,
-// all controllers are correct.
-proof fn consumer_and_producer_properties_hold_in_a_concrete_cluster<S, I>(spec: TempPred<S>)
-    requires
-        spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
-        spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
-            ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
-        spec.entails(consumer_fairness::<S, I>()),
-    ensures
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
-            ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
-        spec.entails(consumer_property::<S>()),
-{
-    let cluster = consumer_and_producers::<S, I>();
-
-    let producer_ids = producers::<S, I>().map(|i: int, producer: Controller<S, I>| i);
-    let consumer_id = cluster.controllers.len() - 1;
-
-    assert forall |s| #[trigger] cluster.init()(s) implies consumer::<S, I>().init()(s) by {
-        assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
-        assert(consumer::<S, I>() =~= cluster.controllers.last());
-    }
-
-    assert forall |p_index| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
-    implies forall |s| #[trigger] cluster.init()(s) ==> producers::<S, I>()[p_index].init()(s) by {
-        assert forall |s| #[trigger] cluster.init()(s) implies producers::<S, I>()[p_index].init()(s) by {
-            assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
-            assert(producers::<S, I>()[p_index] =~= cluster.controllers[p_index]);
-        }
-    }
-
-    assert forall |good_citizen_id: int| 0 <= good_citizen_id < cluster.controllers.len()
-        && good_citizen_id != consumer_id
-        && !(exists |i| 0 <= i < producer_ids.len() && good_citizen_id == producer_ids[i])
-    implies
-        spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))
-        && forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
-            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index))))
-    by {
-        assert forall |controller_id| #[trigger] within_range(cluster.controllers, controller_id)
-        implies controller_id == consumer_id || exists |i| #[trigger] within_range(producer_ids, i) && controller_id == producer_ids[i] by {
-            if controller_id == cluster.controllers.len() - 1 {
-                assert(controller_id == consumer_id);
-            } else {
-                let i = controller_id;
-                assert(within_range(producer_ids, i) && controller_id == producer_ids[i]);
-            }
-        }
-        assert(within_range(cluster.controllers, good_citizen_id));
-        assert(good_citizen_id == consumer_id || exists |i| #[trigger] within_range(producer_ids, i) && good_citizen_id == producer_ids[i]);
-    }
-
-    consumer_and_producer_properties_hold(spec, cluster, consumer_id, producer_ids);
-}
-
-proof fn consumer_and_producer_properties_hold<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int, producer_ids: Seq<int>)
+// This is our end-goal theorem: the consumer and producers are correct in any cluster
+// if the other controllers in that cluster do not interfere with the consumer or producers.
+// # Arguments:
+// * spec: the temporal predicate that represents the state machine
+// * cluster: the cluster that we want to run the consumers/producers in
+// * consumer_id: the index of the consumer inside cluster.controllers
+// * producer_ids: the sequence of indexes of the producers inside cluster.controllers
+proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int, producer_ids: Seq<int>)
     requires
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
@@ -143,7 +94,7 @@ proof fn consumer_and_producer_properties_hold<S, I>(spec: TempPred<S>, cluster:
                 assert(spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))));
             }
         }
-        producer_property_holds_if_no_interference(spec, cluster, producer_id, p_index);
+        producer_is_correct(spec, cluster, producer_id, p_index);
     }
 
     assert forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != consumer_id
@@ -155,15 +106,80 @@ proof fn consumer_and_producer_properties_hold<S, I>(spec: TempPred<S>, cluster:
             assert(spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))));
         }
     }
-    consumer_property_holds_if_no_interference(spec, cluster, consumer_id);
+    consumer_is_correct(spec, cluster, consumer_id);
 }
 
-// To prove the above theorem, there are three proof obligations.
+// A concrete cluster with only producers and consumer
+pub open spec fn consumer_and_producers<S, I>() -> Cluster<S, I> {
+    Cluster {
+        controllers: producers::<S, I>().push(consumer::<S, I>()),
+    }
+}
+
+// We can apply consumer_and_producers_are_correct to the concrete cluster above to conclude that
+// the consumer and producers are correct in a cluster where there are only consumer and producers.
+proof fn consumer_and_producers_are_correct_in_a_concrete_cluster<S, I>(spec: TempPred<S>)
+    requires
+        spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
+        spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
+        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
+            ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
+        spec.entails(consumer_fairness::<S, I>()),
+    ensures
+        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
+            ==> #[trigger] spec.entails(producer_property::<S>(p_index)),
+        spec.entails(consumer_property::<S>()),
+{
+    let cluster = consumer_and_producers::<S, I>();
+
+    let producer_ids = producers::<S, I>().map(|i: int, producer: Controller<S, I>| i);
+    let consumer_id = cluster.controllers.len() - 1;
+
+    assert forall |s| #[trigger] cluster.init()(s) implies consumer::<S, I>().init()(s) by {
+        assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
+        assert(consumer::<S, I>() =~= cluster.controllers.last());
+    }
+
+    assert forall |p_index| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
+    implies forall |s| #[trigger] cluster.init()(s) ==> producers::<S, I>()[p_index].init()(s) by {
+        assert forall |s| #[trigger] cluster.init()(s) implies producers::<S, I>()[p_index].init()(s) by {
+            assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
+            assert(producers::<S, I>()[p_index] =~= cluster.controllers[p_index]);
+        }
+    }
+
+    // Due to our cluster construct, you won't find a good_citizen_id that is neither the consumer nor any producer.
+    // So we prove the following assertion by contradiction.
+    assert forall |good_citizen_id: int| 0 <= good_citizen_id < cluster.controllers.len()
+        && good_citizen_id != consumer_id
+        && !(exists |i| 0 <= i < producer_ids.len() && good_citizen_id == producer_ids[i])
+    implies
+        spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))
+        && forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
+            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index))))
+    by {
+        assert forall |controller_id| #[trigger] within_range(cluster.controllers, controller_id) // I am using within_range here because no one else can be a trigger
+        implies controller_id == consumer_id || exists |i| #[trigger] within_range(producer_ids, i) && controller_id == producer_ids[i] by {
+            if controller_id == cluster.controllers.len() - 1 {
+                assert(controller_id == consumer_id);
+            } else {
+                let i = controller_id;
+                assert(within_range(producer_ids, i) && controller_id == producer_ids[i]);
+            }
+        }
+        assert(within_range(cluster.controllers, good_citizen_id));
+        assert(good_citizen_id == consumer_id || exists |i| #[trigger] within_range(producer_ids, i) && good_citizen_id == producer_ids[i]);
+    }
+
+    consumer_and_producers_are_correct(spec, cluster, consumer_id, producer_ids);
+}
+
+// To prove consumer_and_producers_are_correct, there are five proof obligations.
 
 // Proof obligation 1:
 // Producer is correct when running in any cluster where there is no interference.
 #[verifier(external_body)]
-proof fn producer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producer_id: int, p_index: int)
+proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producer_id: int, p_index: int)
     requires
         0 <= p_index < producers::<S, I>().len(),
         0 <= producer_id < cluster.controllers.len(),
@@ -184,7 +200,7 @@ proof fn producer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, clu
 // Proof obligation 2:
 // Consumer is correct when running in any cluster where each producer's spec is available and there is no interference.
 #[verifier(external_body)]
-proof fn consumer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int)
+proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int)
     requires
         0 <= consumer_id < cluster.controllers.len(),
         spec.entails(lift_state(cluster.init())),
@@ -205,7 +221,7 @@ proof fn consumer_property_holds_if_no_interference<S, I>(spec: TempPred<S>, clu
 {}
 
 // Proof obligation 3:
-// Consumer does not interfere with the producer.
+// Consumer does not interfere with the producer in any cluster.
 #[verifier(external_body)]
 proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
     requires
@@ -219,7 +235,8 @@ proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
         spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))),
 {}
 
-
+// Proof obligation 4:
+// Producer does not interfere with the consumer in any cluster.
 #[verifier(external_body)]
 proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
     requires
@@ -233,11 +250,15 @@ proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, 
         spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))),
 {}
 
+// Proof obligation 4:
+// Producer does not interfere with another producer in any cluster.
 #[verifier(external_body)]
 proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int, q_index: int)
     requires
         0 <= p_index < producers::<S, I>().len(),
         0 <= q_index < producers::<S, I>().len(),
+        // We require the two producers to be different because there is no point to prove
+        // a producer does not interfere with another instance of itself.
         p_index != q_index,
         0 <= good_citizen_id < cluster.controllers.len(),
         spec.entails(lift_state(cluster.init())),

--- a/src/soundness/compositionality/state_machine.rs
+++ b/src/soundness/compositionality/state_machine.rs
@@ -68,6 +68,9 @@ impl<S, I> Cluster<S, I> {
         }
     }
 
+    // Inside this action, we need to require the message sent by controllers[i]
+    // to piggyback i so that we can tell which message in network is sent by who.
+    // In other words, the index i here serves as a sender id.
     pub open spec fn controller_next(self, index: int, input: I) -> ActionPred<S> {
         |s, s_prime| {
             &&& 0 <= index < self.controllers.len()

--- a/src/soundness/compositionality/state_machine.rs
+++ b/src/soundness/compositionality/state_machine.rs
@@ -120,10 +120,4 @@ pub open spec fn consumer_fairness<S, I>() -> TempPred<S> {
     tla_forall(|input: I| weak_fairness(consumer().next(input)))
 }
 
-pub open spec fn consumer_and_producers<S, I>() -> Cluster<S, I> {
-    Cluster {
-        controllers: producers::<S, I>().push(consumer::<S, I>()),
-    }
-}
-
 }


### PR DESCRIPTION
This PR introduces symmetric lemmas for the consumer and producers parameterized by `cluster` so the compositional proof is no longer hard coded to any particular cluster. This means that the consumer's correctness spec can now be used by any downstream controller in any cluster where the consumer and producers are running and there is no interference.

The generalization comes with some cost: the top-level theorem `consumer_and_producers_are_correct` now seems a bit more complex with extra preconditions to constrain the behavior of other controllers in the input `cluster`. The last precondition (the super long one) says that other controllers will not interfere with the consumer or producers. To identify the "other controllers," we need to introduce the id of the consumer and producers: the id is just the index in the `cluster.controllers`, and any controller not pointed by the provided ids is identified as one of the "other controllers."

Besides the top-level theorem, another major change is in the non-interference invariant. Previously the invariant says that "no one interferes with the consumer/producer." Such an invariant is too strong to prove if we don't pose many constraints on the cluster. This PR changes the invariant to "controller identified by `good_citizen_id` does not interfere with the consumer/producer."

With the new proof strategy, to prove the top-level theorem, there are five proof obligations:
1. prove each producer is correct assuming no one interferes with this producer
2. prove the consumer is correct assuming no one interferes with the consumer and each producer is correct
3. prove the consumer does not interfere with each producer
4. prove each producer does not interfere with another producer
5. prove each producer does not interfere with the consumer

To ensure the preconditions of the top-level theorem `consumer_and_producers_are_correct` are reasonable, this PR also applies `consumer_and_producers_are_correct` to a concrete cluster with the consumer and producers only to prove their correctness in such a cluster. See `consumer_and_producers_are_correct_in_a_concrete_cluster`.
