### PR TITLE
Compose controllers incrementally

### DIFF
--- a/src/soundness/compositionality/examples.rs
+++ b/src/soundness/compositionality/examples.rs
@@ -8,110 +8,331 @@ use vstd::prelude::*;
 
 verus! {
 
-// This is a use case of consumer_and_producers_are_correct:
-// We can apply consumer_and_producers_are_correct to a concrete cluster that includes
-// only a waiter and a sequence of cooks.
-pub spec fn cooks<S, I>() -> Seq<Controller<S, I>>;
+// Here are two examples on how to use BaseComposition and IncrementalComposition.
 
-pub spec fn waiter<S, I>() -> Controller<S, I>;
+// Example 1: we use BaseComposition to prove that the waiter_controller (the consumer)
+// and the cook_controllers (the producers) are correct when running together.
 
-pub open spec fn cook_spec_groups<S, I>() -> Seq<ControllerSpecGroup<S, I>> {
-    cooks().map(|i, v| ControllerSpecGroup {
+pub spec fn cook_controllers<S, I>() -> Seq<Controller<S, I>>;
+
+pub spec fn waiter_controller<S, I>() -> Controller<S, I>;
+
+pub open spec fn waiter_and_cooks<S, I>() -> Cluster<S, I> {
+    Cluster {
+        controllers: Map::new(|k| 0 <= k < cook_controllers::<S, I>().len(), |k| cook_controllers::<S, I>()[k])
+            .insert(cook_controllers::<S, I>().len() as int, waiter_controller::<S, I>())
+    }
+}
+
+pub open spec fn cooks<S, I>() -> Seq<ControllerPredGroup<S, I>> {
+    cook_controllers().map(|i, v| ControllerPredGroup {
         controller: v,
-        key: i,
-        property: arbitrary(),
-        not_interfered_by: arbitrary(),
+        property: cook_property(i),
+        not_interfered_by: cook_not_interfered_by(i),
     })
 }
 
-pub open spec fn waiter_spec_group<S, I>() -> ControllerSpecGroup<S, I> {
-    ControllerSpecGroup::<S, I> {
-        controller: waiter(),
-        key: cook_spec_groups::<S, I>().len() as int,
-        property: arbitrary(),
-        not_interfered_by: arbitrary(),
+pub open spec fn waiter<S, I>() -> ControllerPredGroup<S, I> {
+    ControllerPredGroup::<S, I> {
+        controller: waiter_controller(),
+        property: waiter_property(),
+        not_interfered_by: waiter_not_interfered_by(),
     }
 }
 
-// A concrete cluster with only cooks and waiter_spec_group
-pub open spec fn waiter_and_cooks<S, I>() -> Cluster<S, I> {
-    Cluster {
-        controllers: Map::new(|k| 0 <= k < cooks::<S, I>().len(), |k| cooks::<S, I>()[k])
-            .insert(cooks::<S, I>().len() as int, waiter::<S, I>())
-    }
+pub struct BaseCompositionProof<S, I> {
+    dummy_s: std::marker::PhantomData<S>,
+    dummy_i: std::marker::PhantomData<I>,
 }
 
+// Developers need to first prove the five lemmas (proof functions)
+// required by the BaseComposition trait for waiter() and cooks().
+impl<S, I> BaseComposition<S, I> for BaseCompositionProof<S, I> {
+    open spec fn consumer() -> ControllerPredGroup<S, I> {
+        waiter()
+    }
+
+    open spec fn producers() -> Seq<ControllerPredGroup<S, I>> {
+        cooks()
+    }
+
+    #[verifier(external_body)]
+    proof fn consumer_is_correct(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int) {}
+
+    #[verifier(external_body)]
+    proof fn producer_is_correct(spec: TempPred<S>, cluster: Cluster<S, I>, producer_id: int, p_index: int) {}
+
+    #[verifier(external_body)]
+    proof fn consumer_does_not_interfere_with_the_producer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int) {}
+
+    #[verifier(external_body)]
+    proof fn producer_does_not_interfere_with_the_consumer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int) {}
+
+    #[verifier(external_body)]
+    proof fn producer_does_not_interfere_with_the_producer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int, q_index: int) {}
+}
+
+// This proof applies compose_producers_and_consumer to the cluster waiter_and_cooks
+// and concludes that the waiter and cooks are all correct.
 proof fn waiter_and_cooks_are_correct<S, I>(spec: TempPred<S>)
     requires
         spec.entails(lift_state(waiter_and_cooks::<S, I>().init())),
         spec.entails(always(lift_action(waiter_and_cooks::<S, I>().next()))),
-        forall |p_index: int| 0 <= p_index < cook_spec_groups::<S, I>().len()
-            ==> #[trigger] spec.entails(controller_fairness::<S, I>(cook_spec_groups()[p_index].controller)),
-        spec.entails(controller_fairness::<S, I>(waiter_spec_group().controller)),
+        spec.entails(controller_fairness::<S, I>(waiter().controller)),
+        forall |p_index: int| 0 <= p_index < cooks::<S, I>().len()
+            ==> #[trigger] spec.entails(controller_fairness::<S, I>(cooks()[p_index].controller)),
     ensures
-        forall |p_index: int| 0 <= p_index < cook_spec_groups::<S, I>().len()
-            ==> #[trigger] spec.entails(cook_spec_groups::<S, I>()[p_index].property),
-        spec.entails(waiter_spec_group::<S, I>().property),
+        spec.entails(waiter::<S, I>().property),
+        forall |p_index: int| 0 <= p_index < cooks::<S, I>().len()
+            ==> #[trigger] spec.entails(cooks::<S, I>()[p_index].property),
 {
     let cluster = waiter_and_cooks::<S, I>();
 
-    assert forall |s| #[trigger] cluster.init()(s) implies waiter_spec_group::<S, I>().controller.init()(s) by {
+    let cook_ids = Map::new(|k: int| 0 <= k < cook_controllers::<S, I>().len(), |k: int| k);
+    let waiter_id = cook_controllers::<S, I>().len() as int;
+
+    assert forall |s| #[trigger] cluster.init()(s) implies waiter::<S, I>().controller.init()(s) by {
         assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
-        assert(cluster.controllers.contains_key(waiter_spec_group::<S, I>().key));
+        assert(cluster.controllers.contains_key(waiter_id));
     }
 
-    assert forall |p_index| #![trigger cook_spec_groups::<S, I>()[p_index]] 0 <= p_index < cook_spec_groups::<S, I>().len()
-    implies forall |s| #[trigger] cluster.init()(s) ==> cook_spec_groups::<S, I>()[p_index].controller.init()(s) by {
-        assert forall |s| #[trigger] cluster.init()(s) implies cook_spec_groups::<S, I>()[p_index].controller.init()(s) by {
+    assert forall |p_index| #![trigger cooks::<S, I>()[p_index]] 0 <= p_index < cooks::<S, I>().len()
+    implies forall |s| #[trigger] cluster.init()(s) ==> cooks::<S, I>()[p_index].controller.init()(s) by {
+        assert forall |s| #[trigger] cluster.init()(s) implies cooks::<S, I>()[p_index].controller.init()(s) by {
             assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
             assert(cluster.controllers.contains_key(p_index));
         }
     }
 
-    let cook_keys = cook_spec_groups().map_values(|p: ControllerSpecGroup<S, I>| p.key);
-    let cook_key_set = cook_keys.to_set();
-
-    // Due to our cluster construct, you won't find a good_citizen_id that is neither the waiter_spec_group nor any cook.
+    // Due to our cluster construct, you won't find a good_citizen_id that is neither the waiter nor any cook.
     // So we prove the following assertion by contradiction.
     assert forall |good_citizen_id: int|
-        cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id)
+        cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id)
     implies
-        #[trigger] spec.entails(always(lift_state((waiter_spec_group::<S, I>().not_interfered_by)(good_citizen_id))))
+        #[trigger] spec.entails(always(lift_state((waiter::<S, I>().not_interfered_by)(good_citizen_id))))
     by {
         assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
-        implies controller_id == waiter_spec_group::<S, I>().key || cook_key_set.contains(controller_id) by {
-            if controller_id == cook_spec_groups::<S, I>().len() as int {
-                assert(controller_id == waiter_spec_group::<S, I>().key);
+        implies controller_id == waiter_id || cook_ids.values().contains(controller_id) by {
+            if controller_id == cook_controllers::<S, I>().len() as int {
+                assert(controller_id == waiter_id);
             } else {
-                assert(0 <= controller_id < cook_keys.len() && cook_keys[controller_id] == controller_id);
+                assert(cook_ids.dom().contains(controller_id) && cook_ids[controller_id] == controller_id);
             }
         }
-        assert(!cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id));
+        assert(!cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id));
     }
 
-    assert forall |p_index| #![trigger cook_spec_groups::<S, I>()[p_index]] 0 <= p_index < cook_spec_groups::<S, I>().len()
+    // Same as above.
+    assert forall |p_index| #![trigger cooks::<S, I>()[p_index]] 0 <= p_index < cooks::<S, I>().len()
     implies
-        (forall |good_citizen_id| cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] (cook_spec_groups::<S, I>()[p_index].not_interfered_by)(good_citizen_id)))))
+        (forall |good_citizen_id| cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (cooks::<S, I>()[p_index].not_interfered_by)(good_citizen_id)))))
     by {
         assert forall |good_citizen_id|
-            cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id)
+            cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id)
         implies
-            #[trigger] spec.entails(always(lift_state(#[trigger] (cook_spec_groups::<S, I>()[p_index].not_interfered_by)(good_citizen_id))))
+            #[trigger] spec.entails(always(lift_state(#[trigger] (cooks::<S, I>()[p_index].not_interfered_by)(good_citizen_id))))
         by {
             assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
-            implies controller_id == waiter_spec_group::<S, I>().key || cook_key_set.contains(controller_id) by {
-                if controller_id == cook_spec_groups::<S, I>().len() as int {
-                    assert(controller_id == waiter_spec_group::<S, I>().key);
+            implies controller_id == waiter_id || cook_ids.values().contains(controller_id) by {
+                if controller_id == cook_controllers::<S, I>().len() as int {
+                    assert(controller_id == waiter_id);
                 } else {
-                    assert(0 <= controller_id < cook_keys.len() && cook_keys[controller_id] == controller_id);
+                    assert(cook_ids.dom().contains(controller_id) && cook_ids[controller_id] == controller_id);
                 }
             }
-            assert(!cluster.controllers.remove(waiter_spec_group::<S, I>().key).remove_keys(cook_key_set).contains_key(good_citizen_id));
+            assert(!cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id));
         }
     }
 
-    consumer_and_producers_are_correct(spec, cluster, waiter_spec_group(), cook_spec_groups());
+    compose_producers_and_consumer::<S, I, BaseCompositionProof<S, I>>(spec, cluster, waiter::<S, I>(), cooks::<S, I>(), waiter_id, cook_ids);
 }
+
+// Example 2: we use IncrementalComposition to further prove that when the waiter_controller
+// and cook_controllers run with a customer_controller, they are all correct. The key is to
+// first use BaseComposition to prove the correctness of the waiter and cooks, and then use
+// IncrementalComposition to prove the correctness of the customer.
+
+pub spec fn customer_controller<S, I>() -> Controller<S, I>;
+
+pub open spec fn customer_and_waiter_and_cooks<S, I>() -> Cluster<S, I> {
+    Cluster {
+        controllers: Map::new(|k| 0 <= k < cook_controllers::<S, I>().len(), |k| cook_controllers::<S, I>()[k])
+            .insert(cook_controllers::<S, I>().len() as int, waiter_controller::<S, I>())
+            .insert(cook_controllers::<S, I>().len() as int + 1, customer_controller::<S, I>())
+    }
+}
+
+pub open spec fn customer<S, I>() -> ControllerPredGroup<S, I> {
+    ControllerPredGroup::<S, I> {
+        controller: customer_controller(),
+        property: customer_property(),
+        not_interfered_by: customer_not_interfered_by(),
+    }
+}
+
+pub struct IncrementalCompositionProof<S, I> {
+    dummy_s: std::marker::PhantomData<S>,
+    dummy_i: std::marker::PhantomData<I>,
+}
+
+// IncrementalComposition poses only three lemmas for developers to prove
+// and it assumes that producers are already proved correct.
+// For the customer, the producers are the cooks and the waiter.
+
+impl<S, I> IncrementalComposition<S, I> for IncrementalCompositionProof<S, I> {
+    open spec fn consumer() -> ControllerPredGroup<S, I> {
+        customer()
+    }
+
+    open spec fn producers() -> Seq<ControllerPredGroup<S, I>> {
+        cooks().push(waiter())
+    }
+
+    #[verifier(external_body)]
+    proof fn consumer_is_correct(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int) {}
+
+    #[verifier(external_body)]
+    proof fn consumer_does_not_interfere_with_the_producer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int) {}
+
+    #[verifier(external_body)]
+    proof fn producer_does_not_interfere_with_the_consumer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int) {}
+}
+
+proof fn customer_and_waiter_and_cooks_are_correct<S, I>(spec: TempPred<S>)
+    requires
+        spec.entails(lift_state(customer_and_waiter_and_cooks::<S, I>().init())),
+        spec.entails(always(lift_action(customer_and_waiter_and_cooks::<S, I>().next()))),
+        spec.entails(controller_fairness::<S, I>(customer().controller)),
+        spec.entails(controller_fairness::<S, I>(waiter().controller)),
+        forall |p_index: int| 0 <= p_index < cooks::<S, I>().len()
+            ==> #[trigger] spec.entails(controller_fairness::<S, I>(cooks()[p_index].controller)),
+    ensures
+        spec.entails(customer::<S, I>().property),
+        spec.entails(waiter::<S, I>().property),
+        forall |p_index: int| 0 <= p_index < cooks::<S, I>().len()
+            ==> #[trigger] spec.entails(cooks::<S, I>()[p_index].property),
+{
+    let cluster = customer_and_waiter_and_cooks::<S, I>();
+
+    let cook_ids = Map::new(|k: int| 0 <= k < cook_controllers::<S, I>().len(), |k: int| k);
+    let waiter_id = cook_controllers::<S, I>().len() as int;
+    let customer_id = cook_controllers::<S, I>().len() as int + 1;
+
+    assert forall |s| #[trigger] cluster.init()(s) implies waiter::<S, I>().controller.init()(s) by {
+        assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
+        assert(cluster.controllers.contains_key(waiter_id));
+    }
+
+    assert forall |p_index| #![trigger cooks::<S, I>()[p_index]] 0 <= p_index < cooks::<S, I>().len()
+    implies forall |s| #[trigger] cluster.init()(s) ==> cooks::<S, I>()[p_index].controller.init()(s) by {
+        assert forall |s| #[trigger] cluster.init()(s) implies cooks::<S, I>()[p_index].controller.init()(s) by {
+            assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
+            assert(cluster.controllers.contains_key(p_index));
+        }
+    }
+
+    assert forall |good_citizen_id: int|
+        cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id)
+    implies
+        #[trigger] spec.entails(always(lift_state((waiter::<S, I>().not_interfered_by)(good_citizen_id))))
+    by {
+        assert forall |good_citizen_id| #[trigger] cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id)
+        implies good_citizen_id == customer_id by {
+            assert(0 <= good_citizen_id < cook_controllers::<S, I>().len() || waiter_id == good_citizen_id || customer_id == good_citizen_id);
+            if 0 <= good_citizen_id < cook_controllers::<S, I>().len() {
+                assert(cook_ids.dom().contains(good_citizen_id) && cook_ids[good_citizen_id] == good_citizen_id);
+                assert(cook_ids.values().contains(good_citizen_id));
+                assert(!cook_ids.values().contains(good_citizen_id));
+            } else if waiter_id == good_citizen_id {
+                assert(waiter_id != good_citizen_id);
+            }
+        }
+        IncrementalCompositionProof::consumer_does_not_interfere_with_the_producer(spec, cluster, good_citizen_id, cook_controllers::<S, I>().len() as int);
+    }
+
+    assert forall |p_index| #![trigger cooks::<S, I>()[p_index]] 0 <= p_index < cooks::<S, I>().len()
+    implies
+        (forall |good_citizen_id| cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (cooks::<S, I>()[p_index].not_interfered_by)(good_citizen_id)))))
+    by {
+        assert forall |good_citizen_id|
+            cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id)
+        implies
+            #[trigger] spec.entails(always(lift_state(#[trigger] (cooks::<S, I>()[p_index].not_interfered_by)(good_citizen_id))))
+        by {
+            assert forall |good_citizen_id| #[trigger] cluster.controllers.remove(waiter_id).remove_keys(cook_ids.values()).contains_key(good_citizen_id)
+            implies good_citizen_id == customer_id by {
+                assert(0 <= good_citizen_id < cook_controllers::<S, I>().len() || waiter_id == good_citizen_id || customer_id == good_citizen_id);
+                if 0 <= good_citizen_id < cook_controllers::<S, I>().len() {
+                    assert(cook_ids.dom().contains(good_citizen_id) && cook_ids[good_citizen_id] == good_citizen_id);
+                    assert(cook_ids.values().contains(good_citizen_id));
+                    assert(!cook_ids.values().contains(good_citizen_id));
+                } else if waiter_id == good_citizen_id {
+                    assert(waiter_id != good_citizen_id);
+                }
+            }
+            IncrementalCompositionProof::consumer_does_not_interfere_with_the_producer(spec, cluster, good_citizen_id, p_index);
+        }
+    }
+
+    compose_producers_and_consumer::<S, I, BaseCompositionProof<S, I>>(spec, cluster, waiter::<S, I>(), cooks::<S, I>(), waiter_id, cook_ids);
+
+    let cooks_and_waiter = cooks().push(waiter());
+    let cooks_and_waiter_ids = Map::new(|k: int| 0 <= k < cook_controllers::<S, I>().len() + 1, |k: int| k);
+
+    assert forall |s| #[trigger] cluster.init()(s) implies customer::<S, I>().controller.init()(s) by {
+        assert forall |i| #[trigger] cluster.controllers.contains_key(i) implies cluster.controllers[i].init()(s) by {}
+        assert(cluster.controllers.contains_key(customer_id));
+    }
+
+    assert forall |good_citizen_id: int|
+        cluster.controllers.remove(customer_id).remove_keys(cooks_and_waiter_ids.values()).contains_key(good_citizen_id)
+    implies
+        #[trigger] spec.entails(always(lift_state((customer::<S, I>().not_interfered_by)(good_citizen_id))))
+    by {
+        assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
+        implies controller_id == customer_id || cooks_and_waiter_ids.values().contains(controller_id) by {
+            if controller_id == cook_controllers::<S, I>().len() as int + 1 {
+                assert(controller_id == customer_id);
+            } else {
+                assert(cooks_and_waiter_ids.dom().contains(controller_id) && cooks_and_waiter_ids[controller_id] == controller_id);
+            }
+        }
+        assert(!cluster.controllers.remove(customer_id).remove_keys(cooks_and_waiter_ids.values()).contains_key(good_citizen_id));
+    }
+
+    assert forall |p_index| #![trigger cooks_and_waiter[p_index]] 0 <= p_index < cooks_and_waiter.len()
+    implies
+        (forall |good_citizen_id| cluster.controllers.remove(customer_id).remove_keys(cooks_and_waiter_ids.values()).contains_key(good_citizen_id)
+            ==> spec.entails(always(lift_state(#[trigger] (cooks_and_waiter[p_index].not_interfered_by)(good_citizen_id)))))
+    by {
+        assert forall |good_citizen_id|
+            cluster.controllers.remove(customer_id).remove_keys(cooks_and_waiter_ids.values()).contains_key(good_citizen_id)
+        implies
+            #[trigger] spec.entails(always(lift_state(#[trigger] (cooks_and_waiter[p_index].not_interfered_by)(good_citizen_id))))
+        by {
+            assert forall |controller_id| #[trigger] cluster.controllers.contains_key(controller_id)
+            implies controller_id == customer_id || cooks_and_waiter_ids.values().contains(controller_id) by {
+                if controller_id == cook_controllers::<S, I>().len() as int + 1 {
+                    assert(controller_id == customer_id);
+                } else {
+                    assert(cooks_and_waiter_ids.dom().contains(controller_id) && cooks_and_waiter_ids[controller_id] == controller_id);
+                }
+            }
+            assert(!cluster.controllers.remove(customer_id).remove_keys(cooks_and_waiter_ids.values()).contains_key(good_citizen_id));
+        }
+    }
+
+    compose_consumer_incrementally::<S, I, IncrementalCompositionProof<S, I>>(spec, cluster, customer::<S, I>(), cooks_and_waiter, customer_id, cooks_and_waiter_ids);
+}
+
+pub spec fn cook_property<S>(i: int) -> TempPred<S>;
+pub spec fn waiter_property<S>() -> TempPred<S>;
+pub spec fn customer_property<S>() -> TempPred<S>;
+
+pub spec fn cook_not_interfered_by<S>(i: int) -> spec_fn(good_citizen_id: int) -> StatePred<S>;
+pub spec fn waiter_not_interfered_by<S>() -> spec_fn(good_citizen_id: int) -> StatePred<S>;
+pub spec fn customer_not_interfered_by<S>() -> spec_fn(good_citizen_id: int) -> StatePred<S>;
 
 }

--- a/src/soundness/compositionality/proof.rs
+++ b/src/soundness/compositionality/proof.rs
@@ -9,10 +9,8 @@ verus! {
 
 #[verifier::reject_recursive_types(S)]
 #[verifier::reject_recursive_types(I)]
-pub struct ControllerSpecGroup<S, I> {
+pub struct ControllerPredGroup<S, I> {
     pub controller: Controller<S, I>,
-    // The key should be the one that points to controller in the cluster's controllers map
-    pub key: int,
     // The top level property of the input controller (e.g., ESR)
     pub property: TempPred<S>,
     // The inv asserts that the controller indexed by good_citizen_id does not interfere with the input controller's reconcile
@@ -29,13 +27,69 @@ pub struct ControllerSpecGroup<S, I> {
     pub not_interfered_by: spec_fn(good_citizen_id: int) -> StatePred<S>,
 }
 
-// This is our top-level theorem: the consumer and producers are correct in any cluster
-// if the other controllers in that cluster do not interfere with the consumer or producers.
-pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecGroup<S, I>, producers: Seq<ControllerSpecGroup<S, I>>)
+proof fn compose_producers<S, I, BC>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerPredGroup<S, I>>, producer_ids: Map<int, int>)
+    where
+        BC: BaseComposition<S, I>,
     requires
+        BC::producers() == producers,
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
-        // The cluster starts with the initial state of the consumer.
+        // The cluster starts with the initial state of the producer.
+        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> forall |s| #[trigger] cluster.init()(s) ==> producers[p_index].controller.init()(s),
+        // The fairness condition is enough to say that each producer runs as part of the cluster's next transition.
+        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> spec.entails(controller_fairness::<S, I>(producers[p_index].controller)),
+        // A key exists in producer_ids iff it's within the range of producers,
+        // which guarantees that producer_ids covers and only covers all the producers.
+        forall |key| #[trigger] producer_ids.contains_key(key) <==> 0 <= key < producers.len(),
+        // Each element in producer_ids points to each producer respectively.
+        forall |key| producer_ids.contains_key(key)
+            ==> cluster.controllers.contains_pair(#[trigger] producer_ids[key], producers[key].controller),
+        // For each producer, no other controllers interfere with that producer.
+        forall |p_index: int| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> forall |good_citizen_id| cluster.controllers.remove_keys(producer_ids.values()).contains_key(good_citizen_id)
+                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))),
+    ensures
+        // Each producer is correct.
+        forall |p_index| 0 <= p_index < producers.len()
+            ==> #[trigger] spec.entails(producers[p_index].property),
+        // // For each producer, no one interferes with that producer (except that producer itself).
+        // forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+        //     ==> forall |good_citizen_id| cluster.controllers.remove(producer_ids[p_index]).contains_key(good_citizen_id)
+        //         ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))),
+{
+    assert forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+    implies (forall |good_citizen_id| #[trigger] cluster.controllers.remove(producer_ids[p_index]).contains_key(good_citizen_id)
+        ==> spec.entails(always(lift_state((producers[p_index].not_interfered_by)(good_citizen_id)))))
+    by {
+        assert forall |good_citizen_id| cluster.controllers.remove(producer_ids[p_index]).contains_key(good_citizen_id)
+        implies spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))) by {
+            if producer_ids.values().contains(good_citizen_id) {
+                let j = choose |j| producer_ids.dom().contains(j) && #[trigger] producer_ids[j] == good_citizen_id;
+                BC::producer_does_not_interfere_with_the_producer(spec, cluster, good_citizen_id, j, p_index);
+            } else {
+                assert(spec.entails(always(lift_state((producers[p_index].not_interfered_by)(good_citizen_id)))));
+            }
+        }
+    }
+
+    assert forall |p_index| 0 <= p_index < producers.len() implies #[trigger] spec.entails(producers[p_index].property) by {
+        assert(producer_ids.contains_key(p_index));
+        let producer_id = producer_ids[p_index];
+        BC::producer_is_correct(spec, cluster, producer_id, p_index);
+    }
+}
+
+pub proof fn compose_producers_and_consumer<S, I, BC>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerPredGroup<S, I>, producers: Seq<ControllerPredGroup<S, I>>, consumer_id: int, producer_ids: Map<int, int>)
+    where
+        BC: BaseComposition<S, I>
+    requires
+        BC::producers() == producers,
+        BC::consumer() == consumer,
+        spec.entails(lift_state(cluster.init())),
+        spec.entails(always(lift_action(cluster.next()))),
+        // The cluster starts with the initial state of the consumer().
         forall |s| #[trigger] cluster.init()(s) ==> consumer.controller.init()(s),
         // The cluster starts with the initial state of the producer.
         forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
@@ -45,153 +99,255 @@ pub proof fn consumer_and_producers_are_correct<S, I>(spec: TempPred<S>, cluster
         // The fairness condition is enough to say that each producer runs as part of the cluster's next transition.
         forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
             ==> spec.entails(controller_fairness::<S, I>(producers[p_index].controller)),
-        // The consumer.key points to the consumer.controller.
-        cluster.controllers.contains_pair(consumer.key, consumer.controller),
-        // Each producers[p_index].key points to producers[p_index].controller.
-        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
-            ==> cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
-        // No other controllers interfere with the consumer.
-        forall |good_citizen_id| cluster.controllers.remove(consumer.key).remove_keys(producers.map_values(|p: ControllerSpecGroup<S, I>| p.key).to_set()).contains_key(good_citizen_id)
+        // The consumer().key points to the consumer().controller.
+        cluster.controllers.contains_pair(consumer_id, consumer.controller),
+        // A key exists in producer_ids iff it's within the range of producers,
+        // which guarantees that producer_ids covers and only covers all the producers.
+        forall |key| #[trigger] producer_ids.contains_key(key) <==> 0 <= key < producers.len(),
+        // Each element in producer_ids points to each producer respectively.
+        forall |key| producer_ids.contains_key(key)
+            ==> cluster.controllers.contains_pair(#[trigger] producer_ids[key], producers[key].controller),
+        // No other controllers interfere with the consumer().
+        forall |good_citizen_id| cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id)
             ==> spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))),
         // For each producer, no other controllers interfere with that producer.
         forall |p_index: int| #![trigger producers[p_index]] 0 <= p_index < producers.len()
-            ==> forall |good_citizen_id| cluster.controllers.remove(consumer.key).remove_keys(producers.map_values(|p: ControllerSpecGroup<S, I>| p.key).to_set()).contains_key(good_citizen_id)
-                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id))))
+            ==> forall |good_citizen_id| cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id)
+                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))),
     ensures
         // Consumer is correct.
         spec.entails(consumer.property),
         // Each producer is correct.
         forall |p_index| 0 <= p_index < producers.len()
             ==> #[trigger] spec.entails(producers[p_index].property),
-        // No one interferes with the consumer (except the consumer itself).
-        forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))),
-        // For each producer, no one interferes with that producer (except that producer itself).
-        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
-            ==> forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
-                ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))),
+        // // No one interferes with the consumer (except the consumer itself).
+        // forall |good_citizen_id| cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
+        //     ==> spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))),
+        // // For each producer, no one interferes with that producer (except that producer itself).
+        // forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+        //     ==> forall |good_citizen_id| cluster.controllers.remove(producer_ids[p_index]).contains_key(good_citizen_id)
+        //         ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))),
 {
     assert forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
-    implies (forall |good_citizen_id| #[trigger] cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
-        ==> spec.entails(always(lift_state((producers[p_index].not_interfered_by)(good_citizen_id)))))
+    implies (forall |good_citizen_id| cluster.controllers.remove_keys(producer_ids.values()).contains_key(good_citizen_id)
+        ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))))
     by {
-        assert forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
+        assert forall |good_citizen_id| cluster.controllers.remove_keys(producer_ids.values()).contains_key(good_citizen_id)
         implies spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))) by {
-            if good_citizen_id == consumer.key {
-                consumer_does_not_interfere_with_the_producer(spec, cluster, consumer, producers, p_index);
-            } else if producers.map_values(|p: ControllerSpecGroup<S, I>| p.key).to_set().contains(good_citizen_id) {
-                let j = choose |j| 0 <= j < producers.len() && #[trigger] producers[j].key == good_citizen_id;
-                producer_does_not_interfere_with_the_producer(spec, cluster, producers, j, p_index);
-            } else {
-                assert(spec.entails(always(lift_state((producers[p_index].not_interfered_by)(good_citizen_id)))));
-            }
+            if good_citizen_id == consumer_id {
+                BC::consumer_does_not_interfere_with_the_producer(spec, cluster, good_citizen_id, p_index);
+            } else { }
         }
     }
 
-    assert forall |p_index| 0 <= p_index < producers.len() implies #[trigger] spec.entails(producers[p_index].property) by {
-        producer_is_correct(spec, cluster, producers, p_index);
-    }
+    compose_producers::<S, I, BC>(spec, cluster, producers, producer_ids);
 
-    assert forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
+    assert forall |good_citizen_id| cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
     implies spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))) by {
-        if producers.map_values(|p: ControllerSpecGroup<S, I>| p.key).to_set().contains(good_citizen_id) {
-            let j = choose |j| 0 <= j < producers.len() && #[trigger] producers[j].key == good_citizen_id;
-            producer_does_not_interfere_with_the_consumer(spec, cluster, consumer, producers, j);
+        if producer_ids.values().contains(good_citizen_id) {
+            let j = choose |j| producer_ids.dom().contains(j) && #[trigger] producer_ids[j] == good_citizen_id;
+            BC::producer_does_not_interfere_with_the_consumer(spec, cluster, good_citizen_id, j);
         } else {
             assert(spec.entails(always(lift_state((consumer.not_interfered_by)(good_citizen_id)))));
         }
     }
-    consumer_is_correct(spec, cluster, consumer, producers);
+    BC::consumer_is_correct(spec, cluster, consumer_id);
 }
 
-// To prove consumer_and_producers_are_correct, there are five proof obligations.
-
-// Proof obligation 1:
-// Producer is correct when running in any cluster where there is no interference.
-#[verifier(external_body)]
-proof fn producer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerSpecGroup<S, I>>, p_index: int)
+pub proof fn compose_consumer_incrementally<S, I, IC>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerPredGroup<S, I>, producers: Seq<ControllerPredGroup<S, I>>, consumer_id: int, producer_ids: Map<int, int>)
+    where
+        IC: IncrementalComposition<S, I>,
     requires
-        0 <= p_index < producers.len(),
+        IC::producers() == producers,
+        IC::consumer() == consumer,
         spec.entails(lift_state(cluster.init())),
         spec.entails(always(lift_action(cluster.next()))),
+        // The cluster starts with the initial state of the consumer().
+        forall |s| #[trigger] cluster.init()(s) ==> consumer.controller.init()(s),
         // The cluster starts with the initial state of the producer.
-        forall |s| cluster.init()(s) ==> #[trigger] producers[p_index].controller.init()(s),
-        // The fairness condition is enough to say that the producer runs as part of the cluster's next transition.
-        spec.entails(controller_fairness::<S, I>(producers[p_index].controller)),
-        // The next two preconditions say that no controller (except the producer itself) interferes with this producer.
-        cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
-        forall |good_citizen_id| cluster.controllers.remove(producers[p_index].key).contains_key(good_citizen_id)
-            ==> spec.entails(always(lift_state(#[trigger] (producers[p_index].not_interfered_by)(good_citizen_id)))),
-    ensures
-        spec.entails(producers[p_index].property),
-{}
-
-// Proof obligation 2:
-// Consumer is correct when running in any cluster where each producer's spec is available and there is no interference.
-#[verifier(external_body)]
-proof fn consumer_is_correct<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecGroup<S, I>, producers: Seq<ControllerSpecGroup<S, I>>)
-    requires
-        spec.entails(lift_state(cluster.init())),
-        spec.entails(always(lift_action(cluster.next()))),
-        // The cluster starts with the initial state of the consumer.
-        forall |s| cluster.init()(s) ==> #[trigger] consumer.controller.init()(s),
+        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> forall |s| #[trigger] cluster.init()(s) ==> producers[p_index].controller.init()(s),
         // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
         spec.entails(controller_fairness::<S, I>(consumer.controller)),
-        // The next two preconditions say that no controller (except the consumer itself) interferes with this consumer.
-        cluster.controllers.contains_pair(consumer.key, consumer.controller),
-        forall |good_citizen_id| cluster.controllers.remove(consumer.key).contains_key(good_citizen_id)
+        // The fairness condition is enough to say that each producer runs as part of the cluster's next transition.
+        forall |p_index| #![trigger producers[p_index]] 0 <= p_index < producers.len()
+            ==> spec.entails(controller_fairness::<S, I>(producers[p_index].controller)),
+        // The consumer().key points to the consumer().controller.
+        cluster.controllers.contains_pair(consumer_id, consumer.controller),
+        // A key exists in producer_ids iff it's within the range of producers,
+        // which guarantees that producer_ids covers and only covers all the producers.
+        forall |key| #[trigger] producer_ids.contains_key(key) <==> 0 <= key < producers.len(),
+        // Each element in producer_ids points to each producer respectively.
+        forall |key| producer_ids.contains_key(key)
+            ==> cluster.controllers.contains_pair(#[trigger] producer_ids[key], producers[key].controller),
+        // No other controllers interfere with the consumer().
+        forall |good_citizen_id| cluster.controllers.remove(consumer_id).remove_keys(producer_ids.values()).contains_key(good_citizen_id)
             ==> spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))),
-        // We directly use the temporal property of the producers.
-        forall |p_index: int| 0 <= p_index < producers.len()
+        // Each producer is correct.
+        forall |p_index| 0 <= p_index < producers.len()
             ==> #[trigger] spec.entails(producers[p_index].property),
     ensures
+        // Consumer is correct.
         spec.entails(consumer.property),
-{}
+        // // No one interferes with the consumer (except the consumer itself).
+        // forall |good_citizen_id| cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
+        //     ==> spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))),
+{
+    assert forall |good_citizen_id| cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
+    implies spec.entails(always(lift_state(#[trigger] (consumer.not_interfered_by)(good_citizen_id)))) by {
+        if producer_ids.values().contains(good_citizen_id) {
+            let j = choose |j| producer_ids.dom().contains(j) && #[trigger] producer_ids[j] == good_citizen_id;
+            IC::producer_does_not_interfere_with_the_consumer(spec, cluster, good_citizen_id, j);
+        } else {
+            assert(spec.entails(always(lift_state((consumer.not_interfered_by)(good_citizen_id)))));
+        }
+    }
+    IC::consumer_is_correct(spec, cluster, consumer_id);
+}
 
-// Proof obligation 3:
-// Consumer does not interfere with the producer in any cluster.
-#[verifier(external_body)]
-proof fn consumer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecGroup<S, I>, producers: Seq<ControllerSpecGroup<S, I>>, p_index: int)
-    requires
-        0 <= p_index < producers.len(),
-        spec.entails(lift_state(cluster.init())),
-        spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers.contains_pair(consumer.key, consumer.controller),
-    ensures
-        // The consumer never interferes with the producer.
-        spec.entails(always(lift_state((producers[p_index].not_interfered_by)(consumer.key)))),
-{}
+pub trait BaseComposition<S, I>: Sized {
 
-// Proof obligation 4:
-// Producer does not interfere with another producer in any cluster.
-#[verifier(external_body)]
-proof fn producer_does_not_interfere_with_the_producer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, producers: Seq<ControllerSpecGroup<S, I>>, p_index: int, q_index: int)
-    requires
-        0 <= p_index < producers.len(),
-        0 <= q_index < producers.len(),
-        // We require the two producers to be different because there is no point to prove
-        // a producer does not interfere with another instance of itself.
-        p_index != q_index,
-        spec.entails(lift_state(cluster.init())),
-        spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
-    ensures
-        // The producer (p_index) never interferes with the other producer (q_index).
-        spec.entails(always(lift_state((producers[q_index].not_interfered_by)(producers[p_index].key)))),
-{}
+    spec fn consumer() -> ControllerPredGroup<S, I>;
 
-// Proof obligation 5:
-// Producer does not interfere with the consumer in any cluster.
-#[verifier(external_body)]
-proof fn producer_does_not_interfere_with_the_consumer<S, I>(spec: TempPred<S>, cluster: Cluster<S, I>, consumer: ControllerSpecGroup<S, I>, producers: Seq<ControllerSpecGroup<S, I>>, p_index: int)
-    requires
-        0 <= p_index < producers.len(),
-        spec.entails(lift_state(cluster.init())),
-        spec.entails(always(lift_action(cluster.next()))),
-        cluster.controllers.contains_pair(producers[p_index].key, producers[p_index].controller),
-    ensures
-        // The producer never interferes with the consumer.
-        spec.entails(always(lift_state((consumer.not_interfered_by)(producers[p_index].key)))),
-{}
+    spec fn producers() -> Seq<ControllerPredGroup<S, I>>;
+
+    // Proof obligation 1:
+    // Consumer is correct when running in any cluster where each producer's spec is available and there is no interference.
+    proof fn consumer_is_correct(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int)
+        requires
+            spec.entails(lift_state(cluster.init())),
+            spec.entails(always(lift_action(cluster.next()))),
+            // The cluster starts with the initial state of the consumer().
+            forall |s| cluster.init()(s) ==> #[trigger] Self::consumer().controller.init()(s),
+            // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
+            spec.entails(controller_fairness::<S, I>(Self::consumer().controller)),
+            // The next two preconditions say that no controller (except the consumer itself) interferes with this consumer().
+            cluster.controllers.contains_pair(consumer_id, Self::consumer().controller),
+            forall |good_citizen_id| cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
+                ==> spec.entails(always(lift_state(#[trigger] (Self::consumer().not_interfered_by)(good_citizen_id)))),
+            // We directly use the temporal property of the producers().
+            forall |p_index: int| 0 <= p_index < Self::producers().len()
+                ==> #[trigger] spec.entails(Self::producers()[p_index].property),
+        ensures
+            spec.entails(Self::consumer().property),
+        ;
+
+    // Proof obligation 2:
+    // Producer is correct when running in any cluster where there is no interference.
+    proof fn producer_is_correct(spec: TempPred<S>, cluster: Cluster<S, I>, producer_id: int, p_index: int)
+        requires
+            0 <= p_index < Self::producers().len(),
+            spec.entails(lift_state(cluster.init())),
+            spec.entails(always(lift_action(cluster.next()))),
+            // The cluster starts with the initial state of the producer.
+            forall |s| cluster.init()(s) ==> #[trigger] Self::producers()[p_index].controller.init()(s),
+            // The fairness condition is enough to say that the producer runs as part of the cluster's next transition.
+            spec.entails(controller_fairness::<S, I>(Self::producers()[p_index].controller)),
+            // The next two preconditions say that no controller (except the producer itself) interferes with this producer.
+            cluster.controllers.contains_pair(producer_id, Self::producers()[p_index].controller),
+            forall |good_citizen_id| cluster.controllers.remove(producer_id).contains_key(good_citizen_id)
+                ==> spec.entails(always(lift_state(#[trigger] (Self::producers()[p_index].not_interfered_by)(good_citizen_id)))),
+        ensures
+            spec.entails(Self::producers()[p_index].property),
+        ;
+
+    // Proof obligation 3:
+    // Consumer does not interfere with the producer in any cluster.
+    proof fn consumer_does_not_interfere_with_the_producer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
+        requires
+            0 <= p_index < Self::producers().len(),
+            spec.entails(lift_state(cluster.init())),
+            spec.entails(always(lift_action(cluster.next()))),
+            cluster.controllers.contains_pair(good_citizen_id, Self::consumer().controller),
+        ensures
+            // The consumer never interferes with the producer.
+            spec.entails(always(lift_state((Self::producers()[p_index].not_interfered_by)(good_citizen_id)))),
+        ;
+
+    // Proof obligation 4:
+    // Producer does not interfere with the consumer in any cluster.
+    proof fn producer_does_not_interfere_with_the_consumer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
+        requires
+            0 <= p_index < Self::producers().len(),
+            spec.entails(lift_state(cluster.init())),
+            spec.entails(always(lift_action(cluster.next()))),
+            cluster.controllers.contains_pair(good_citizen_id, Self::producers()[p_index].controller),
+        ensures
+            // The producer never interferes with the consumer().
+            spec.entails(always(lift_state((Self::consumer().not_interfered_by)(good_citizen_id)))),
+        ;
+
+    // Proof obligation 5:
+    // Producer does not interfere with another producer in any cluster.
+    proof fn producer_does_not_interfere_with_the_producer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int, q_index: int)
+        requires
+            0 <= p_index < Self::producers().len(),
+            0 <= q_index < Self::producers().len(),
+            // We require the two producers to be different because there is no point to prove
+            // a producer does not interfere with another instance of itself.
+            p_index != q_index,
+            spec.entails(lift_state(cluster.init())),
+            spec.entails(always(lift_action(cluster.next()))),
+            cluster.controllers.contains_pair(good_citizen_id, Self::producers()[p_index].controller),
+        ensures
+            // The producer (p_index) never interferes with the other producer (q_index).
+            spec.entails(always(lift_state((Self::producers()[q_index].not_interfered_by)(good_citizen_id)))),
+        ;
+}
+
+pub trait IncrementalComposition<S, I>: Sized {
+
+    spec fn consumer() -> ControllerPredGroup<S, I>;
+
+    spec fn producers() -> Seq<ControllerPredGroup<S, I>>;
+
+    // Proof obligation 1:
+    // Consumer is correct when running in any cluster where each producer's spec is available and there is no interference.
+    proof fn consumer_is_correct(spec: TempPred<S>, cluster: Cluster<S, I>, consumer_id: int)
+        requires
+            spec.entails(lift_state(cluster.init())),
+            spec.entails(always(lift_action(cluster.next()))),
+            // The cluster starts with the initial state of the consumer().
+            forall |s| cluster.init()(s) ==> #[trigger] Self::consumer().controller.init()(s),
+            // The fairness condition is enough to say that the consumer runs as part of the cluster's next transition.
+            spec.entails(controller_fairness::<S, I>(Self::consumer().controller)),
+            // The next two preconditions say that no controller (except the consumer itself) interferes with this consumer().
+            cluster.controllers.contains_pair(consumer_id, Self::consumer().controller),
+            forall |good_citizen_id| cluster.controllers.remove(consumer_id).contains_key(good_citizen_id)
+                ==> spec.entails(always(lift_state(#[trigger] (Self::consumer().not_interfered_by)(good_citizen_id)))),
+            // We directly use the temporal property of the producers().
+            forall |p_index: int| 0 <= p_index < Self::producers().len()
+                ==> #[trigger] spec.entails(Self::producers()[p_index].property),
+        ensures
+            spec.entails(Self::consumer().property),
+        ;
+
+    // Proof obligation 2:
+    // Consumer does not interfere with the producer in any cluster.
+    proof fn consumer_does_not_interfere_with_the_producer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
+        requires
+            0 <= p_index < Self::producers().len(),
+            spec.entails(lift_state(cluster.init())),
+            spec.entails(always(lift_action(cluster.next()))),
+            cluster.controllers.contains_pair(good_citizen_id, Self::consumer().controller),
+        ensures
+            // The consumer never interferes with the producer.
+            spec.entails(always(lift_state((Self::producers()[p_index].not_interfered_by)(good_citizen_id)))),
+        ;
+
+    // Proof obligation 3:
+    // Producer does not interfere with the consumer in any cluster.
+    proof fn producer_does_not_interfere_with_the_consumer(spec: TempPred<S>, cluster: Cluster<S, I>, good_citizen_id: int, p_index: int)
+        requires
+            0 <= p_index < Self::producers().len(),
+            spec.entails(lift_state(cluster.init())),
+            spec.entails(always(lift_action(cluster.next()))),
+            cluster.controllers.contains_pair(good_citizen_id, Self::producers()[p_index].controller),
+        ensures
+            // The producer never interferes with the consumer().
+            spec.entails(always(lift_state((Self::consumer().not_interfered_by)(good_citizen_id)))),
+        ;
+}
+
 
 }


### PR DESCRIPTION
This PR introduces a way for developers to compose controllers incrementally when proving the correctness of a cluster of controllers. By "incrementally", we mean that if we already have a proof `P` for the correctness of a controller `foo` and its producers, we can develop another proof for the correctness of controller `bar` that relies on `foo` and its producers on top of `P` by focusing on reasoning about `bar`.

More concretely, this PR introduces:
- `BaseComposition`: a trait with five proof functions (as trait methods) as the proof obligations to compose a consumer and a sequence of producers.
- `IncrementalComposition`: a trait with three proof functions as the proof obligations to incrementally compose a consumer with a sequence of producers (that have already been proved correct).
- Two examples of how to use `BaseComposition` and `IncrementalComposition`.