### PR TITLE
Simplify compositional theorems by using `Map` to represent controllers

### DIFF
--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -32,11 +32,6 @@ spec fn one_does_not_interfere_with_consumer<S, I>(cluster: Cluster<S, I>, good_
 // similar to the one above.
 spec fn one_does_not_interfere_with_producer<S, I>(cluster: Cluster<S, I>, good_citizen_id: int, p_index: int) -> StatePred<S>;
 
-// The only reason I need this spec fun is to use it as a trigger in the case that no one else can serve as a trigger.
-pub open spec fn within_range<A>(seq: Seq<A>, index: int) -> bool {
-    0 <= index < seq.len()
-}
-
 // This is our top-level theorem: the consumer and producers are correct in any cluster
 // if the other controllers in that cluster do not interfere with the consumer or producers.
 // # Arguments:

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -42,36 +42,33 @@ pub open spec fn within_range<A>(seq: Seq<A>, index: int) -> bool {
 // # Arguments:
 // * spec: the temporal predicate that represents the state machine
 // * cluster: the cluster that we want to run the consumers/producers in
-// * consumer_id: the index of the consumer inside cluster.controllers
-// * producer_ids: the sequence of indexes of the producers inside cluster.controllers
-proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int, producer_ids: Seq<int>)
+// * consumer_id: the key of the consumer in cluster.controllers
+// * producer_ids: maps the index of each producer to the key used in cluster.controllers
+proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int, producer_ids: Map<int, int>)
     requires
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
         // The cluster starts with the initial state of the consumer.
         forall |s| cluster.init()(s) ==> #[trigger] consumer::<S, I>().init()(s),
         // The cluster starts with the initial state of the producer.
-        forall |p_index: int| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
+        forall |p_index| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
             ==> forall |s| cluster.init()(s) ==> #[trigger] producers::<S, I>()[p_index].init()(s),
         // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
         spec.entails(consumer_fairness::<S, I>()),
         // The fairness condition is enough to say that each producer runs as part of the cluster's next transition.
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
+        forall |p_index| 0 <= p_index < producers::<S, I>().len()
             ==> #[trigger] spec.entails(producer_fairness::<S, I>(p_index)),
-        // The next five preconditions say that each consumer/producer id points to the consumer and producers
-        // in cluster.controllers.
-        0 <= consumer_id < cluster.controllers.len(),
-        producer_ids.len() == producers::<S, I>().len(),
-        forall |i| #![trigger producer_ids[i]] 0 <= i < producer_ids.len() ==> 0 <= producer_ids[i] < cluster.controllers.len(),
-        cluster.controllers[consumer_id] == consumer::<S, I>(),
-        forall |i| #![trigger producer_ids[i]] 0 <= i < producer_ids.len() ==> cluster.controllers[producer_ids[i]] == producers::<S, I>()[i],
-        // For any other controller in the cluster that is not pointed by the consumer or producer id...
-        forall |good_citizen_id: int| 0 <= good_citizen_id < cluster.controllers.len()
-            && good_citizen_id != consumer_id
-            && !(exists |i| 0 <= i < producer_ids.len() && good_citizen_id == producer_ids[i])
-            // ..., that controller does not interfere with the consumer...
-            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))
-                // ...and does not interfere with any producer.
+        // The consumer_id points to the consumer.
+        cluster.controllers.contains_pair(consumer_id, consumer::<S, I>()),
+        // Each element in producer_ids points to each producer respectively,
+        // and each producer is pointed by some element in producer_ids.
+        forall |key| #[trigger] producer_ids.contains_key(key) <==> 0 <= key < producers::<S, I>().len(),
+        forall |key| producer_ids.contains_key(key)
+            ==> cluster.controllers.contains_pair(#[trigger] producer_ids[key], producers::<S, I>()[key]),
+        // For any other controller in the cluster that is not pointed by the consumer or producer id,
+        // that controller does not interfere with the consumer or any producer.
+        forall |good_citizen_id| #[trigger] cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))
                 && forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
                     ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index))))
     ensures
@@ -80,29 +77,30 @@ proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cl
         spec.entails(consumer_property::<S>()),
 {
     assert forall |p_index| 0 <= p_index < producers::<S, I>().len() implies #[trigger] spec.entails(producer_property::<S>(p_index)) by {
+        assert(producer_ids.contains_key(p_index));
         let producer_id = producer_ids[p_index];
-        assert forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != producer_id
+        assert forall |good_citizen_id| cluster.controllers.contains_key(good_citizen_id) && good_citizen_id != producer_id
         implies spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))) by {
             if good_citizen_id == consumer_id {
                 consumer_does_not_interfere_with_the_producer(spec, cluster, good_citizen_id, p_index);
-            } else if exists |j| 0 <= j < producer_ids.len() && good_citizen_id == producer_ids[j] {
-                let j = choose |j| 0 <= j < producer_ids.len() && good_citizen_id == producer_ids[j];
-                assert(cluster.controllers[good_citizen_id] == producers::<S, I>()[j]);
+            } else if producer_ids.contains_value(good_citizen_id) {
+                let j = choose |j| producer_ids.dom().contains(j) && #[trigger] producer_ids[j] == good_citizen_id;
                 producer_does_not_interfere_with_the_producer(spec, cluster, good_citizen_id, j, p_index);
             } else {
-                assert(spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))); // this assert is just used for triggering
+                assert(cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id));
                 assert(spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))));
             }
         }
         producer_is_correct(spec, cluster, producer_id, p_index);
     }
 
-    assert forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != consumer_id
+    assert forall |good_citizen_id| cluster.controllers.contains_key(good_citizen_id) && good_citizen_id != consumer_id
     implies spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))) by {
-        if exists |j| 0 <= j < producer_ids.len() && good_citizen_id == producer_ids[j] {
-            let j = choose |j| 0 <= j < producer_ids.len() && good_citizen_id == producer_ids[j];
+        if producer_ids.contains_value(good_citizen_id) {
+            let j = choose |j| producer_ids.dom().contains(j) && #[trigger] producer_ids[j] == good_citizen_id;
             producer_does_not_interfere_with_the_consumer(spec, cluster, good_citizen_id, j);
         } else {
+            assert(cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id));
             assert(spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))));
         }
     }
@@ -112,7 +110,8 @@ proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cl
 // A concrete cluster with only producers and consumer
 pub open spec fn consumer_and_producers<S, I>() -> Cluster<S, I> {
     Cluster {
-        controllers: producers::<S, I>().push(consumer::<S, I>()),
+        controllers: Map::new(|k| 0 <= k < producers::<S, I>().len(), |k| producers::<S, I>()[k])
+            .insert(producers::<S, I>().len() as int, consumer::<S, I>())
     }
 }
 
@@ -132,43 +131,40 @@ proof fn consumer_and_producers_are_correct_in_a_concrete_cluster<S, I>(spec: Te
 {
     let cluster = consumer_and_producers::<S, I>();
 
-    let producer_ids = producers::<S, I>().map(|i: int, producer: Controller<S, I>| i);
-    let consumer_id = cluster.controllers.len() - 1;
+    let producer_ids = Map::new(|k: int| 0 <= k < producers::<S, I>().len(), |k: int| k);
+    let consumer_id = producers::<S, I>().len() as int;
 
     assert forall |s| #[trigger] cluster.init()(s) implies consumer::<S, I>().init()(s) by {
-        assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
-        assert(consumer::<S, I>() =~= cluster.controllers.last());
+        assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
+        assert(cluster.controllers.contains_key(consumer_id));
     }
 
     assert forall |p_index| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
     implies forall |s| #[trigger] cluster.init()(s) ==> producers::<S, I>()[p_index].init()(s) by {
         assert forall |s| #[trigger] cluster.init()(s) implies producers::<S, I>()[p_index].init()(s) by {
-            assert forall |i| 0 <= i < cluster.controllers.len() implies #[trigger] cluster.controllers[i].init()(s) by {}
-            assert(producers::<S, I>()[p_index] =~= cluster.controllers[p_index]);
+            assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
+            assert(cluster.controllers.contains_key(p_index));
         }
     }
 
     // Due to our cluster construct, you won't find a good_citizen_id that is neither the consumer nor any producer.
     // So we prove the following assertion by contradiction.
-    assert forall |good_citizen_id: int| 0 <= good_citizen_id < cluster.controllers.len()
-        && good_citizen_id != consumer_id
-        && !(exists |i| 0 <= i < producer_ids.len() && good_citizen_id == producer_ids[i])
+    assert forall |good_citizen_id: int|
+        #[trigger] cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id)
     implies
-        spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))
+        spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id))))
         && forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
             ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index))))
     by {
-        assert forall |controller_id| #[trigger] within_range(cluster.controllers, controller_id) // I am using within_range here because no one else can be a trigger
-        implies controller_id == consumer_id || exists |i| #[trigger] within_range(producer_ids, i) && controller_id == producer_ids[i] by {
-            if controller_id == cluster.controllers.len() - 1 {
+        assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
+        implies controller_id == consumer_id || producer_ids.values().contains(controller_id) by {
+            if controller_id == producers::<S, I>().len() as int {
                 assert(controller_id == consumer_id);
             } else {
-                let i = controller_id;
-                assert(within_range(producer_ids, i) && controller_id == producer_ids[i]);
+                assert(producer_ids.dom().contains(controller_id) && producer_ids[controller_id] == controller_id);
             }
         }
-        assert(within_range(cluster.controllers, good_citizen_id));
-        assert(good_citizen_id == consumer_id || exists |i| #[trigger] within_range(producer_ids, i) && good_citizen_id == producer_ids[i]);
+        assert(!cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id));
     }
 
     consumer_and_producers_are_correct(spec, cluster, consumer_id, producer_ids);
@@ -182,7 +178,6 @@ proof fn consumer_and_producers_are_correct_in_a_concrete_cluster<S, I>(spec: Te
 proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producer_id: int, p_index: int)
     requires
         0 <= p_index < producers::<S, I>().len(),
-        0 <= producer_id < cluster.controllers.len(),
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
         // The cluster starts with the initial state of the producer.
@@ -190,8 +185,8 @@ proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, pr
         // The fairness condition is enough to say that the producer runs as part of the cluster's next transition.
         spec.entails(producer_fairness::<S, I>(p_index)),
         // The next two preconditions say that no controller (except the producer itself) interferes with this producer.
-        cluster.controllers[producer_id] == producers::<S, I>()[p_index],
-        forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != producer_id
+        cluster.controllers.contains_pair(producer_id, producers::<S, I>()[p_index]),
+        forall |good_citizen_id| cluster.controllers.contains_key(good_citizen_id) && good_citizen_id != producer_id
             ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))),
     ensures
         spec.entails(producer_property::<S>(p_index)),
@@ -202,7 +197,6 @@ proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, pr
 #[verifier(external_body)]
 proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int)
     requires
-        0 <= consumer_id < cluster.controllers.len(),
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
         // The cluster starts with the initial state of the consumer.
@@ -210,8 +204,8 @@ proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, co
         // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
         spec.entails(consumer_fairness::<S, I>()),
         // The next two preconditions say that no controller (except the consumer itself) interferes with this consumer.
-        cluster.controllers[consumer_id] == consumer::<S, I>(),
-        forall |good_citizen_id| 0 <= good_citizen_id < cluster.controllers.len() && good_citizen_id != consumer_id
+        cluster.controllers.contains_pair(consumer_id, consumer::<S, I>()),
+        forall |good_citizen_id| cluster.controllers.contains_key(good_citizen_id) && good_citizen_id != consumer_id
             ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))),
         // We directly use the temporal spec of the producers.
         forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
@@ -226,10 +220,9 @@ proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, co
 proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
     requires
         0 <= p_index < producers::<S, I>().len(),
-        0 <= good_citizen_id < cluster.controllers.len(),
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers[good_citizen_id] == consumer::<S, I>(),
+        cluster.controllers.contains_pair(good_citizen_id, consumer::<S, I>()),
     ensures
         // The consumer (which is the good citizen here) never interferes with the producer.
         spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, p_index)))),
@@ -245,10 +238,9 @@ proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
         // We require the two producers to be different because there is no point to prove
         // a producer does not interfere with another instance of itself.
         p_index != q_index,
-        0 <= good_citizen_id < cluster.controllers.len(),
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers[good_citizen_id] == producers::<S, I>()[p_index],
+        cluster.controllers.contains_pair(good_citizen_id, producers::<S, I>()[p_index]),
     ensures
         // The producer (p_index, which is the good citizen here) never interferes with the other producer (q_index).
         spec.entails(always(lift_state(one_does_not_interfere_with_producer::<S, I>(cluster, good_citizen_id, q_index)))),
@@ -260,10 +252,9 @@ proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
 proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
     requires
         0 <= p_index < producers::<S, I>().len(),
-        0 <= good_citizen_id < cluster.controllers.len(),
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers[good_citizen_id] == producers::<S, I>()[p_index],
+        cluster.controllers.contains_pair(good_citizen_id, producers::<S, I>()[p_index]),
     ensures
         // The producer (which is the good citizen here) never interferes with the consumer.
         spec.entails(always(lift_state(one_does_not_interfere_with_consumer::<S, I>(cluster, good_citizen_id)))),

--- a/src/soundness/compositionality/state_machine.rs
+++ b/src/soundness/compositionality/state_machine.rs
@@ -56,14 +56,14 @@ impl<S, I> Controller<S, I> {
 #[verifier::reject_recursive_types(S)]
 #[verifier::reject_recursive_types(I)]
 pub struct Cluster<S, I> {
-    pub controllers: Seq<Controller<S, I>>,
+    pub controllers: Map<int, Controller<S, I>>,
 }
 
 // The methods below define the initial state and next transitions of the state machine.
 impl<S, I> Cluster<S, I> {
     pub open spec fn init(self) -> StatePred<S> {
         |s| {
-            &&& forall |i| 0 <= i < self.controllers.len() ==> #[trigger] self.controllers[i].init()(s)
+            &&& forall |key| #[trigger] self.controllers.contains_key(key) ==> self.controllers[key].init()(s)
             &&& other_init()(s)
         }
     }
@@ -73,7 +73,7 @@ impl<S, I> Cluster<S, I> {
     // In other words, the index i here serves as a sender id.
     pub open spec fn controller_next(self, index: int, input: I) -> ActionPred<S> {
         |s, s_prime| {
-            &&& 0 <= index < self.controllers.len()
+            &&& self.controllers.contains_key(index)
             &&& self.controllers[index].next(input)(s, s_prime)
         }
     }


### PR DESCRIPTION
This PR uses `Map` instead of `Seq` to store the controllers in the cluster. The major benefit is that `Map` makes it much easier to state "controllers other than x, y, and z satisfy properties P" by simply removing the entries of x, y, and z from the map and applying P to the resulting map.

One limitation of using `Map` is that we cannot have multiple instances of the same controllers in the cluster. However, in practice this is not a concern: there is no reason to have two identical controllers running in the cluster. The two will conflict and interfere with each other. The common practice is to have only one active instance (the primary) of each controller running, with multiple threads internally handling different pieces of the cluster state, and some other inactive instances as backup if the primary one terminates. This behavior is already well modeled in our state machine.