### PR TITLE
Prove that there are no pending update or update status requests on pods

### DIFF
--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -21,4 +21,47 @@ use vstd::{multiset::*, prelude::*, string::*};
 
 verus! {
 
+pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_on_pods(
+    spec: TempPred<VRSCluster>, vrs: VReplicaSetView
+)
+    requires
+        spec.entails(always(lift_state(VRSCluster::each_object_in_etcd_is_well_formed()))),
+        spec.entails(always(lift_state(VRSCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
+        spec.entails(always(lift_state(VRSCluster::busy_disabled()))),
+        spec.entails(always(lift_state(VRSCluster::pod_event_disabled()))),
+        spec.entails(always(lift_action(VRSCluster::next()))),
+        spec.entails(tla_forall(|i| VRSCluster::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(VRSCluster::desired_state_is(vrs)))),
+    ensures spec.entails(true_pred().leads_to(always(lift_state(no_pending_update_or_update_status_request_on_pods())))),
+{
+    let requirements = |msg: VRSMessage, s: VRSCluster| {
+        &&& msg.content.is_update_request() ==> msg.content.get_update_request().key().kind != PodView::kind()
+        &&& msg.content.is_update_status_request() ==> msg.content.get_update_status_request().key().kind != PodView::kind()
+    };
+
+    let stronger_next = |s: VRSCluster, s_prime: VRSCluster| {
+        &&& VRSCluster::next()(s, s_prime)
+        &&& VRSCluster::desired_state_is(vrs)(s)
+        &&& VRSCluster::each_object_in_etcd_is_well_formed()(s)
+    };
+
+    assert forall |s: VRSCluster, s_prime: VRSCluster| #[trigger]  #[trigger] stronger_next(s, s_prime) implies VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
+        assume(false);
+    }
+
+    invariant_n!(
+        spec, lift_action(stronger_next), 
+        lift_action(VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
+        lift_action(VRSCluster::next()), 
+        lift_state(VRSCluster::desired_state_is(vrs)),
+        lift_state(VRSCluster::each_object_in_etcd_is_well_formed())
+    );
+
+    VRSCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
+    temp_pred_equality(
+        lift_state(no_pending_update_or_update_status_request_on_pods()),
+        lift_state(VRSCluster::every_in_flight_req_msg_satisfies(requirements))
+    );
+}
+
 }

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -31,6 +31,7 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
         spec.entails(always(lift_state(VRSCluster::pod_event_disabled()))),
         spec.entails(always(lift_action(VRSCluster::next()))),
         spec.entails(tla_forall(|i| VRSCluster::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| VRSCluster::external_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(VRSCluster::desired_state_is(vrs)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(no_pending_update_or_update_status_request_on_pods())))),
 {
@@ -43,6 +44,7 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
         &&& VRSCluster::next()(s, s_prime)
         &&& VRSCluster::desired_state_is(vrs)(s)
         &&& VRSCluster::each_object_in_etcd_is_well_formed()(s)
+        &&& VRSCluster::pod_event_disabled()(s)
     };
 
     assert forall |s: VRSCluster, s_prime: VRSCluster| #[trigger]  #[trigger] stronger_next(s, s_prime) implies VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
@@ -67,7 +69,8 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
         lift_action(VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(VRSCluster::next()), 
         lift_state(VRSCluster::desired_state_is(vrs)),
-        lift_state(VRSCluster::each_object_in_etcd_is_well_formed())
+        lift_state(VRSCluster::each_object_in_etcd_is_well_formed()),
+        lift_state(VRSCluster::pod_event_disabled())
     );
 
     VRSCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -25,14 +25,11 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
     spec: TempPred<VRSCluster>, vrs: VReplicaSetView
 )
     requires
-        spec.entails(always(lift_state(VRSCluster::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(VRSCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
-        spec.entails(always(lift_state(VRSCluster::busy_disabled()))),
         spec.entails(always(lift_state(VRSCluster::pod_event_disabled()))),
         spec.entails(always(lift_action(VRSCluster::next()))),
         spec.entails(tla_forall(|i| VRSCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| VRSCluster::external_api_next().weak_fairness(i))),
-        spec.entails(always(lift_state(VRSCluster::desired_state_is(vrs)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(no_pending_update_or_update_status_request_on_pods())))),
 {
     let requirements = |msg: VRSMessage, s: VRSCluster| {
@@ -42,8 +39,6 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
 
     let stronger_next = |s: VRSCluster, s_prime: VRSCluster| {
         &&& VRSCluster::next()(s, s_prime)
-        &&& VRSCluster::desired_state_is(vrs)(s)
-        &&& VRSCluster::each_object_in_etcd_is_well_formed()(s)
         &&& VRSCluster::pod_event_disabled()(s)
     };
 
@@ -67,9 +62,7 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
     invariant_n!(
         spec, lift_action(stronger_next), 
         lift_action(VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
-        lift_action(VRSCluster::next()), 
-        lift_state(VRSCluster::desired_state_is(vrs)),
-        lift_state(VRSCluster::each_object_in_etcd_is_well_formed()),
+        lift_action(VRSCluster::next()),
         lift_state(VRSCluster::pod_event_disabled())
     );
 

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -46,7 +46,20 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
     };
 
     assert forall |s: VRSCluster, s_prime: VRSCluster| #[trigger]  #[trigger] stronger_next(s, s_prime) implies VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
-        assume(false);
+        assert forall |msg: VRSMessage| (!s.in_flight().contains(msg) || requirements(msg, s)) && #[trigger] s_prime.in_flight().contains(msg)
+        implies requirements(msg, s_prime) by {
+            if s.in_flight().contains(msg) {
+                assert(requirements(msg, s));
+                assert(requirements(msg, s_prime));
+            } else {
+                let step = choose |step| VRSCluster::next_step(s, s_prime, step);
+                match step {
+                    _ => {
+                        assert(requirements(msg, s_prime));
+                    }
+                }
+            }
+        }
     }
 
     invariant_n!(

--- a/src/controller_examples/v_replica_set_controller/proof/liveness/spec.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/liveness/spec.rs
@@ -69,6 +69,7 @@ pub open spec fn spec_before_phase_n(n: nat, vrs: VReplicaSetView) -> TempPred<V
     }
 }
 
+#[verifier(external_body)]
 pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(i: nat, vrs: VReplicaSetView)
     requires 1 <= i <= 7,
     ensures spec_before_phase_n(i, vrs).entails(true_pred().leads_to(invariants_since_phase_n(i, vrs))),
@@ -89,39 +90,13 @@ pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(i: nat, v
             lift_state(VRSCluster::the_object_in_schedule_has_spec_and_uid_as(vrs))
         );
     } else {
-        assume(false);
-        // terminate::reconcile_eventually_terminates(spec, vrs);
-        // if i == 2 {
-        //     VRSCluster::lemma_true_leads_to_always_the_object_in_reconcile_has_spec_and_uid_as(spec, vrs);
-        // } else if i == 3 {
-        //     helper_invariants::lemma_always_vrs_is_well_formed(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_every_resource_create_request_implies_at_after_create_resource_step_forall(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr_forall(spec, vrs);
-        //     let a_to_p_1 = |sub_resource: SubResource| lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, vrs));
-        //     let a_to_p_2 = |sub_resource: SubResource| lift_state(helper_invariants::object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(sub_resource, vrs));
-        //     helper_invariants::lemma_eventually_always_every_zk_set_data_request_implies_at_after_update_zk_node_step(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_every_zk_create_node_request_implies_at_after_create_zk_node_step(spec, vrs);
-        //     leads_to_always_combine_n!(
-        //         spec, true_pred(), tla_forall(a_to_p_1), tla_forall(a_to_p_2),
-        //         lift_state(helper_invariants::every_zk_set_data_request_implies_at_after_update_zk_node_step(vrs)),
-        //         lift_state(helper_invariants::every_zk_create_node_request_implies_at_after_create_zk_node_step(vrs))
-        //     );
-        // } else if i == 4 {
-        //     helper_invariants::lemma_eventually_always_resource_object_only_has_owner_reference_pointing_to_current_cr_forall(spec, vrs);
-        // } else if i == 5 {
-        //     helper_invariants::lemma_eventually_always_no_delete_resource_request_msg_in_flight_forall(spec, vrs);
-        // } else if i == 6 {
-        //     helper_invariants::lemma_eventually_always_every_resource_update_request_implies_at_after_update_resource_step_forall(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_object_in_response_at_after_create_resource_step_is_same_as_etcd_forall(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_object_in_response_at_after_update_resource_step_is_same_as_etcd_forall(spec, vrs);
-        //     let a_to_p_1 = |sub_resource: SubResource| lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(sub_resource, vrs));
-        //     leads_to_always_combine_n!(
-        //         spec, true_pred(),
-        //         tla_forall(a_to_p_1), lift_state(helper_invariants::object_in_response_at_after_create_resource_step_is_same_as_etcd(SubResource::ConfigMap, vrs)), lift_state(helper_invariants::object_in_response_at_after_update_resource_step_is_same_as_etcd(SubResource::ConfigMap, vrs))
-        //     );
-        // } else if i == 7 {
-        //     helper_invariants::lemma_eventually_always_cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated_forall(spec, vrs);
-        // }
+        terminate::reconcile_eventually_terminates(spec, vrs);
+        if i == 2 {
+            assume(false);
+            //
+        } else {
+            assume(false);
+        }
     }
 }
 

--- a/src/kubernetes_cluster/proof/cluster.rs
+++ b/src/kubernetes_cluster/proof/cluster.rs
@@ -75,6 +75,19 @@ pub proof fn lemma_true_leads_to_busy_always_disabled(
     leads_to_stable::<Self>(spec, lift_action(Self::next()), true_pred(), lift_state(Self::busy_disabled()));
 }
 
+pub proof fn lemma_true_leads_to_pod_event_always_disabled(
+    spec: TempPred<Self>,
+)
+    requires
+        spec.entails(always(lift_action(Self::next()))),
+        spec.entails(Self::disable_pod_event().weak_fairness(())),
+    ensures spec.entails(true_pred().leads_to(always(lift_state(Self::pod_event_disabled())))),
+{
+    let true_state = |s: Self| true;
+    Self::disable_pod_event().wf1((), spec, Self::next(), true_state, Self::pod_event_disabled());
+    leads_to_stable::<Self>(spec, lift_action(Self::next()), true_pred(), lift_state(Self::pod_event_disabled()));
+}
+
 // This desired_state_is specifies the desired state (described in the cr object)
 // Informally, it says that given the cr object, the object's key exists in the etcd,
 // and the corresponding object in etcd has the same spec and uid of the given cr object.


### PR DESCRIPTION
This PR adds the proof of the invariant in `no_pending_update_or_update_status_request_on_pods` (https://github.com/anvil-verifier/anvil/blob/main/src/controller_examples/v_replica_set_controller/proof/helper_invariants/predicate.rs), stating nothing in the cluster updates or updates the status of a pod. 

This is a provisional invariant: composition may require making this invariant less strict.