### PR TITLE
Group the spec functions for each controller

### DIFF
--- a/src/soundness/compositionality/examples.rs
+++ b/src/soundness/compositionality/examples.rs
@@ -8,9 +8,9 @@ use vstd::prelude::*;
 
 verus! {
 
-// This is a use case of waiter_and_cooks_are_correct:
-// We can apply waiter_and_cooks_are_correct to a concrete cluster that includes
-// only a waiter_spec_group and a sequence of cook_spec_groups.
+// This is a use case of consumer_and_producers_are_correct:
+// We can apply consumer_and_producers_are_correct to a concrete cluster that includes
+// only a waiter and a sequence of cooks.
 pub spec fn cooks<S, I>() -> Seq<Controller<S, I>>;
 
 pub spec fn waiter<S, I>() -> Controller<S, I>;

--- a/src/soundness/compositionality/examples.rs
+++ b/src/soundness/compositionality/examples.rs
@@ -8,15 +8,15 @@ use vstd::prelude::*;
 
 verus! {
 
-// This is a use case of consumer_and_producers_are_correct:
-// We can apply consumer_and_producers_are_correct to a concrete cluster that includes
-// only a consumer and a sequence of producers.
-pub spec fn producer_controllers<S, I>() -> Seq<Controller<S, I>>;
+// This is a use case of waiter_and_cooks_are_correct:
+// We can apply waiter_and_cooks_are_correct to a concrete cluster that includes
+// only a waiter_spec_group and a sequence of cook_spec_groups.
+pub spec fn cooks<S, I>() -> Seq<Controller<S, I>>;
 
-pub spec fn consumer_controller<S, I>() -> Controller<S, I>;
+pub spec fn waiter<S, I>() -> Controller<S, I>;
 
-pub open spec fn producers<S, I>() -> Seq<ControllerSpecGroup<S, I>> {
-    producer_controllers().map(|i, v| ControllerSpecGroup {
+pub open spec fn cook_spec_groups<S, I>() -> Seq<ControllerSpecGroup<S, I>> {
+    cooks().map(|i, v| ControllerSpecGroup {
         controller: v,
         key: i,
         property: arbitrary(),
@@ -24,94 +24,94 @@ pub open spec fn producers<S, I>() -> Seq<ControllerSpecGroup<S, I>> {
     })
 }
 
-pub open spec fn consumer<S, I>() -> ControllerSpecGroup<S, I> {
+pub open spec fn waiter_spec_group<S, I>() -> ControllerSpecGroup<S, I> {
     ControllerSpecGroup::<S, I> {
-        controller: consumer_controller(),
-        key: producers::<S, I>().len() as int,
+        controller: waiter(),
+        key: cook_spec_groups::<S, I>().len() as int,
         property: arbitrary(),
         not_interfered_by: arbitrary(),
     }
 }
 
-// A concrete cluster with only producers and consumer
-pub open spec fn consumer_and_producers<S, I>() -> Cluster<S, I> {
+// A concrete cluster with only cooks and waiter_spec_group
+pub open spec fn waiter_and_cooks<S, I>() -> Cluster<S, I> {
     Cluster {
-        controllers: Map::new(|k| 0 <= k < producer_controllers::<S, I>().len(), |k| producer_controllers::<S, I>()[k])
-            .insert(producer_controllers::<S, I>().len() as int, consumer_controller::<S, I>())
+        controllers: Map::new(|k| 0 <= k < cooks::<S, I>().len(), |k| cooks::<S, I>()[k])
+            .insert(cooks::<S, I>().len() as int, waiter::<S, I>())
     }
 }
 
-proof fn consumer_and_producers_are_correct_in_a_concrete_cluster<S, I>(spec: TempPred<S>)
+proof fn waiter_and_cooks_are_correct<S, I>(spec: TempPred<S>)
     requires
-        spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
-        spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
-            ==> #[trigger] spec.entails(controller_fairness::<S, I>(producers()[p_index].controller)),
-        spec.entails(controller_fairness::<S, I>(consumer().controller)),
+        spec.entails(lift_state(waiter_and_cooks::<S, I>().init())),
+        spec.entails(always(lift_action(waiter_and_cooks::<S, I>().next()))),
+        forall |p_index: int| 0 <= p_index < cook_spec_groups::<S, I>().len()
+            ==> #[trigger] spec.entails(controller_fairness::<S, I>(cook_spec_groups()[p_index].controller)),
+        spec.entails(controller_fairness::<S, I>(waiter_spec_group().controller)),
     ensures
-        forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
-            ==> #[trigger] spec.entails(producers::<S, I>()[p_index].property),
-        spec.entails(consumer::<S, I>().property),
+        forall |p_index: int| 0 <= p_index < cook_spec_groups::<S, I>().len()
+            ==> #[trigger] spec.entails(cook_spec_groups::<S, I>()[p_index].property),
+        spec.entails(waiter_spec_group::<S, I>().property),
 {
-    let cluster = consumer_and_producers::<S, I>();
+    let cluster = waiter_and_cooks::<S, I>();
 
-    assert forall |s| #[trigger] cluster.init()(s) implies consumer::<S, I>().controller.init()(s) by {
+    assert forall |s| #[trigger] cluster.init()(s) implies waiter_spec_group::<S, I>().controller.init()(s) by {
         assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
-        assert(cluster.controllers.contains_key(consumer::<S, I>().key));
+        assert(cluster.controllers.contains_key(waiter_spec_group::<S, I>().key));
     }
 
-    assert forall |p_index| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
-    implies forall |s| #[trigger] cluster.init()(s) ==> producers::<S, I>()[p_index].controller.init()(s) by {
-        assert forall |s| #[trigger] cluster.init()(s) implies producers::<S, I>()[p_index].controller.init()(s) by {
+    assert forall |p_index| #![trigger cook_spec_groups::<S, I>()[p_index]] 0 <= p_index < cook_spec_groups::<S, I>().len()
+    implies forall |s| #[trigger] cluster.init()(s) ==> cook_spec_groups::<S, I>()[p_index].controller.init()(s) by {
+        assert forall |s| #[trigger] cluster.init()(s) implies cook_spec_groups::<S, I>()[p_index].controller.init()(s) by {
             assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
             assert(cluster.controllers.contains_key(p_index));
         }
     }
 
-    let producer_keys = producers().map_values(|p: ControllerSpecGroup<S, I>| p.key);
-    let producer_key_set = producer_keys.to_set();
+    let cook_keys = cook_spec_groups().map_values(|p: ControllerSpecGroup<S, I>| p.key);
+    let cook_key_set = cook_keys.to_set();
 
-    // Due to our cluster construct, you won't find a good_citizen_id that is neither the consumer nor any producer.
+    // Due to our cluster construct, you won't find a good_citizen_id that is neither the waiter_spec_group nor any cook.
     // So we prove the following assertion by contradiction.
     assert forall |good_citizen_id: int|
-        cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id)
+        cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id)
     implies
-        #[trigger] spec.entails(always(lift_state((consumer::<S, I>().not_interfered_by)(good_citizen_id))))
+        #[trigger] spec.entails(always(lift_state((waiter_spec_group::<S, I>().not_interfered_by)(good_citizen_id))))
     by {
         assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
-        implies controller_id == consumer::<S, I>().key || producer_key_set.contains(controller_id) by {
-            if controller_id == producers::<S, I>().len() as int {
-                assert(controller_id == consumer::<S, I>().key);
+        implies controller_id == waiter_spec_group::<S, I>().key || cook_key_set.contains(controller_id) by {
+            if controller_id == cook_spec_groups::<S, I>().len() as int {
+                assert(controller_id == waiter_spec_group::<S, I>().key);
             } else {
-                assert(0 <= controller_id < producer_keys.len() && producer_keys[controller_id] == controller_id);
+                assert(0 <= controller_id < cook_keys.len() && cook_keys[controller_id] == controller_id);
             }
         }
-        assert(!cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id));
+        assert(!cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id));
     }
 
-    assert forall |p_index| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
+    assert forall |p_index| #![trigger cook_spec_groups::<S, I>()[p_index]] 0 <= p_index < cook_spec_groups::<S, I>().len()
     implies
-        (forall |good_citizen_id| cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] (producers::<S, I>()[p_index].not_interfered_by)(good_citizen_id)))))
+        (forall |good_citizen_id| cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (cook_spec_groups::<S, I>()[p_index].not_interfered_by)(good_citizen_id)))))
     by {
         assert forall |good_citizen_id|
-            cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id)
+            cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id)
         implies
-            #[trigger] spec.entails(always(lift_state(#[trigger] (producers::<S, I>()[p_index].not_interfered_by)(good_citizen_id))))
+            #[trigger] spec.entails(always(lift_state(#[trigger] (cook_spec_groups::<S, I>()[p_index].not_interfered_by)(good_citizen_id))))
         by {
             assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
-            implies controller_id == consumer::<S, I>().key || producer_key_set.contains(controller_id) by {
-                if controller_id == producers::<S, I>().len() as int {
-                    assert(controller_id == consumer::<S, I>().key);
+            implies controller_id == waiter_spec_group::<S, I>().key || cook_key_set.contains(controller_id) by {
+                if controller_id == cook_spec_groups::<S, I>().len() as int {
+                    assert(controller_id == waiter_spec_group::<S, I>().key);
                 } else {
-                    assert(0 <= controller_id < producer_keys.len() && producer_keys[controller_id] == controller_id);
+                    assert(0 <= controller_id < cook_keys.len() && cook_keys[controller_id] == controller_id);
                 }
             }
-            assert(!cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id));
+            assert(!cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id));
         }
     }
 
-    consumer_and_producers_are_correct(spec, cluster, consumer(), producers());
+    consumer_and_producers_are_correct(spec, cluster, waiter_spec_group(), cook_spec_groups());
 }
 
 }

--- a/src/soundness/compositionality/examples.rs
+++ b/src/soundness/compositionality/examples.rs
@@ -11,15 +11,33 @@ verus! {
 // This is a use case of consumer_and_producers_are_correct:
 // We can apply consumer_and_producers_are_correct to a concrete cluster that includes
 // only a consumer and a sequence of producers.
-pub spec fn producers<S, I>() -> Seq<Controller<S, I>>;
+pub spec fn producer_controllers<S, I>() -> Seq<Controller<S, I>>;
 
-pub spec fn consumer<S, I>() -> Controller<S, I>;
+pub spec fn consumer_controller<S, I>() -> Controller<S, I>;
+
+pub open spec fn producers<S, I>() -> Seq<ControllerSpecs<S, I>> {
+    producer_controllers().map(|i, v| ControllerSpecs {
+        controller: v,
+        key: i,
+        property: arbitrary(),
+        non_interference: arbitrary(),
+    })
+}
+
+pub open spec fn consumer<S, I>() -> ControllerSpecs<S, I> {
+    ControllerSpecs::<S, I> {
+        controller: consumer_controller(),
+        key: producers::<S, I>().len() as int,
+        property: arbitrary(),
+        non_interference: arbitrary(),
+    }
+}
 
 // A concrete cluster with only producers and consumer
 pub open spec fn consumer_and_producers<S, I>() -> Cluster<S, I> {
     Cluster {
-        controllers: Map::new(|k| 0 <= k < producers::<S, I>().len(), |k| producers::<S, I>()[k])
-            .insert(producers::<S, I>().len() as int, consumer::<S, I>())
+        controllers: Map::new(|k| 0 <= k < producer_controllers::<S, I>().len(), |k| producer_controllers::<S, I>()[k])
+            .insert(producer_controllers::<S, I>().len() as int, consumer_controller::<S, I>())
     }
 }
 
@@ -28,52 +46,72 @@ proof fn consumer_and_producers_are_correct_in_a_concrete_cluster<S, I>(spec: Te
         spec.entails(lift_state(consumer_and_producers::<S, I>().init())),
         spec.entails(always(lift_action(consumer_and_producers::<S, I>().next()))),
         forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
-            ==> #[trigger] spec.entails(controller_fairness::<S, I>(producers()[p_index])),
-        spec.entails(controller_fairness::<S, I>(consumer())),
+            ==> #[trigger] spec.entails(controller_fairness::<S, I>(producers()[p_index].controller)),
+        spec.entails(controller_fairness::<S, I>(consumer().controller)),
     ensures
         forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
-            ==> #[trigger] spec.entails(property::<S, I>(producers()[p_index])),
-        spec.entails(property::<S, I>(consumer())),
+            ==> #[trigger] spec.entails(producers::<S, I>()[p_index].property),
+        spec.entails(consumer::<S, I>().property),
 {
     let cluster = consumer_and_producers::<S, I>();
 
-    let producer_ids = Map::new(|k: int| 0 <= k < producers::<S, I>().len(), |k: int| k);
-    let consumer_id = producers::<S, I>().len() as int;
-
-    assert forall |s| #[trigger] cluster.init()(s) implies consumer::<S, I>().init()(s) by {
+    assert forall |s| #[trigger] cluster.init()(s) implies consumer::<S, I>().controller.init()(s) by {
         assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
-        assert(cluster.controllers.contains_key(consumer_id));
+        assert(cluster.controllers.contains_key(consumer::<S, I>().key));
     }
 
     assert forall |p_index| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
-    implies forall |s| #[trigger] cluster.init()(s) ==> producers::<S, I>()[p_index].init()(s) by {
-        assert forall |s| #[trigger] cluster.init()(s) implies producers::<S, I>()[p_index].init()(s) by {
+    implies forall |s| #[trigger] cluster.init()(s) ==> producers::<S, I>()[p_index].controller.init()(s) by {
+        assert forall |s| #[trigger] cluster.init()(s) implies producers::<S, I>()[p_index].controller.init()(s) by {
             assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
             assert(cluster.controllers.contains_key(p_index));
         }
     }
 
+    let producer_keys = producers().map_values(|p: ControllerSpecs<S, I>| p.key);
+    let producer_key_set = producer_keys.to_set();
+
     // Due to our cluster construct, you won't find a good_citizen_id that is neither the consumer nor any producer.
     // So we prove the following assertion by contradiction.
     assert forall |good_citizen_id: int|
-        #[trigger] cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id)
+        cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id)
     implies
-        spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, consumer()))))
-        && forall |p_index: int| 0 <= p_index < producers::<S, I>().len()
-            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers()[p_index]))))
+        #[trigger] spec.entails(always(lift_state((consumer::<S, I>().non_interference)(good_citizen_id))))
     by {
         assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
-        implies controller_id == consumer_id || producer_ids.values().contains(controller_id) by {
+        implies controller_id == consumer::<S, I>().key || producer_key_set.contains(controller_id) by {
             if controller_id == producers::<S, I>().len() as int {
-                assert(controller_id == consumer_id);
+                assert(controller_id == consumer::<S, I>().key);
             } else {
-                assert(producer_ids.dom().contains(controller_id) && producer_ids[controller_id] == controller_id);
+                assert(0 <= controller_id < producer_keys.len() && producer_keys[controller_id] == controller_id);
             }
         }
-        assert(!cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id));
+        assert(!cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id));
     }
 
-    consumer_and_producers_are_correct(spec, cluster, consumer(), consumer_id, producers(), producer_ids);
+    assert forall |p_index| #![trigger producers::<S, I>()[p_index]] 0 <= p_index < producers::<S, I>().len()
+    implies
+        (forall |good_citizen_id| cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (producers::<S, I>()[p_index].non_interference)(good_citizen_id)))))
+    by {
+        assert forall |good_citizen_id|
+            cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id)
+        implies
+            #[trigger] spec.entails(always(lift_state(#[trigger] (producers::<S, I>()[p_index].non_interference)(good_citizen_id))))
+        by {
+            assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
+            implies controller_id == consumer::<S, I>().key || producer_key_set.contains(controller_id) by {
+                if controller_id == producers::<S, I>().len() as int {
+                    assert(controller_id == consumer::<S, I>().key);
+                } else {
+                    assert(0 <= controller_id < producer_keys.len() && producer_keys[controller_id] == controller_id);
+                }
+            }
+            assert(!cluster.controllers.remove(consumer::<S, I>().key).remove_keys(producer_key_set).contains_key(good_citizen_id));
+        }
+    }
+
+    consumer_and_producers_are_correct(spec, cluster, consumer(), producers());
 }
 
 }

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -7,107 +7,101 @@ use vstd::prelude::*;
 
 verus! {
 
-// The top level property of the input controller (e.g., ESR)
-pub spec fn property<S, I>(controller: Controller<S, I>) -> TempPred<S>;
-
-// The inv asserts that the controller indexed by good_citizen_id does not interfere with the input controller's reconcile
-// This invariant, if interpretable, should state something like:
-// forall |message| message is sent by the controller indexed by good_citizen_id ==> message does not modify object X,
-// where X is something that the input controller cares about.
-//
-// To tell whether a message in the network is sent by a controller, our cluster state machine should attach the
-// controller id (the index) to each message sent by the controller, regardless of the controller's implementation.
-//
-// Note that the invariant likely does not hold when good_citizen_id points to the input controller itself, that is,
-// if there are two instances of the same controller, they will interfere with each other.
-// This is not a problem because there is no reason to run two such instances at the same time.
-pub spec fn one_does_not_interfere_with_this_controller<S, I>(cluster: Cluster<S, I>, good_citizen_id: int, controller: Controller<S, I>) -> StatePred<S>;
+#[verifier::reject_recursive_types(S)]
+#[verifier::reject_recursive_types(I)]
+pub struct ControllerSpecs<S, I> {
+    pub controller: Controller<S, I>,
+    // The key should be the one that points to controller in the cluster's controllers map
+    pub key: int,
+    // The top level property of the input controller (e.g., ESR)
+    pub property: TempPred<S>,
+    // The inv asserts that the controller indexed by good_citizen_id does not interfere with the input controller's reconcile
+    // This invariant, if interpretable, should state something like:
+    // forall |message| message is sent by the controller indexed by good_citizen_id ==> message does not modify object X,
+    // where X is something that the input controller cares about.
+    //
+    // To tell whether a message in the network is sent by a controller, our cluster state machine should attach the
+    // controller key to each message sent by the controller, regardless of the controller's implementation.
+    //
+    // Note that the invariant likely does not hold when good_citizen_id points to the input controller itself, that is,
+    // if there are two instances of the same controller, they will interfere with each other.
+    // This is not a problem because there is no reason to run two such instances at the same time.
+    pub non_interference: spec_fn(good_citizen_id: int) -> StatePred<S>,
+}
 
 // This is our top-level theorem: the consumer and producers are correct in any cluster
 // if the other controllers in that cluster do not interfere with the consumer or producers.
-// # Arguments:
-// * spec: the temporal predicate that represents the state machine
-// * cluster: the cluster that we want to run the consumers/producers in
-// * consumer_id: the key of the consumer in cluster.controllers
-// * producer_ids: maps the index of each producer to the key used in cluster.controllers
-pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: Controller<S, I>, consumer_id: int, producers: Seq<Controller<S, I>>, producer_ids: Map<int, int>)
+pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecs<S, I>, producers: Seq<ControllerSpecs<S, I>>)
     requires
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
         // The cluster starts with the initial state of the consumer.
-        forall |s| cluster.init()(s) ==> #[trigger] consumer.init()(s),
+        forall |s| #[trigger] cluster.init()(s) ==> consumer.controller.init()(s),
         // The cluster starts with the initial state of the producer.
         forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
-            ==> forall |s| cluster.init()(s) ==> #[trigger] producers[p_index].init()(s),
+            ==> forall |s| #[trigger] cluster.init()(s) ==> producers[p_index].controller.init()(s),
         // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
-        spec.entails(controller_fairness::<S, I>(consumer)),
+        spec.entails(controller_fairness::<S, I>(consumer.controller)),
         // The fairness condition is enough to say that each producer runs as part of the cluster's next transition.
-        forall |p_index| 0 <= p_index < producers.len()
-            ==> #[trigger] spec.entails(controller_fairness::<S, I>(producers[p_index])),
-        // The consumer_id points to the consumer.
-        cluster.controllers.contains_pair(consumer_id, consumer),
-        // Each element in producer_ids points to each producer respectively.
-        forall |key| producer_ids.contains_key(key)
-            ==> cluster.controllers.contains_pair(#[trigger] producer_ids[key], producers[key]),
-        // A key exists in producer_ids iff it's within the range of producers,
-        // which guarantees that producer_ids covers and only covers all the producers.
-        forall |key| #[trigger] producer_ids.contains_key(key) <==> 0 <= key < producers.len(),
+        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> spec.entails(controller_fairness::<S, I>(producers[p_index].controller)),
+        // The consumer.key points to the consumer.controller.
+        cluster.controllers.contains_pair(consumer.key, consumer.controller),
+        // Each producers[p_index].key points to producers[p_index].controller.
+        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
         // No other controllers interfere with the consumer.
-        forall |good_citizen_id| #[trigger] cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, consumer)))),
+        forall |good_citizen_id| cluster.controllers.remove(consumer.key).remove_keys(producers.map_values(|p: ControllerSpecs<S, I>| p.key).to_set()).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (consumer.non_interference)(good_citizen_id)))),
         // For each producer, no other controllers interfere with that producer.
-        forall |p_index: int| #![trigger producer_ids[p_index]] 0 <= p_index < producers.len()
-            ==> forall |good_citizen_id| #[trigger] cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id)
-                ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers[p_index]))))
+        forall |p_index: int| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> forall |good_citizen_id| cluster.controllers.remove(consumer.key).remove_keys(producers.map_values(|p: ControllerSpecs<S, I>| p.key).to_set()).contains_key(good_citizen_id)
+                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].non_interference)(good_citizen_id))))
     ensures
         // Consumer is correct.
-        spec.entails(property::<S, I>(consumer)),
+        spec.entails(consumer.property),
         // Each producer is correct.
         forall |p_index| 0 <= p_index < producers.len()
-            ==> #[trigger] spec.entails(property::<S, I>(producers[p_index])),
+            ==> #[trigger] spec.entails(producers[p_index].property),
         // No one interferes with the consumer (except the consumer itself).
-        forall |good_citizen_id| #[trigger] cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, consumer)))),
+        forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (consumer.non_interference)(good_citizen_id)))),
         // For each producer, no one interferes with that producer (except that producer itself).
-        forall |p_index| #![trigger producer_ids[p_index]] 0 <= p_index < producers.len()
-            ==> forall |good_citizen_id| #[trigger] cluster.controllers.remove(producer_ids[p_index]).contains_key(good_citizen_id)
-                ==> spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers[p_index])))),
+        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
+                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].non_interference)(good_citizen_id)))),
 {
-    assert forall |p_index| #![trigger producer_ids[p_index]] 0 <= p_index < producers.len()
-    implies (forall |good_citizen_id| #[trigger] cluster.controllers.remove(producer_ids[p_index]).contains_key(good_citizen_id)
-        ==> spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers[p_index])))))
+    assert forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+    implies (forall |good_citizen_id| #[trigger] cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
+        ==> spec.entails(always(lift_state((producers[p_index].non_interference)(good_citizen_id)))))
     by {
-        assert forall |good_citizen_id| #[trigger] cluster.controllers.contains_key(good_citizen_id) && good_citizen_id != producer_ids[p_index]
-        implies spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers[p_index])))) by {
-            if good_citizen_id == consumer_id {
-                consumer_does_not_interfere_with_the_producer(spec, cluster, consumer, producers, good_citizen_id, p_index);
-            } else if producer_ids.contains_value(good_citizen_id) {
-                let j = choose |j| producer_ids.dom().contains(j) && #[trigger] producer_ids[j] == good_citizen_id;
-                producer_does_not_interfere_with_the_producer(spec, cluster, producers, good_citizen_id, j, p_index);
+        assert forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
+        implies spec.entails(always(lift_state(#[trigger] (producers[p_index].non_interference)(good_citizen_id)))) by {
+            if good_citizen_id == consumer.key {
+                consumer_does_not_interfere_with_the_producer(spec, cluster, consumer, producers, p_index);
+            } else if producers.map_values(|p: ControllerSpecs<S, I>| p.key).to_set().contains(good_citizen_id) {
+                let j = choose |j| 0 <= j < producers.len() && #[trigger] producers[j].key == good_citizen_id;
+                producer_does_not_interfere_with_the_producer(spec, cluster, producers, j, p_index);
             } else {
-                assert(cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id));
-                assert(spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers[p_index])))));
+                assert(spec.entails(always(lift_state((producers[p_index].non_interference)(good_citizen_id)))));
             }
         }
     }
 
-    assert forall |p_index| 0 <= p_index < producers.len() implies #[trigger] spec.entails(property::<S, I>(producers[p_index])) by {
-        assert(producer_ids.contains_key(p_index));
-        let producer_id = producer_ids[p_index];
-        producer_is_correct(spec, cluster, producers, producer_id, p_index);
+    assert forall |p_index| 0 <= p_index < producers.len() implies #[trigger] spec.entails(producers[p_index].property) by {
+        producer_is_correct(spec, cluster, producers, p_index);
     }
 
-    assert forall |good_citizen_id| cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
-    implies spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, consumer)))) by {
-        if producer_ids.contains_value(good_citizen_id) {
-            let j = choose |j| producer_ids.dom().contains(j) && #[trigger] producer_ids[j] == good_citizen_id;
-            producer_does_not_interfere_with_the_consumer(spec, cluster, consumer, producers, good_citizen_id, j);
+    assert forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
+    implies spec.entails(always(lift_state(#[trigger] (consumer.non_interference)(good_citizen_id)))) by {
+        if producers.map_values(|p: ControllerSpecs<S, I>| p.key).to_set().contains(good_citizen_id) {
+            let j = choose |j| 0 <= j < producers.len() && #[trigger] producers[j].key == good_citizen_id;
+            producer_does_not_interfere_with_the_consumer(spec, cluster, consumer, producers, j);
         } else {
-            assert(cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id));
-            assert(spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, consumer)))));
+            assert(spec.entails(always(lift_state((consumer.non_interference)(good_citizen_id)))));
         }
     }
-    consumer_is_correct(spec, cluster, consumer, consumer_id, producers);
+    consumer_is_correct(spec, cluster, consumer, producers);
 }
 
 // To prove consumer_and_producers_are_correct, there are five proof obligations.
@@ -115,63 +109,63 @@ pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster
 // Proof obligation 1:
 // Producer is correct when running in any cluster where there is no interference.
 #[verifier(external_body)]
-proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<Controller<S, I>>, producer_id: int, p_index: int)
+proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerSpecs<S, I>>, p_index: int)
     requires
         0 <= p_index < producers.len(),
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
         // The cluster starts with the initial state of the producer.
-        forall |s| cluster.init()(s) ==> #[trigger] producers[p_index].init()(s),
+        forall |s| cluster.init()(s) ==> #[trigger] producers[p_index].controller.init()(s),
         // The fairness condition is enough to say that the producer runs as part of the cluster's next transition.
-        spec.entails(controller_fairness::<S, I>(producers[p_index])),
+        spec.entails(controller_fairness::<S, I>(producers[p_index].controller)),
         // The next two preconditions say that no controller (except the producer itself) interferes with this producer.
-        cluster.controllers.contains_pair(producer_id, producers[p_index]),
-        forall |good_citizen_id| cluster.controllers.remove(producer_id).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers[p_index])))),
+        cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
+        forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].non_interference)(good_citizen_id)))),
     ensures
-        spec.entails(property::<S, I>(producers[p_index])),
+        spec.entails(producers[p_index].property),
 {}
 
 // Proof obligation 2:
 // Consumer is correct when running in any cluster where each producer's spec is available and there is no interference.
 #[verifier(external_body)]
-proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: Controller<S, I>, consumer_id: int, producers: Seq<Controller<S, I>>)
+proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecs<S, I>, producers: Seq<ControllerSpecs<S, I>>)
     requires
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
         // The cluster starts with the initial state of the consumer.
-        forall |s| cluster.init()(s) ==> #[trigger] consumer.init()(s),
+        forall |s| cluster.init()(s) ==> #[trigger] consumer.controller.init()(s),
         // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
-        spec.entails(controller_fairness::<S, I>(consumer)),
+        spec.entails(controller_fairness::<S, I>(consumer.controller)),
         // The next two preconditions say that no controller (except the consumer itself) interferes with this consumer.
-        cluster.controllers.contains_pair(consumer_id, consumer),
-        forall |good_citizen_id| cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, consumer)))),
-        // We directly use the temporal spec of the producers.
+        cluster.controllers.contains_pair(consumer.key, consumer.controller),
+        forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (consumer.non_interference)(good_citizen_id)))),
+        // We directly use the temporal property of the producers.
         forall |p_index: int| 0 <= p_index < producers.len()
-            ==> #[trigger] spec.entails(property::<S, I>(producers[p_index])),
+            ==> #[trigger] spec.entails(producers[p_index].property),
     ensures
-        spec.entails(property::<S, I>(consumer)),
+        spec.entails(consumer.property),
 {}
 
 // Proof obligation 3:
 // Consumer does not interfere with the producer in any cluster.
 #[verifier(external_body)]
-proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: Controller<S, I>, producers: Seq<Controller<S, I>>, good_citizen_id: int, p_index: int)
+proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecs<S, I>, producers: Seq<ControllerSpecs<S, I>>, p_index: int)
     requires
         0 <= p_index < producers.len(),
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers.contains_pair(good_citizen_id, consumer),
+        cluster.controllers.contains_pair(consumer.key, consumer.controller),
     ensures
         // The consumer never interferes with the producer.
-        spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers[p_index])))),
+        spec.entails(always(lift_state((producers[p_index].non_interference)(consumer.key)))),
 {}
 
 // Proof obligation 4:
 // Producer does not interfere with another producer in any cluster.
 #[verifier(external_body)]
-proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<Controller<S, I>>, good_citizen_id: int, p_index: int, q_index: int)
+proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerSpecs<S, I>>, p_index: int, q_index: int)
     requires
         0 <= p_index < producers.len(),
         0 <= q_index < producers.len(),
@@ -180,24 +174,24 @@ proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
         p_index != q_index,
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers.contains_pair(good_citizen_id, producers[p_index]),
+        cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
     ensures
         // The producer (p_index) never interferes with the other producer (q_index).
-        spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, producers[q_index])))),
+        spec.entails(always(lift_state((producers[q_index].non_interference)(producers[p_index].key)))),
 {}
 
 // Proof obligation 5:
 // Producer does not interfere with the consumer in any cluster.
 #[verifier(external_body)]
-proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: Controller<S, I>, producers: Seq<Controller<S, I>>, good_citizen_id: int, p_index: int)
+proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecs<S, I>, producers: Seq<ControllerSpecs<S, I>>, p_index: int)
     requires
         0 <= p_index < producers.len(),
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers.contains_pair(good_citizen_id, producers[p_index]),
+        cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
     ensures
         // The producer never interferes with the consumer.
-        spec.entails(always(lift_state(one_does_not_interfere_with_this_controller::<S, I>(cluster, good_citizen_id, consumer)))),
+        spec.entails(always(lift_state((consumer.non_interference)(producers[p_index].key)))),
 {}
 
 }

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -9,7 +9,7 @@ verus! {
 
 #[verifier::reject_recursive_types(S)]
 #[verifier::reject_recursive_types(I)]
-pub struct ControllerSpecs<S, I> {
+pub struct ControllerSpecGroup<S, I> {
     pub controller: Controller<S, I>,
     // The key should be the one that points to controller in the cluster's controllers map
     pub key: int,
@@ -26,12 +26,12 @@ pub struct ControllerSpecs<S, I> {
     // Note that the invariant likely does not hold when good_citizen_id points to the input controller itself, that is,
     // if there are two instances of the same controller, they will interfere with each other.
     // This is not a problem because there is no reason to run two such instances at the same time.
-    pub non_interference: spec_fn(good_citizen_id: int) -> StatePred<S>,
+    pub not_interfered_by: spec_fn(good_citizen_id: int) -> StatePred<S>,
 }
 
 // This is our top-level theorem: the consumer and producers are correct in any cluster
 // if the other controllers in that cluster do not interfere with the consumer or producers.
-pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecs<S, I>, producers: Seq<ControllerSpecs<S, I>>)
+pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecGroup<S, I>, producers: Seq<ControllerSpecGroup<S, I>>)
     requires
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
@@ -51,12 +51,12 @@ pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster
         forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
             ==> cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
         // No other controllers interfere with the consumer.
-        forall |good_citizen_id| cluster.controllers.remove(consumer.key).remove_keys(producers.map_values(|p: ControllerSpecs<S, I>| p.key).to_set()).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] (consumer.non_interference)(good_citizen_id)))),
+        forall |good_citizen_id| cluster.controllers.remove(consumer.key).remove_keys(producers.map_values(|p: ControllerSpecGroup<S, I>| p.key).to_set()).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))),
         // For each producer, no other controllers interfere with that producer.
         forall |p_index: int| #![trigger producers[p_index]] 0 <= p_index < producers.len()
-            ==> forall |good_citizen_id| cluster.controllers.remove(consumer.key).remove_keys(producers.map_values(|p: ControllerSpecs<S, I>| p.key).to_set()).contains_key(good_citizen_id)
-                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].non_interference)(good_citizen_id))))
+            ==> forall |good_citizen_id| cluster.controllers.remove(consumer.key).remove_keys(producers.map_values(|p: ControllerSpecGroup<S, I>| p.key).to_set()).contains_key(good_citizen_id)
+                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id))))
     ensures
         // Consumer is correct.
         spec.entails(consumer.property),
@@ -65,25 +65,25 @@ pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster
             ==> #[trigger] spec.entails(producers[p_index].property),
         // No one interferes with the consumer (except the consumer itself).
         forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] (consumer.non_interference)(good_citizen_id)))),
+            ==> spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))),
         // For each producer, no one interferes with that producer (except that producer itself).
         forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
             ==> forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
-                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].non_interference)(good_citizen_id)))),
+                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))),
 {
     assert forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
     implies (forall |good_citizen_id| #[trigger] cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
-        ==> spec.entails(always(lift_state((producers[p_index].non_interference)(good_citizen_id)))))
+        ==> spec.entails(always(lift_state((producers[p_index].not_interfered_by)(good_citizen_id)))))
     by {
         assert forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
-        implies spec.entails(always(lift_state(#[trigger] (producers[p_index].non_interference)(good_citizen_id)))) by {
+        implies spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))) by {
             if good_citizen_id == consumer.key {
                 consumer_does_not_interfere_with_the_producer(spec, cluster, consumer, producers, p_index);
-            } else if producers.map_values(|p: ControllerSpecs<S, I>| p.key).to_set().contains(good_citizen_id) {
+            } else if producers.map_values(|p: ControllerSpecGroup<S, I>| p.key).to_set().contains(good_citizen_id) {
                 let j = choose |j| 0 <= j < producers.len() && #[trigger] producers[j].key == good_citizen_id;
                 producer_does_not_interfere_with_the_producer(spec, cluster, producers, j, p_index);
             } else {
-                assert(spec.entails(always(lift_state((producers[p_index].non_interference)(good_citizen_id)))));
+                assert(spec.entails(always(lift_state((producers[p_index].not_interfered_by)(good_citizen_id)))));
             }
         }
     }
@@ -93,12 +93,12 @@ pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster
     }
 
     assert forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
-    implies spec.entails(always(lift_state(#[trigger] (consumer.non_interference)(good_citizen_id)))) by {
-        if producers.map_values(|p: ControllerSpecs<S, I>| p.key).to_set().contains(good_citizen_id) {
+    implies spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))) by {
+        if producers.map_values(|p: ControllerSpecGroup<S, I>| p.key).to_set().contains(good_citizen_id) {
             let j = choose |j| 0 <= j < producers.len() && #[trigger] producers[j].key == good_citizen_id;
             producer_does_not_interfere_with_the_consumer(spec, cluster, consumer, producers, j);
         } else {
-            assert(spec.entails(always(lift_state((consumer.non_interference)(good_citizen_id)))));
+            assert(spec.entails(always(lift_state((consumer.not_interfered_by)(good_citizen_id)))));
         }
     }
     consumer_is_correct(spec, cluster, consumer, producers);
@@ -109,7 +109,7 @@ pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster
 // Proof obligation 1:
 // Producer is correct when running in any cluster where there is no interference.
 #[verifier(external_body)]
-proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerSpecs<S, I>>, p_index: int)
+proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerSpecGroup<S, I>>, p_index: int)
     requires
         0 <= p_index < producers.len(),
         spec.entails(lift_state(cluster.init())),
@@ -121,7 +121,7 @@ proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, pr
         // The next two preconditions say that no controller (except the producer itself) interferes with this producer.
         cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
         forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].non_interference)(good_citizen_id)))),
+            ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))),
     ensures
         spec.entails(producers[p_index].property),
 {}
@@ -129,7 +129,7 @@ proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, pr
 // Proof obligation 2:
 // Consumer is correct when running in any cluster where each producer's spec is available and there is no interference.
 #[verifier(external_body)]
-proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecs<S, I>, producers: Seq<ControllerSpecs<S, I>>)
+proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecGroup<S, I>, producers: Seq<ControllerSpecGroup<S, I>>)
     requires
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
@@ -140,7 +140,7 @@ proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, co
         // The next two preconditions say that no controller (except the consumer itself) interferes with this consumer.
         cluster.controllers.contains_pair(consumer.key, consumer.controller),
         forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] (consumer.non_interference)(good_citizen_id)))),
+            ==> spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))),
         // We directly use the temporal property of the producers.
         forall |p_index: int| 0 <= p_index < producers.len()
             ==> #[trigger] spec.entails(producers[p_index].property),
@@ -151,7 +151,7 @@ proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, co
 // Proof obligation 3:
 // Consumer does not interfere with the producer in any cluster.
 #[verifier(external_body)]
-proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecs<S, I>, producers: Seq<ControllerSpecs<S, I>>, p_index: int)
+proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecGroup<S, I>, producers: Seq<ControllerSpecGroup<S, I>>, p_index: int)
     requires
         0 <= p_index < producers.len(),
         spec.entails(lift_state(cluster.init())),
@@ -159,13 +159,13 @@ proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
         cluster.controllers.contains_pair(consumer.key, consumer.controller),
     ensures
         // The consumer never interferes with the producer.
-        spec.entails(always(lift_state((producers[p_index].non_interference)(consumer.key)))),
+        spec.entails(always(lift_state((producers[p_index].not_interfered_by)(consumer.key)))),
 {}
 
 // Proof obligation 4:
 // Producer does not interfere with another producer in any cluster.
 #[verifier(external_body)]
-proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerSpecs<S, I>>, p_index: int, q_index: int)
+proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerSpecGroup<S, I>>, p_index: int, q_index: int)
     requires
         0 <= p_index < producers.len(),
         0 <= q_index < producers.len(),
@@ -177,13 +177,13 @@ proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, 
         cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
     ensures
         // The producer (p_index) never interferes with the other producer (q_index).
-        spec.entails(always(lift_state((producers[q_index].non_interference)(producers[p_index].key)))),
+        spec.entails(always(lift_state((producers[q_index].not_interfered_by)(producers[p_index].key)))),
 {}
 
 // Proof obligation 5:
 // Producer does not interfere with the consumer in any cluster.
 #[verifier(external_body)]
-proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecs<S, I>, producers: Seq<ControllerSpecs<S, I>>, p_index: int)
+proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecGroup<S, I>, producers: Seq<ControllerSpecGroup<S, I>>, p_index: int)
     requires
         0 <= p_index < producers.len(),
         spec.entails(lift_state(cluster.init())),
@@ -191,7 +191,7 @@ proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, 
         cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
     ensures
         // The producer never interferes with the consumer.
-        spec.entails(always(lift_state((consumer.non_interference)(producers[p_index].key)))),
+        spec.entails(always(lift_state((consumer.not_interfered_by)(producers[p_index].key)))),
 {}
 
 }


### PR DESCRIPTION
This PR introduces `ControllerSpecGroup` which includes the controller, its key in the `cluster.controllers` map, its temporal property, and its non-interference invariant. This struct helps to simplify the compositional theorems, as we no longer need to carry the `consumer_id`/`producer_ids` along the way.