### PR TITLE
Differentiate between different custom resource types

### DIFF
--- a/src/conformance_tests/api_server.rs
+++ b/src/conformance_tests/api_server.rs
@@ -18,41 +18,43 @@ use vstd::string::*;
 #[derive(Debug, Clone)]
 enum GeneratedRequest {
     Get {
-        kind: Kind,
+        kind: KindExec,
         name: std::string::String,
     },
     Create {
-        kind: Kind,
+        kind: KindExec,
         name: std::string::String,
     },
 }
 
-impl Kind {
+impl KindExec {
     fn to_api_resource(&self) -> ApiResource {
         match self {
-            Kind::ConfigMapKind => {
+            KindExec::ConfigMapKind => {
                 ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<
                     deps_hack::k8s_openapi::api::core::v1::ConfigMap,
                 >(&()))
             }
-            Kind::SecretKind => ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<
-                deps_hack::k8s_openapi::api::core::v1::Secret,
-            >(&())),
+            KindExec::SecretKind => {
+                ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<
+                    deps_hack::k8s_openapi::api::core::v1::Secret,
+                >(&()))
+            }
             _ => panic!(),
         }
     }
 
     fn to_default_dynamic_object(&self) -> DynamicObject {
         match self {
-            Kind::ConfigMapKind => ConfigMap::default().marshal(),
-            Kind::SecretKind => Secret::default().marshal(),
+            KindExec::ConfigMapKind => ConfigMap::default().marshal(),
+            KindExec::SecretKind => Secret::default().marshal(),
             _ => panic!(),
         }
     }
 }
 
-fn kind_strategy() -> BoxedStrategy<Kind> {
-    prop_oneof![Just(Kind::ConfigMapKind), Just(Kind::SecretKind),].boxed()
+fn kind_strategy() -> BoxedStrategy<KindExec> {
+    prop_oneof![Just(KindExec::ConfigMapKind), Just(KindExec::SecretKind),].boxed()
 }
 
 prop_compose! {

--- a/src/controller_examples/fluent_controller/fluentbit/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/proof/helper_invariants/predicate.rs
@@ -41,6 +41,7 @@ pub open spec fn the_object_in_schedule_satisfies_state_validation() -> StatePre
         forall |key: ObjectRef|
         #[trigger] s.scheduled_reconciles().contains_key(key)
         && key.kind.is_CustomResourceKind()
+        && key.kind == FluentBitView::kind()
         ==> s.scheduled_reconciles()[key].state_validation()
     }
 }
@@ -51,6 +52,7 @@ pub open spec fn cr_objects_in_etcd_satisfy_state_validation() -> StatePred<FBCl
         forall |key: ObjectRef|
         #[trigger] s.resources().contains_key(key)
         && key.kind.is_CustomResourceKind()
+        && key.kind == FluentBitView::kind()
         ==> FluentBitView::unmarshal(s.resources()[key]).is_Ok()
             && FluentBitView::unmarshal(s.resources()[key]).get_Ok_0().state_validation()
     }

--- a/src/controller_examples/fluent_controller/fluentbit/trusted/spec_types.rs
+++ b/src/controller_examples/fluent_controller/fluentbit/trusted/spec_types.rs
@@ -66,7 +66,7 @@ impl ResourceView for FluentBitView {
 
     open spec fn metadata(self) -> ObjectMetaView { self.metadata }
 
-    open spec fn kind() -> Kind { Kind::CustomResourceKind }
+    open spec fn kind() -> Kind { Kind::CustomResourceKind("fluentbit"@) }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {

--- a/src/controller_examples/fluent_controller/fluentbit_config/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/proof/helper_invariants/predicate.rs
@@ -41,6 +41,7 @@ pub open spec fn the_object_in_schedule_satisfies_state_validation() -> StatePre
         forall |key: ObjectRef|
         #[trigger] s.scheduled_reconciles().contains_key(key)
         && key.kind.is_CustomResourceKind()
+        && key.kind == FluentBitConfigView::kind()
         ==> s.scheduled_reconciles()[key].state_validation()
     }
 }
@@ -51,6 +52,7 @@ pub open spec fn cr_objects_in_etcd_satisfy_state_validation() -> StatePred<FBCC
         forall |key: ObjectRef|
         #[trigger] s.resources().contains_key(key)
         && key.kind.is_CustomResourceKind()
+        && key.kind == FluentBitConfigView::kind()
         ==> FluentBitConfigView::unmarshal(s.resources()[key]).is_Ok()
             && FluentBitConfigView::unmarshal(s.resources()[key]).get_Ok_0().state_validation()
     }

--- a/src/controller_examples/fluent_controller/fluentbit_config/trusted/spec_types.rs
+++ b/src/controller_examples/fluent_controller/fluentbit_config/trusted/spec_types.rs
@@ -65,7 +65,7 @@ impl ResourceView for FluentBitConfigView {
 
     open spec fn metadata(self) -> ObjectMetaView { self.metadata }
 
-    open spec fn kind() -> Kind { Kind::CustomResourceKind }
+    open spec fn kind() -> Kind { Kind::CustomResourceKind("fluentbitconfig"@) }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {

--- a/src/controller_examples/rabbitmq_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/rabbitmq_controller/proof/helper_invariants/predicate.rs
@@ -42,6 +42,7 @@ pub open spec fn the_object_in_schedule_satisfies_state_validation() -> StatePre
         forall |key: ObjectRef|
         #[trigger] s.scheduled_reconciles().contains_key(key)
         && key.kind.is_CustomResourceKind()
+        && key.kind == RabbitmqClusterView::kind()
         ==> s.scheduled_reconciles()[key].state_validation()
     }
 }
@@ -52,6 +53,7 @@ pub open spec fn cr_objects_in_etcd_satisfy_state_validation() -> StatePred<RMQC
         forall |key: ObjectRef|
         #[trigger] s.resources().contains_key(key)
         && key.kind.is_CustomResourceKind()
+        && key.kind == RabbitmqClusterView::kind()
         ==> RabbitmqClusterView::unmarshal(s.resources()[key]).is_Ok()
             && RabbitmqClusterView::unmarshal(s.resources()[key]).get_Ok_0().state_validation()
     }

--- a/src/controller_examples/rabbitmq_controller/trusted/spec_types.rs
+++ b/src/controller_examples/rabbitmq_controller/trusted/spec_types.rs
@@ -66,7 +66,7 @@ impl ResourceView for RabbitmqClusterView {
 
     open spec fn metadata(self) -> ObjectMetaView { self.metadata }
 
-    open spec fn kind() -> Kind { Kind::CustomResourceKind }
+    open spec fn kind() -> Kind { Kind::CustomResourceKind("rabbitmq"@) }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {

--- a/src/controller_examples/v_replica_set_controller/trusted/spec_types.rs
+++ b/src/controller_examples/v_replica_set_controller/trusted/spec_types.rs
@@ -69,7 +69,7 @@ impl ResourceView for VReplicaSetView {
 
     open spec fn metadata(self) -> ObjectMetaView { self.metadata }
 
-    open spec fn kind() -> Kind { Kind::CustomResourceKind }
+    open spec fn kind() -> Kind { Kind::CustomResourceKind("vreplicaset") }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {

--- a/src/controller_examples/v_replica_set_controller/trusted/spec_types.rs
+++ b/src/controller_examples/v_replica_set_controller/trusted/spec_types.rs
@@ -69,7 +69,7 @@ impl ResourceView for VReplicaSetView {
 
     open spec fn metadata(self) -> ObjectMetaView { self.metadata }
 
-    open spec fn kind() -> Kind { Kind::CustomResourceKind("vreplicaset") }
+    open spec fn kind() -> Kind { Kind::CustomResourceKind("vreplicaset"@) }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {

--- a/src/controller_examples/zookeeper_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/zookeeper_controller/proof/helper_invariants/predicate.rs
@@ -42,6 +42,7 @@ pub open spec fn the_object_in_schedule_satisfies_state_validation() -> StatePre
         forall |key: ObjectRef|
         #[trigger] s.scheduled_reconciles().contains_key(key)
         && key.kind.is_CustomResourceKind()
+        && key.kind == ZookeeperClusterView::kind()
         ==> s.scheduled_reconciles()[key].state_validation()
     }
 }
@@ -52,6 +53,7 @@ pub open spec fn cr_objects_in_etcd_satisfy_state_validation() -> StatePred<ZKCl
         forall |key: ObjectRef|
         #[trigger] s.resources().contains_key(key)
         && key.kind.is_CustomResourceKind()
+        && key.kind == ZookeeperClusterView::kind()
         ==> ZookeeperClusterView::unmarshal(s.resources()[key]).is_Ok()
             && ZookeeperClusterView::unmarshal(s.resources()[key]).get_Ok_0().state_validation()
     }

--- a/src/controller_examples/zookeeper_controller/trusted/spec_types.rs
+++ b/src/controller_examples/zookeeper_controller/trusted/spec_types.rs
@@ -70,7 +70,7 @@ impl ResourceView for ZookeeperClusterView {
 
     open spec fn metadata(self) -> ObjectMetaView { self.metadata }
 
-    open spec fn kind() -> Kind { Kind::CustomResourceKind }
+    open spec fn kind() -> Kind { Kind::CustomResourceKind("zookeeper"@) }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {

--- a/src/executable_model/api_server.rs
+++ b/src/executable_model/api_server.rs
@@ -63,21 +63,23 @@ fn metadata_transition_validity_check(obj: &DynamicObject, old_obj: &DynamicObje
 }
 
 fn valid_object(obj: &DynamicObject) -> (ret: bool)
-    requires model::unmarshallable_object::<K::V>(obj@)
+    requires
+        model::unmarshallable_object::<K::V>(obj@),
+        obj@.kind.is_CustomResourceKind() ==> obj@.kind == K::V::kind(),
     ensures ret == model::valid_object::<K::V>(obj@)
 {
     match obj.kind() {
-        Kind::ConfigMapKind => ConfigMap::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::DaemonSetKind => DaemonSet::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::PersistentVolumeClaimKind => PersistentVolumeClaim::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::PodKind => Pod::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::RoleBindingKind => RoleBinding::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::RoleKind => Role::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::SecretKind => Secret::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::ServiceKind => Service::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::StatefulSetKind => StatefulSet::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::ServiceAccountKind => ServiceAccount::unmarshal(obj.clone()).unwrap().state_validation(),
-        Kind::CustomResourceKind => {
+        KindExec::ConfigMapKind => ConfigMap::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::DaemonSetKind => DaemonSet::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::PersistentVolumeClaimKind => PersistentVolumeClaim::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::PodKind => Pod::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::RoleBindingKind => RoleBinding::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::RoleKind => Role::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::SecretKind => Secret::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::ServiceKind => Service::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::StatefulSetKind => StatefulSet::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::ServiceAccountKind => ServiceAccount::unmarshal(obj.clone()).unwrap().state_validation(),
+        KindExec::CustomResourceKind(_) => {
             proof {
                 K::V::unmarshal_result_determined_by_unmarshal_spec_and_status();
                 K::V::kind_is_custom_resource();
@@ -88,7 +90,9 @@ fn valid_object(obj: &DynamicObject) -> (ret: bool)
 }
 
 fn object_validity_check(obj: &DynamicObject) -> (ret: Option<APIError>)
-    requires model::unmarshallable_object::<K::V>(obj@)
+    requires
+        model::unmarshallable_object::<K::V>(obj@),
+        obj@.kind.is_CustomResourceKind() ==> obj@.kind == K::V::kind(),
     ensures ret == model::object_validity_check::<K::V>(obj@)
 {
     if !Self::valid_object(obj) {
@@ -105,20 +109,21 @@ fn valid_transition(obj: &DynamicObject, old_obj: &DynamicObject) -> (ret: bool)
         old_obj@.kind == obj@.kind,
         model::valid_object::<K::V>(obj@),
         model::valid_object::<K::V>(old_obj@),
+        obj@.kind.is_CustomResourceKind() ==> obj@.kind == K::V::kind(),
     ensures ret == model::valid_transition::<K::V>(obj@, old_obj@)
 {
     match obj.kind() {
-        Kind::ConfigMapKind => ConfigMap::unmarshal(obj.clone()).unwrap().transition_validation(&ConfigMap::unmarshal(old_obj.clone()).unwrap()),
-        Kind::DaemonSetKind => DaemonSet::unmarshal(obj.clone()).unwrap().transition_validation(&DaemonSet::unmarshal(old_obj.clone()).unwrap()),
-        Kind::PersistentVolumeClaimKind => PersistentVolumeClaim::unmarshal(obj.clone()).unwrap().transition_validation(&PersistentVolumeClaim::unmarshal(old_obj.clone()).unwrap()),
-        Kind::PodKind => Pod::unmarshal(obj.clone()).unwrap().transition_validation(&Pod::unmarshal(old_obj.clone()).unwrap()),
-        Kind::RoleBindingKind => RoleBinding::unmarshal(obj.clone()).unwrap().transition_validation(&RoleBinding::unmarshal(old_obj.clone()).unwrap()),
-        Kind::RoleKind => Role::unmarshal(obj.clone()).unwrap().transition_validation(&Role::unmarshal(old_obj.clone()).unwrap()),
-        Kind::SecretKind => Secret::unmarshal(obj.clone()).unwrap().transition_validation(&Secret::unmarshal(old_obj.clone()).unwrap()),
-        Kind::ServiceKind => Service::unmarshal(obj.clone()).unwrap().transition_validation(&Service::unmarshal(old_obj.clone()).unwrap()),
-        Kind::StatefulSetKind => StatefulSet::unmarshal(obj.clone()).unwrap().transition_validation(&StatefulSet::unmarshal(old_obj.clone()).unwrap()),
-        Kind::ServiceAccountKind => ServiceAccount::unmarshal(obj.clone()).unwrap().transition_validation(&ServiceAccount::unmarshal(old_obj.clone()).unwrap()),
-        Kind::CustomResourceKind => {
+        KindExec::ConfigMapKind => ConfigMap::unmarshal(obj.clone()).unwrap().transition_validation(&ConfigMap::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::DaemonSetKind => DaemonSet::unmarshal(obj.clone()).unwrap().transition_validation(&DaemonSet::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::PersistentVolumeClaimKind => PersistentVolumeClaim::unmarshal(obj.clone()).unwrap().transition_validation(&PersistentVolumeClaim::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::PodKind => Pod::unmarshal(obj.clone()).unwrap().transition_validation(&Pod::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::RoleBindingKind => RoleBinding::unmarshal(obj.clone()).unwrap().transition_validation(&RoleBinding::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::RoleKind => Role::unmarshal(obj.clone()).unwrap().transition_validation(&Role::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::SecretKind => Secret::unmarshal(obj.clone()).unwrap().transition_validation(&Secret::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::ServiceKind => Service::unmarshal(obj.clone()).unwrap().transition_validation(&Service::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::StatefulSetKind => StatefulSet::unmarshal(obj.clone()).unwrap().transition_validation(&StatefulSet::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::ServiceAccountKind => ServiceAccount::unmarshal(obj.clone()).unwrap().transition_validation(&ServiceAccount::unmarshal(old_obj.clone()).unwrap()),
+        KindExec::CustomResourceKind(_) => {
             proof {
                 K::V::unmarshal_result_determined_by_unmarshal_spec_and_status();
                 K::V::kind_is_custom_resource();
@@ -135,6 +140,7 @@ fn object_transition_validity_check(obj: &DynamicObject, old_obj: &DynamicObject
         old_obj@.kind == obj@.kind,
         model::valid_object::<K::V>(obj@),
         model::valid_object::<K::V>(old_obj@),
+        obj@.kind.is_CustomResourceKind() ==> obj@.kind == K::V::kind(),
     ensures ret == model::object_transition_validity_check::<K::V>(obj@, old_obj@)
 {
     if !Self::valid_transition(obj, old_obj) {
@@ -180,7 +186,9 @@ fn create_request_admission_check(req: &KubeCreateRequest, s: &ApiServerState) -
 }
 
 fn created_object_validity_check(created_obj: &DynamicObject) -> (ret: Option<APIError>)
-    requires model::unmarshallable_object::<K::V>(created_obj@)
+    requires
+        model::unmarshallable_object::<K::V>(created_obj@),
+        created_obj@.kind.is_CustomResourceKind() ==> created_obj@.kind == K::V::kind(),
     ensures ret == model::created_object_validity_check::<K::V>(created_obj@)
 {
     if Self::metadata_validity_check(created_obj).is_some() {
@@ -206,6 +214,7 @@ pub fn handle_create_request(req: &KubeCreateRequest, s: &mut ApiServerState) ->
         // No integer overflow
         old(s).resource_version_counter < i64::MAX,
         old(s).uid_counter < i64::MAX,
+        req@.obj.kind.is_CustomResourceKind() ==> req@.obj.kind == K::V::kind(),
     ensures (s@, ret@) == model::handle_create_request::<K::V>(req@, old(s)@)
 {
     // TODO: use if-let?
@@ -269,11 +278,11 @@ pub fn handle_delete_request(req: &KubeDeleteRequest, s: &mut ApiServerState) ->
     }
 }
 
-fn allow_unconditional_update(kind: &Kind) -> (ret: bool)
-    ensures ret == model::allow_unconditional_update(*kind)
+fn allow_unconditional_update(kind: &KindExec) -> (ret: bool)
+    ensures ret == model::allow_unconditional_update(kind@)
 {
     match kind {
-        Kind::CustomResourceKind => false,
+        KindExec::CustomResourceKind(_) => false,
         _ => true,
     }
 }
@@ -335,6 +344,7 @@ fn updated_object_validity_check(updated_obj: &DynamicObject, old_obj: &DynamicO
         model::unmarshallable_object::<K::V>(old_obj@),
         old_obj@.kind == updated_obj@.kind,
         model::valid_object::<K::V>(old_obj@),
+        updated_obj@.kind.is_CustomResourceKind() ==> updated_obj@.kind == K::V::kind(),
     ensures ret == model::updated_object_validity_check::<K::V>(updated_obj@, old_obj@)
 {
     if Self::metadata_validity_check(updated_obj).is_some() {
@@ -361,6 +371,7 @@ pub fn handle_update_request(req: &KubeUpdateRequest, s: &mut ApiServerState) ->
         // The old version has the right key (name, namespace, kind)
         old(s)@.resources.contains_key(req@.key()) ==> old(s)@.resources[req@.key()].object_ref() == req@.key(),
         // All the three preconditions above are proved by the invariant lemma_always_each_object_in_etcd_is_well_formed
+        req@.obj.kind.is_CustomResourceKind() ==> req@.obj.kind == K::V::kind(),
     ensures (s@, ret@) == model::handle_update_request::<K::V>(req@, old(s)@)
 {
     let request_check_error = Self::update_request_admission_check(req, s);
@@ -427,6 +438,7 @@ pub fn handle_update_status_request(req: &KubeUpdateStatusRequest, s: &mut ApiSe
         // The old version has the right key (name, namespace, kind)
         old(s)@.resources.contains_key(req@.key()) ==> old(s)@.resources[req@.key()].object_ref() == req@.key(),
         // All the three preconditions above are proved by the invariant lemma_always_each_object_in_etcd_is_well_formed
+        req@.obj.kind.is_CustomResourceKind() ==> req@.obj.kind == K::V::kind(),
     ensures (s@, ret@) == model::handle_update_status_request::<K::V>(req@, old(s)@)
 {
     let request_check_error = Self::update_status_request_admission_check(req, s);

--- a/src/executable_model/common.rs
+++ b/src/executable_model/common.rs
@@ -15,7 +15,7 @@ use vstd::string::*;
 // because it internally uses vstd::string::String, which does not implement such traits.
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct ExternalObjectRef {
-    pub kind: Kind,
+    pub kind: KindExec,
     pub name: std::string::String,
     pub namespace: std::string::String,
 }
@@ -33,7 +33,7 @@ impl KubeObjectRef {
 verus! {
 
 pub struct KubeObjectRef {
-    pub kind: Kind,
+    pub kind: KindExec,
     pub name: String,
     pub namespace: String,
 }
@@ -42,7 +42,7 @@ impl View for KubeObjectRef {
     type V = ObjectRef;
     open spec fn view(&self) -> ObjectRef {
         ObjectRef {
-            kind: self.kind,
+            kind: self.kind@,
             name: self.name@,
             namespace: self.namespace@,
         }
@@ -64,20 +64,20 @@ impl std::clone::Clone for KubeObjectRef {
 impl ApiResource {
     // This kind() is not a perfect implementation but it is sufficient for conformance tests.
     #[verifier(external_body)]
-    pub fn kind(&self) -> (kind: Kind)
-        ensures kind == self@.kind,
+    pub fn kind(&self) -> (kind: KindExec)
+        ensures kind@ == self@.kind,
     {
         match self.as_kube_ref().kind.as_str() {
-            "ConfigMap" => Kind::ConfigMapKind,
-            "DaemonSet" => Kind::DaemonSetKind,
-            "PersistentVolumeClaim" => Kind::PersistentVolumeClaimKind,
-            "Pod" => Kind::PodKind,
-            "Role" => Kind::RoleKind,
-            "RoleBinding" => Kind::RoleBindingKind,
-            "StatefulSet" => Kind::StatefulSetKind,
-            "Service" => Kind::ServiceKind,
-            "ServiceAccount" => Kind::ServiceAccountKind,
-            "Secret" => Kind::SecretKind,
+            "ConfigMap" => KindExec::ConfigMapKind,
+            "DaemonSet" => KindExec::DaemonSetKind,
+            "PersistentVolumeClaim" => KindExec::PersistentVolumeClaimKind,
+            "Pod" => KindExec::PodKind,
+            "Role" => KindExec::RoleKind,
+            "RoleBinding" => KindExec::RoleBindingKind,
+            "StatefulSet" => KindExec::StatefulSetKind,
+            "Service" => KindExec::ServiceKind,
+            "ServiceAccount" => KindExec::ServiceAccountKind,
+            "Secret" => KindExec::SecretKind,
             _ => panic!(), // We assume the DynamicObject won't be a custom object
         }
     }
@@ -154,23 +154,23 @@ impl DynamicObjectView {
 impl DynamicObject {
     // This kind() is not a perfect implementation but it is sufficient for conformance tests.
     #[verifier(external_body)]
-    pub fn kind(&self) -> (kind: Kind)
-        ensures kind == self@.kind,
+    pub fn kind(&self) -> (kind: KindExec)
+        ensures kind@ == self@.kind,
     {
         if self.as_kube_ref().types.is_none() {
             panic!();
         }
         match self.as_kube_ref().types.as_ref().unwrap().kind.as_str() {
-            "ConfigMap" => Kind::ConfigMapKind,
-            "DaemonSet" => Kind::DaemonSetKind,
-            "PersistentVolumeClaim" => Kind::PersistentVolumeClaimKind,
-            "Pod" => Kind::PodKind,
-            "Role" => Kind::RoleKind,
-            "RoleBinding" => Kind::RoleBindingKind,
-            "StatefulSet" => Kind::StatefulSetKind,
-            "Service" => Kind::ServiceKind,
-            "ServiceAccount" => Kind::ServiceAccountKind,
-            "Secret" => Kind::SecretKind,
+            "ConfigMap" => KindExec::ConfigMapKind,
+            "DaemonSet" => KindExec::DaemonSetKind,
+            "PersistentVolumeClaim" => KindExec::PersistentVolumeClaimKind,
+            "Pod" => KindExec::PodKind,
+            "Role" => KindExec::RoleKind,
+            "RoleBinding" => KindExec::RoleBindingKind,
+            "StatefulSet" => KindExec::StatefulSetKind,
+            "Service" => KindExec::ServiceKind,
+            "ServiceAccount" => KindExec::ServiceAccountKind,
+            "Secret" => KindExec::SecretKind,
             _ => panic!(), // We assume the DynamicObject won't be a custom object
         }
     }
@@ -539,7 +539,7 @@ impl ResourceView for SimpleCRView {
 
     open spec fn metadata(self) -> ObjectMetaView { self.metadata }
 
-    open spec fn kind() -> Kind { Kind::CustomResourceKind }
+    open spec fn kind() -> Kind { Kind::CustomResourceKind("simple"@) }
 
     open spec fn object_ref(self) -> ObjectRef {
         ObjectRef {

--- a/src/kubernetes_api_objects/exec/common.rs
+++ b/src/kubernetes_api_objects/exec/common.rs
@@ -1,0 +1,66 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::spec::common::*;
+use crate::vstd_ext::string_view::*;
+use vstd::prelude::*;
+use vstd::string::*;
+
+verus! {
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum KindExec {
+    ConfigMapKind,
+    CustomResourceKind(String),
+    DaemonSetKind,
+    PersistentVolumeClaimKind,
+    PodKind,
+    RoleKind,
+    RoleBindingKind,
+    StatefulSetKind,
+    ServiceKind,
+    ServiceAccountKind,
+    SecretKind,
+}
+
+impl View for KindExec {
+    type V = Kind;
+
+    open spec fn view(&self) -> Self::V {
+        match self {
+            KindExec::ConfigMapKind => Kind::ConfigMapKind,
+            KindExec::DaemonSetKind => Kind::DaemonSetKind,
+            KindExec::PersistentVolumeClaimKind => Kind::PersistentVolumeClaimKind,
+            KindExec::PodKind => Kind::PodKind,
+            KindExec::RoleBindingKind => Kind::RoleBindingKind,
+            KindExec::RoleKind => Kind::RoleKind,
+            KindExec::SecretKind => Kind::SecretKind,
+            KindExec::ServiceKind => Kind::ServiceKind,
+            KindExec::StatefulSetKind => Kind::StatefulSetKind,
+            KindExec::ServiceAccountKind => Kind::ServiceAccountKind,
+            KindExec::CustomResourceKind(s) => Kind::CustomResourceKind(s@),
+        }
+    }
+}
+
+impl std::clone::Clone for KindExec {
+    #[verifier(external_body)]
+    fn clone(&self) -> (result: Self)
+        ensures result == self
+    {
+        match self {
+            KindExec::ConfigMapKind => KindExec::ConfigMapKind,
+            KindExec::DaemonSetKind => KindExec::DaemonSetKind,
+            KindExec::PersistentVolumeClaimKind => KindExec::PersistentVolumeClaimKind,
+            KindExec::PodKind => KindExec::PodKind,
+            KindExec::RoleBindingKind => KindExec::RoleBindingKind,
+            KindExec::RoleKind => KindExec::RoleKind,
+            KindExec::SecretKind => KindExec::SecretKind,
+            KindExec::ServiceKind => KindExec::ServiceKind,
+            KindExec::StatefulSetKind => KindExec::StatefulSetKind,
+            KindExec::ServiceAccountKind => KindExec::ServiceAccountKind,
+            KindExec::CustomResourceKind(s) => KindExec::CustomResourceKind(s.clone()),
+        }
+    }
+}
+
+}

--- a/src/kubernetes_api_objects/exec/mod.rs
+++ b/src/kubernetes_api_objects/exec/mod.rs
@@ -3,6 +3,7 @@
 pub mod affinity;
 pub mod api_method;
 pub mod api_resource;
+pub mod common;
 pub mod config_map;
 pub mod container;
 pub mod daemon_set;

--- a/src/kubernetes_api_objects/exec/prelude.rs
+++ b/src/kubernetes_api_objects/exec/prelude.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 pub use crate::kubernetes_api_objects::exec::api_method::*;
+pub use crate::kubernetes_api_objects::exec::common::*;
 pub use crate::kubernetes_api_objects::exec::config_map::*;
 pub use crate::kubernetes_api_objects::exec::daemon_set::*;
 pub use crate::kubernetes_api_objects::exec::dynamic::*;

--- a/src/kubernetes_api_objects/spec/common.rs
+++ b/src/kubernetes_api_objects/spec/common.rs
@@ -20,10 +20,9 @@ pub type GenerateNameCounter = int;
 // TODO: make CustomResourceKind take a string so that we
 // can differentiate between different custom resources
 #[is_variant]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Kind {
     ConfigMapKind,
-    CustomResourceKind,
+    CustomResourceKind(StringView),
     DaemonSetKind,
     PersistentVolumeClaimKind,
     PodKind,
@@ -33,15 +32,6 @@ pub enum Kind {
     ServiceKind,
     ServiceAccountKind,
     SecretKind,
-}
-
-impl std::marker::Copy for Kind {}
-
-impl std::clone::Clone for Kind {
-    #[verifier(external_body)]
-    fn clone(&self) -> (result: Self)
-        ensures result == self
-    { *self }
 }
 
 pub struct ObjectRef {

--- a/src/kubernetes_api_objects/spec/resource.rs
+++ b/src/kubernetes_api_objects/spec/resource.rs
@@ -100,7 +100,7 @@ pub open spec fn empty_status() -> EmptyStatusView {
 
 pub trait CustomResourceView: ResourceView {
     proof fn kind_is_custom_resource()
-        ensures Self::kind() == Kind::CustomResourceKind;
+        ensures Self::kind().is_CustomResourceKind();
 }
 
 }

--- a/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -85,6 +85,7 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_idle(spec: TempPred<Self>, 
     requires
         K::kind().is_CustomResourceKind(),
         cr_key.kind.is_CustomResourceKind(),
+        K::kind() == cr_key.kind,
         spec.entails(always(lift_action(Self::next()))),
         spec.entails(tla_forall(|i| Self::controller_next().weak_fairness(i))),
     ensures spec.entails(lift_state(Self::reconciler_reconcile_done(cr_key)).leads_to(lift_state(|s: Self| { !s.ongoing_reconciles().contains_key(cr_key)}))),
@@ -105,6 +106,7 @@ pub proof fn lemma_reconcile_error_leads_to_reconcile_idle
     requires
         K::kind().is_CustomResourceKind(),
         cr_key.kind.is_CustomResourceKind(),
+        K::kind() == cr_key.kind,
         spec.entails(always(lift_action(Self::next()))),
         spec.entails(tla_forall(|i| Self::controller_next().weak_fairness(i))),
     ensures spec.entails(lift_state(Self::reconciler_reconcile_error(cr_key)).leads_to(lift_state(|s: Self| { !s.ongoing_reconciles().contains_key(cr_key) }))),
@@ -123,6 +125,7 @@ pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init
     requires
         K::kind().is_CustomResourceKind(),
         cr_key.kind.is_CustomResourceKind(),
+        K::kind() == cr_key.kind,
         spec.entails(always(lift_action(Self::next()))),
         spec.entails(always(lift_state(Self::crash_disabled()))),
         spec.entails(tla_forall(|i| Self::controller_next().weak_fairness(i))),

--- a/src/kubernetes_cluster/proof/validation_rule.rs
+++ b/src/kubernetes_cluster/proof/validation_rule.rs
@@ -51,7 +51,7 @@ pub open spec fn transition_rule_applies_to_etcd_and_scheduled_and_triggering_cr
 
 pub proof fn lemma_always_transition_rule_applies_to_etcd_and_scheduled_and_triggering_cr(spec: TempPred<Self>, cr: K)
     requires
-        K::kind() == Kind::CustomResourceKind,
+        K::kind().is_CustomResourceKind(),
         Self::marshal_preserves_spec(),
         Self::marshal_preserves_status(),
         Self::is_reflexive_and_transitive(),
@@ -81,7 +81,7 @@ pub open spec fn transition_rule_applies_to_etcd_and_scheduled_cr(cr: K) -> Stat
 
 proof fn lemma_always_transition_rule_applies_to_etcd_and_scheduled_cr(spec: TempPred<Self>, cr: K)
     requires
-        K::kind() == Kind::CustomResourceKind,
+        K::kind().is_CustomResourceKind(),
         Self::is_reflexive_and_transitive(),
         Self::marshal_preserves_spec(),
         Self::marshal_preserves_status(),
@@ -174,7 +174,7 @@ pub open spec fn transition_rule_applies_to_scheduled_and_triggering_cr(cr: K) -
 
 proof fn lemma_always_triggering_cr_is_in_correct_order(spec: TempPred<Self>, cr: K)
     requires
-        K::kind() == Kind::CustomResourceKind,
+        K::kind().is_CustomResourceKind(),
         Self::marshal_preserves_spec(),
         Self::marshal_preserves_status(),
         Self::is_reflexive_and_transitive(),

--- a/src/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -35,7 +35,7 @@ pub open spec fn unmarshallable_spec<K: CustomResourceView>(obj: DynamicObjectVi
         Kind::ServiceKind => ServiceView::unmarshal_spec(obj.spec).is_Ok(),
         Kind::StatefulSetKind => StatefulSetView::unmarshal_spec(obj.spec).is_Ok(),
         Kind::ServiceAccountKind => ServiceAccountView::unmarshal_spec(obj.spec).is_Ok(),
-        Kind::CustomResourceKind => K::unmarshal_spec(obj.spec).is_Ok(),
+        Kind::CustomResourceKind(_) => K::unmarshal_spec(obj.spec).is_Ok(),
     }
 }
 
@@ -52,7 +52,7 @@ pub open spec fn unmarshallable_status<K: CustomResourceView>(obj: DynamicObject
         Kind::ServiceKind => ServiceView::unmarshal_status(obj.status).is_Ok(),
         Kind::StatefulSetKind => StatefulSetView::unmarshal_status(obj.status).is_Ok(),
         Kind::ServiceAccountKind => ServiceAccountView::unmarshal_status(obj.status).is_Ok(),
-        Kind::CustomResourceKind => K::unmarshal_status(obj.status).is_Ok(),
+        Kind::CustomResourceKind(_) => K::unmarshal_status(obj.status).is_Ok(),
     }
 }
 
@@ -92,7 +92,7 @@ pub open spec fn valid_object<K: CustomResourceView>(obj: DynamicObjectView) -> 
         Kind::ServiceKind => ServiceView::unmarshal(obj).get_Ok_0().state_validation(),
         Kind::StatefulSetKind => StatefulSetView::unmarshal(obj).get_Ok_0().state_validation(),
         Kind::ServiceAccountKind => ServiceAccountView::unmarshal(obj).get_Ok_0().state_validation(),
-        Kind::CustomResourceKind => K::unmarshal(obj).get_Ok_0().state_validation(),
+        Kind::CustomResourceKind(_) => K::unmarshal(obj).get_Ok_0().state_validation(),
     }
 }
 
@@ -116,7 +116,7 @@ pub open spec fn valid_transition<K: CustomResourceView>(obj: DynamicObjectView,
         Kind::ServiceKind => ServiceView::unmarshal(obj).get_Ok_0().transition_validation(ServiceView::unmarshal(old_obj).get_Ok_0()),
         Kind::StatefulSetKind => StatefulSetView::unmarshal(obj).get_Ok_0().transition_validation(StatefulSetView::unmarshal(old_obj).get_Ok_0()),
         Kind::ServiceAccountKind => ServiceAccountView::unmarshal(obj).get_Ok_0().transition_validation(ServiceAccountView::unmarshal(old_obj).get_Ok_0()),
-        Kind::CustomResourceKind => K::unmarshal(obj).get_Ok_0().transition_validation(K::unmarshal(old_obj).get_Ok_0()),
+        Kind::CustomResourceKind(_) => K::unmarshal(obj).get_Ok_0().transition_validation(K::unmarshal(old_obj).get_Ok_0()),
     }
 }
 
@@ -140,7 +140,7 @@ pub open spec fn marshalled_default_status<K: CustomResourceView>(kind: Kind) ->
         Kind::ServiceKind => ServiceView::marshal_status(ServiceView::default().status()),
         Kind::StatefulSetKind => StatefulSetView::marshal_status(StatefulSetView::default().status()),
         Kind::ServiceAccountKind => ServiceAccountView::marshal_status(ServiceAccountView::default().status()),
-        Kind::CustomResourceKind => K::marshal_status(K::default().status()),
+        Kind::CustomResourceKind(_) => K::marshal_status(K::default().status()),
     }
 }
 
@@ -309,7 +309,7 @@ pub open spec fn handle_delete_request(req: DeleteRequest, s: ApiServerState) ->
 // Note that if the resource version is provided, it has to be the correct one.
 pub open spec fn allow_unconditional_update(kind: Kind) -> bool {
     match kind {
-        Kind::CustomResourceKind => false,
+        Kind::CustomResourceKind(_) => false,
         _ => true,
     }
 }

--- a/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -4,10 +4,10 @@
 use crate::external_api::spec::*;
 use crate::kubernetes_api_objects::error::*;
 use crate::kubernetes_api_objects::spec::prelude::*;
-use crate::v2::kubernetes_cluster::spec::{api_server::types::*, message::*};
 use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
 use crate::temporal_logic::defs::*;
+use crate::v2::kubernetes_cluster::spec::{api_server::types::*, message::*};
 use crate::vstd_ext::{map_lib::*, string_view::*};
 use vstd::{multiset::*, prelude::*};
 
@@ -34,7 +34,7 @@ pub open spec fn unmarshallable_spec(obj: DynamicObjectView, installed_types: In
         Kind::ServiceKind => ServiceView::unmarshal_spec(obj.spec).is_Ok(),
         Kind::StatefulSetKind => StatefulSetView::unmarshal_spec(obj.spec).is_Ok(),
         Kind::ServiceAccountKind => ServiceAccountView::unmarshal_spec(obj.spec).is_Ok(),
-        Kind::CustomResourceKind => (installed_types.unmarshallable_spec)(obj),
+        Kind::CustomResourceKind(_) => (installed_types.unmarshallable_spec)(obj),
     }
 }
 
@@ -51,7 +51,7 @@ pub open spec fn unmarshallable_status(obj: DynamicObjectView, installed_types: 
         Kind::ServiceKind => ServiceView::unmarshal_status(obj.status).is_Ok(),
         Kind::StatefulSetKind => StatefulSetView::unmarshal_status(obj.status).is_Ok(),
         Kind::ServiceAccountKind => ServiceAccountView::unmarshal_status(obj.status).is_Ok(),
-        Kind::CustomResourceKind => (installed_types.unmarshallable_status)(obj),
+        Kind::CustomResourceKind(_) => (installed_types.unmarshallable_status)(obj),
     }
 }
 
@@ -91,7 +91,7 @@ pub open spec fn valid_object(obj: DynamicObjectView, installed_types: Installed
         Kind::ServiceKind => ServiceView::unmarshal(obj).get_Ok_0().state_validation(),
         Kind::StatefulSetKind => StatefulSetView::unmarshal(obj).get_Ok_0().state_validation(),
         Kind::ServiceAccountKind => ServiceAccountView::unmarshal(obj).get_Ok_0().state_validation(),
-        Kind::CustomResourceKind => (installed_types.valid_object)(obj),
+        Kind::CustomResourceKind(_) => (installed_types.valid_object)(obj),
     }
 }
 
@@ -115,7 +115,7 @@ pub open spec fn valid_transition(obj: DynamicObjectView, old_obj: DynamicObject
         Kind::ServiceKind => ServiceView::unmarshal(obj).get_Ok_0().transition_validation(ServiceView::unmarshal(old_obj).get_Ok_0()),
         Kind::StatefulSetKind => StatefulSetView::unmarshal(obj).get_Ok_0().transition_validation(StatefulSetView::unmarshal(old_obj).get_Ok_0()),
         Kind::ServiceAccountKind => ServiceAccountView::unmarshal(obj).get_Ok_0().transition_validation(ServiceAccountView::unmarshal(old_obj).get_Ok_0()),
-        Kind::CustomResourceKind => (installed_types.valid_transition)(obj, old_obj),
+        Kind::CustomResourceKind(_) => (installed_types.valid_transition)(obj, old_obj),
     }
 }
 
@@ -139,7 +139,7 @@ pub open spec fn marshalled_default_status(kind: Kind, installed_types: Installe
         Kind::ServiceKind => ServiceView::marshal_status(ServiceView::default().status()),
         Kind::StatefulSetKind => StatefulSetView::marshal_status(StatefulSetView::default().status()),
         Kind::ServiceAccountKind => ServiceAccountView::marshal_status(ServiceAccountView::default().status()),
-        Kind::CustomResourceKind => (installed_types.marshalled_default_status)(kind),
+        Kind::CustomResourceKind(_) => (installed_types.marshalled_default_status)(kind),
     }
 }
 
@@ -308,7 +308,7 @@ pub open spec fn handle_delete_request(req: DeleteRequest, s: APIServerState) ->
 // Note that if the resource version is provided, it has to be the correct one.
 pub open spec fn allow_unconditional_update(kind: Kind) -> bool {
     match kind {
-        Kind::CustomResourceKind => false,
+        Kind::CustomResourceKind(_) => false,
         _ => true,
     }
 }


### PR DESCRIPTION
This PR modifies the `Kind` type to let its `CustomResourceKind` variant carry a `StringView`, which can be used to differentiate between different custom resource types. For example, the ZooKeeper controller's CR type should be `CustomResourceKind("zookeeper"@)` while the RabbitMQ controller's should be `CustomResourceKind("rabbitmq"@)`. This is important for state machine v2 because it will take in multiple controllers and multiple custom resource types and we need to differentiate them during the proof.