### PR TITLE
Prove key invariants for VReplicaSet possibly involving PodEvent

### DIFF
--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/predicate.rs
@@ -25,6 +25,10 @@ use vstd::{multiset::*, prelude::*, string::*};
 
 verus! {
 
+pub open spec fn vrs_is_well_formed(vrs: VReplicaSetView) -> StatePred<VRSCluster> {
+    |s: VRSCluster| vrs.well_formed()
+}
+
 pub open spec fn cluster_resources_is_finite() -> StatePred<VRSCluster> {
     |s: VRSCluster| s.resources().dom().finite()
 } 

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/predicate.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/predicate.rs
@@ -113,6 +113,7 @@ pub open spec fn every_create_request_is_well_formed() -> StatePred<VRSCluster> 
                 status: marshalled_default_status::<VReplicaSetView>(req.obj.kind), // Overwrite the status with the default one
             };
             &&& obj.metadata.deletion_timestamp.is_None()
+            &&& obj.metadata.namespace.is_Some()
             &&& content.get_create_request().namespace == obj.metadata.namespace.unwrap()
             &&& unmarshallable_object::<VReplicaSetView>(obj)
             &&& created_object_validity_check::<VReplicaSetView>(created_obj).is_none()

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -6,7 +6,7 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
-    api_server::state_machine::generated_name_is_unique,
+    api_server::state_machine::generate_name,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -20,6 +20,8 @@ use crate::v_replica_set_controller::{
     model::reconciler::{objects_to_pods, filter_pods},
 };
 use vstd::{multiset::*, prelude::*, string::*};
+
+use crate::kubernetes_cluster::spec::api_server::state_machine::handle_create_request;
 
 verus! {
 
@@ -252,13 +254,13 @@ pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_a
                     let local_step_prime = s_prime.ongoing_reconciles()[cr_key].local_state.reconcile_step;
                     let new_diff = local_step_prime.get_AfterDeletePod_0();
 
-                    //assert()
-
                     if local_step.is_AfterListPods() {
-                        assume(false); // TODO: Deal with later
+                        // TODO: Prove this case later
+                        assume(false);
                         // The proof is true in this case since AfterListPods
                         // will issue a delete on an element that has been filtered
                         // out using filter_pods
+                        // use something like the lemma lemma_filtered_pods_set_equals_matching_pods.
                     }
 
                     let controller_owners = obj.metadata.owner_references.unwrap().filter(
@@ -284,10 +286,11 @@ pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_a
                     match step {
                         Step::ApiServerStep(input) => {
                             let msg = input.unwrap();
+                            let content = msg.content;
                             if msg.content.is_create_request() {
-                                assume(false); // TODO: Deal with later
-                                // We need some other invariant or restriction to prove this,
-                                // the invariant as written is false.
+                                // TODO: Prove this case later
+                                // after the state machine has been modified to support delete preconditions.
+                                assume(false);
                             }
                         },
                         _ => {}

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -22,7 +22,7 @@ use vstd::{multiset::*, prelude::*, string::*};
 verus! {
 
 pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_on_pods(
-    spec: TempPred<VRSCluster>, vrs: VReplicaSetView
+    spec: TempPred<VRSCluster>
 )
     requires
         spec.entails(always(lift_state(VRSCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
@@ -69,6 +69,190 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
     VRSCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
     temp_pred_equality(
         lift_state(no_pending_update_or_update_status_request_on_pods()),
+        lift_state(VRSCluster::every_in_flight_req_msg_satisfies(requirements))
+    );
+}
+
+pub proof fn lemma_eventually_always_every_create_matching_pod_request_implies_at_after_create_pod_step(
+    spec: TempPred<VRSCluster>, vrs: VReplicaSetView
+)
+    requires
+        spec.entails(always(lift_state(VRSCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
+        spec.entails(always(lift_state(VRSCluster::crash_disabled()))),
+        spec.entails(always(lift_state(VRSCluster::busy_disabled()))),
+        spec.entails(always(lift_state(VRSCluster::pod_event_disabled()))),
+        spec.entails(always(lift_action(VRSCluster::next()))),
+        spec.entails(tla_forall(|i| VRSCluster::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| VRSCluster::external_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(VRSCluster::desired_state_is(vrs)))),
+    ensures spec.entails(true_pred().leads_to(always(lift_state(every_create_matching_pod_request_implies_at_after_create_pod_step(vrs))))),
+{
+    let requirements = |msg: VRSMessage, s: VRSCluster| {
+        ({
+            let content = msg.content;
+            let obj = content.get_create_request().obj;
+            &&& content.is_create_request()
+            &&& owned_selector_match_is(vrs, obj)
+        } ==> {
+            &&& exists |diff: usize| #[trigger] at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterCreatePod(diff))(s)
+            &&& VRSCluster::pending_req_msg_is(s, vrs.object_ref(), msg)
+        })
+    };
+
+    let stronger_next = |s: VRSCluster, s_prime: VRSCluster| {
+        &&& VRSCluster::next()(s, s_prime)
+        &&& VRSCluster::crash_disabled()(s)
+        &&& VRSCluster::busy_disabled()(s)
+        &&& VRSCluster::pod_event_disabled()(s)
+        &&& VRSCluster::desired_state_is(vrs)(s)
+    };
+
+    assert forall |s: VRSCluster, s_prime: VRSCluster| #[trigger]  #[trigger] stronger_next(s, s_prime) implies VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
+        assert forall |msg: VRSMessage| (!s.in_flight().contains(msg) || requirements(msg, s)) && #[trigger] s_prime.in_flight().contains(msg)
+        implies requirements(msg, s_prime) by {
+            if s.in_flight().contains(msg) {
+                assert(requirements(msg, s));
+
+                let content = msg.content;
+                let obj = content.get_create_request().obj;
+                if content.is_create_request() && owned_selector_match_is(vrs, obj) {
+                    let diff = choose |diff: usize| #[trigger] at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterCreatePod(diff))(s);
+                    let step = choose |step| VRSCluster::next_step(s, s_prime, step);
+                    match step {
+                        Step::ControllerStep(input) => {
+                            assume(false) // DEAL WITH LATER
+                        },
+                        _ => {
+                            assert(at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterCreatePod(diff))(s_prime));
+                            assert(requirements(msg, s_prime));
+                        }
+                    }
+                }
+
+                assert(requirements(msg, s_prime));
+            } else {
+                let step = choose |step| VRSCluster::next_step(s, s_prime, step);
+                match step {
+                    Step::ControllerStep(_) => {
+                        assume(false); // DEAL WITH LATER
+                    },
+                    _ => {
+                        assert(requirements(msg, s_prime));
+                    }
+                }
+            }
+        }
+    }
+
+    invariant_n!(
+        spec, lift_action(stronger_next), 
+        lift_action(VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
+        lift_action(VRSCluster::next()),
+        lift_state(VRSCluster::crash_disabled()),
+        lift_state(VRSCluster::busy_disabled()),
+        lift_state(VRSCluster::pod_event_disabled()),
+        lift_state(VRSCluster::desired_state_is(vrs))
+    );
+
+    VRSCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
+    temp_pred_equality(
+        lift_state(every_create_matching_pod_request_implies_at_after_create_pod_step(vrs)),
+        lift_state(VRSCluster::every_in_flight_req_msg_satisfies(requirements))
+    );
+}
+
+pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_at_after_delete_pod_step(
+    spec: TempPred<VRSCluster>, vrs: VReplicaSetView
+)
+    requires
+        spec.entails(always(lift_state(VRSCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
+        spec.entails(always(lift_state(VRSCluster::crash_disabled()))),
+        spec.entails(always(lift_state(VRSCluster::busy_disabled()))),
+        spec.entails(always(lift_state(VRSCluster::pod_event_disabled()))),
+        spec.entails(always(lift_action(VRSCluster::next()))),
+        spec.entails(tla_forall(|i| VRSCluster::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| VRSCluster::external_api_next().weak_fairness(i))),
+        spec.entails(always(lift_state(VRSCluster::desired_state_is(vrs)))),
+    ensures spec.entails(true_pred().leads_to(always(lift_state(every_delete_matching_pod_request_implies_at_after_delete_pod_step(vrs))))),
+{
+    let requirements = |msg: VRSMessage, s: VRSCluster| {
+        ({
+            let content = msg.content;
+            let key = content.get_delete_request().key;
+            let obj = s.resources()[key];
+            &&& content.is_delete_request()
+            &&& s.resources().contains_key(key)
+            &&& owned_selector_match_is(vrs, obj)
+        } ==> {
+            &&& exists |diff: usize| #[trigger] at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterDeletePod(diff))(s)
+            &&& VRSCluster::pending_req_msg_is(s, vrs.object_ref(), msg)
+        })
+    };
+
+    let stronger_next = |s: VRSCluster, s_prime: VRSCluster| {
+        &&& VRSCluster::next()(s, s_prime)
+        &&& VRSCluster::crash_disabled()(s)
+        &&& VRSCluster::busy_disabled()(s)
+        &&& VRSCluster::pod_event_disabled()(s)
+        &&& VRSCluster::desired_state_is(vrs)(s)
+    };
+
+    assert forall |s: VRSCluster, s_prime: VRSCluster| #[trigger]  #[trigger] stronger_next(s, s_prime) implies VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
+        assert forall |msg: VRSMessage| (!s.in_flight().contains(msg) || requirements(msg, s)) && #[trigger] s_prime.in_flight().contains(msg)
+        implies requirements(msg, s_prime) by {
+            if s.in_flight().contains(msg) {
+                assert(requirements(msg, s));
+
+                let content = msg.content;
+                let key = content.get_delete_request().key;
+                let obj = s.resources()[key];
+                if content.is_delete_request() 
+                    && s.resources().contains_key(key)
+                    && owned_selector_match_is(vrs, obj) {
+                    let diff = choose |diff: usize| #[trigger] at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterDeletePod(diff))(s);
+                    let step = choose |step| VRSCluster::next_step(s, s_prime, step);
+                    match step {
+                        Step::ControllerStep(input) => {
+                            assume(false) // DEAL WITH LATER
+                        },
+                        _ => {
+                            assert(at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterDeletePod(diff))(s_prime));
+                            assert(requirements(msg, s_prime));
+                        }
+                    }
+                } else {
+                    assume(false); // DEAL WITH LATER
+                }
+
+                assert(requirements(msg, s_prime));
+            } else {
+                assume(false); // DEAL WITH LATER
+                let step = choose |step| VRSCluster::next_step(s, s_prime, step);
+                match step {
+                    Step::ControllerStep(_) => {
+                        assume(false); // DEAL WITH LATER
+                    },
+                    _ => {
+                        assert(requirements(msg, s_prime));
+                    }
+                }
+            }
+        }
+    }
+
+    invariant_n!(
+        spec, lift_action(stronger_next), 
+        lift_action(VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
+        lift_action(VRSCluster::next()),
+        lift_state(VRSCluster::crash_disabled()),
+        lift_state(VRSCluster::busy_disabled()),
+        lift_state(VRSCluster::pod_event_disabled()),
+        lift_state(VRSCluster::desired_state_is(vrs))
+    );
+
+    VRSCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
+    temp_pred_equality(
+        lift_state(every_delete_matching_pod_request_implies_at_after_delete_pod_step(vrs)),
         lift_state(VRSCluster::every_in_flight_req_msg_satisfies(requirements))
     );
 }

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -31,6 +31,7 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
         spec.entails(always(lift_state(VRSCluster::pod_event_disabled()))),
         spec.entails(always(lift_action(VRSCluster::next()))),
         spec.entails(tla_forall(|i| VRSCluster::kubernetes_api_next().weak_fairness(i))),
+        spec.entails(tla_forall(|i| VRSCluster::external_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(VRSCluster::desired_state_is(vrs)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(no_pending_update_or_update_status_request_on_pods())))),
 {
@@ -43,6 +44,7 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
         &&& VRSCluster::next()(s, s_prime)
         &&& VRSCluster::desired_state_is(vrs)(s)
         &&& VRSCluster::each_object_in_etcd_is_well_formed()(s)
+        &&& VRSCluster::pod_event_disabled()(s)
     };
 
     assert forall |s: VRSCluster, s_prime: VRSCluster| #[trigger]  #[trigger] stronger_next(s, s_prime) implies VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
@@ -67,7 +69,8 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
         lift_action(VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
         lift_action(VRSCluster::next()), 
         lift_state(VRSCluster::desired_state_is(vrs)),
-        lift_state(VRSCluster::each_object_in_etcd_is_well_formed())
+        lift_state(VRSCluster::each_object_in_etcd_is_well_formed()),
+        lift_state(VRSCluster::pod_event_disabled())
     );
 
     VRSCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -136,15 +136,11 @@ pub proof fn lemma_eventually_always_every_create_matching_pod_request_implies_a
                 } else {
                     let step = choose |step| VRSCluster::next_step(s, s_prime, step);
                     let cr_key = step.get_ControllerStep_0().1.get_Some_0();
-                    assert(step.is_ControllerStep());
-                    assert(s.ongoing_reconciles().contains_key(cr_key));
                     let local_step = s.ongoing_reconciles()[cr_key].local_state.reconcile_step;
                     let local_step_prime = s_prime.ongoing_reconciles()[cr_key].local_state.reconcile_step;
-                    assert(local_step.is_AfterListPods() || local_step.is_AfterCreatePod());
-                    assert(local_step_prime.is_AfterCreatePod());
                     let new_diff = local_step_prime.get_AfterCreatePod_0();
-                    assume(key == cr_key); // How to prove this?
                     assert(at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterCreatePod(new_diff))(s_prime));
+                    assert(requirements(msg, s_prime));
                 }
             }
         }

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -6,6 +6,7 @@ use crate::kubernetes_api_objects::spec::{
     api_method::*, common::*, owner_reference::*, prelude::*, resource::*,
 };
 use crate::kubernetes_cluster::spec::{
+    api_server::state_machine::generated_name_is_unique,
     cluster::*,
     cluster_state_machine::Step,
     controller::types::{ControllerActionInput, ControllerStep},
@@ -16,6 +17,7 @@ use crate::vstd_ext::{multiset_lib, seq_lib, string_view::*};
 use crate::v_replica_set_controller::{
     proof::{predicate::*},
     trusted::{liveness_theorem::*, spec_types::*, step::*},
+    model::reconciler::{objects_to_pods, filter_pods},
 };
 use vstd::{multiset::*, prelude::*, string::*};
 
@@ -175,11 +177,20 @@ pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_a
         spec.entails(always(lift_state(VRSCluster::busy_disabled()))),
         spec.entails(always(lift_state(VRSCluster::pod_event_disabled()))),
         spec.entails(always(lift_action(VRSCluster::next()))),
+        spec.entails(always(lift_state(VRSCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()))),
+        spec.entails(always(lift_state(VRSCluster::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(VRSCluster::the_object_in_reconcile_has_spec_and_uid_as(vrs)))),
+        spec.entails(always(lift_state(VRSCluster::each_object_in_etcd_is_well_formed()))),
+        spec.entails(always(lift_state(VRSCluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
+        spec.entails(always(lift_state(each_vrs_in_reconcile_implies_filtered_pods_owned_by_vrs_if_in_etcd()))),
+        spec.entails(always(lift_state(no_pending_update_or_update_status_request_on_pods()))),
+        spec.entails(always(lift_state(every_create_request_is_well_formed()))),
         spec.entails(tla_forall(|i| VRSCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| VRSCluster::external_api_next().weak_fairness(i))),
         spec.entails(always(lift_state(VRSCluster::desired_state_is(vrs)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(every_delete_matching_pod_request_implies_at_after_delete_pod_step(vrs))))),
 {
+    let key = vrs.object_ref();
     let requirements = |msg: VRSMessage, s: VRSCluster| {
         ({
             let content = msg.content;
@@ -193,6 +204,14 @@ pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_a
             &&& VRSCluster::pending_req_msg_is(s, vrs.object_ref(), msg)
         })
     };
+    let requirements_antecedent = |msg: VRSMessage, s: VRSCluster| {
+        let content = msg.content;
+        let key = content.get_delete_request().key;
+        let obj = s.resources()[key];
+        &&& content.is_delete_request()
+        &&& s.resources().contains_key(key)
+        &&& owned_selector_match_is(vrs, obj)
+    };
 
     let stronger_next = |s: VRSCluster, s_prime: VRSCluster| {
         &&& VRSCluster::next()(s, s_prime)
@@ -200,47 +219,80 @@ pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_a
         &&& VRSCluster::busy_disabled()(s)
         &&& VRSCluster::pod_event_disabled()(s)
         &&& VRSCluster::desired_state_is(vrs)(s)
+        &&& VRSCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()(s)
+        &&& VRSCluster::every_in_flight_msg_has_unique_id()(s)
+        &&& VRSCluster::the_object_in_reconcile_has_spec_and_uid_as(vrs)(s)
+        &&& VRSCluster::each_object_in_etcd_is_well_formed()(s)
+        &&& VRSCluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
+        &&& each_vrs_in_reconcile_implies_filtered_pods_owned_by_vrs_if_in_etcd()(s)
+        &&& no_pending_update_or_update_status_request_on_pods()(s)
+        &&& every_create_request_is_well_formed()(s)
     };
 
     assert forall |s: VRSCluster, s_prime: VRSCluster| #[trigger]  #[trigger] stronger_next(s, s_prime) implies VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
         assert forall |msg: VRSMessage| (!s.in_flight().contains(msg) || requirements(msg, s)) && #[trigger] s_prime.in_flight().contains(msg)
         implies requirements(msg, s_prime) by {
-            if s.in_flight().contains(msg) {
-                assert(requirements(msg, s));
+            if requirements_antecedent(msg, s) {
+                if s.in_flight().contains(msg) {
+                    assert(requirements(msg, s));
 
-                let content = msg.content;
-                let key = content.get_delete_request().key;
-                let obj = s.resources()[key];
-                if content.is_delete_request() 
-                    && s.resources().contains_key(key)
-                    && owned_selector_match_is(vrs, obj) {
                     let diff = choose |diff: usize| #[trigger] at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterDeletePod(diff))(s);
+                    assert(s.ongoing_reconciles()[key] == s_prime.ongoing_reconciles()[key]);
+                    assert(at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterDeletePod(diff))(s_prime)
+                        || at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterDeletePod((diff + 1) as usize))(s_prime));
+
+                    assert(requirements(msg, s_prime));
+                } else {
+                    let content = msg.content;
+                    let obj = s.resources()[content.get_delete_request().key];
+
+                    let step = choose |step| VRSCluster::next_step(s, s_prime, step);
+                    let cr_key = step.get_ControllerStep_0().1.get_Some_0();
+                    let local_step = s.ongoing_reconciles()[cr_key].local_state.reconcile_step;
+                    let local_step_prime = s_prime.ongoing_reconciles()[cr_key].local_state.reconcile_step;
+                    let new_diff = local_step_prime.get_AfterDeletePod_0();
+
+                    //assert()
+
+                    if local_step.is_AfterListPods() {
+                        assume(false); // TODO: Deal with later
+                        // The proof is true in this case since AfterListPods
+                        // will issue a delete on an element that has been filtered
+                        // out using filter_pods
+                    }
+
+                    let controller_owners = obj.metadata.owner_references.unwrap().filter(
+                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                    );
+                    assert(controller_owners.contains(
+                        s.ongoing_reconciles()[cr_key].triggering_cr.controller_owner_ref()
+                    ));
+                    assert(controller_owners.contains(vrs.controller_owner_ref()));
+
+                    assert(cr_key.name == key.name);
+                    assert(at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterDeletePod(new_diff))(s_prime));
+                    assert(requirements(msg, s_prime));
+                }
+            } else {
+                if s.in_flight().contains(msg) {
+                    assert(!requirements_antecedent(msg, s));
+                    let content = msg.content;
+                    let key = content.get_delete_request().key;
+                    let obj = s.resources()[key];
+
                     let step = choose |step| VRSCluster::next_step(s, s_prime, step);
                     match step {
-                        Step::ControllerStep(input) => {
-                            assume(false) // DEAL WITH LATER
+                        Step::ApiServerStep(input) => {
+                            let msg = input.unwrap();
+                            if msg.content.is_create_request() {
+                                assume(false); // TODO: Deal with later
+                                // We need some other invariant or restriction to prove this,
+                                // the invariant as written is false.
+                            }
                         },
-                        _ => {
-                            assert(at_vrs_step_with_vrs(vrs, VReplicaSetReconcileStep::AfterDeletePod(diff))(s_prime));
-                            assert(requirements(msg, s_prime));
-                        }
+                        _ => {}
                     }
-                } else {
-                    assume(false); // DEAL WITH LATER
-                }
-
-                assert(requirements(msg, s_prime));
-            } else {
-                assume(false); // DEAL WITH LATER
-                let step = choose |step| VRSCluster::next_step(s, s_prime, step);
-                match step {
-                    Step::ControllerStep(_) => {
-                        assume(false); // DEAL WITH LATER
-                    },
-                    _ => {
-                        assert(requirements(msg, s_prime));
-                    }
-                }
+                }            
             }
         }
     }
@@ -252,7 +304,15 @@ pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_a
         lift_state(VRSCluster::crash_disabled()),
         lift_state(VRSCluster::busy_disabled()),
         lift_state(VRSCluster::pod_event_disabled()),
-        lift_state(VRSCluster::desired_state_is(vrs))
+        lift_state(VRSCluster::desired_state_is(vrs)),
+        lift_state(VRSCluster::each_object_in_reconcile_has_consistent_key_and_valid_metadata()),
+        lift_state(VRSCluster::every_in_flight_msg_has_unique_id()),
+        lift_state(VRSCluster::the_object_in_reconcile_has_spec_and_uid_as(vrs)),
+        lift_state(VRSCluster::each_object_in_etcd_is_well_formed()),
+        lift_state(VRSCluster::each_object_in_etcd_has_at_most_one_controller_owner()),
+        lift_state(each_vrs_in_reconcile_implies_filtered_pods_owned_by_vrs_if_in_etcd()),
+        lift_state(no_pending_update_or_update_status_request_on_pods()),
+        lift_state(every_create_request_is_well_formed())
     );
 
     VRSCluster::lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -25,14 +25,11 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
     spec: TempPred<VRSCluster>, vrs: VReplicaSetView
 )
     requires
-        spec.entails(always(lift_state(VRSCluster::each_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(VRSCluster::every_in_flight_msg_has_lower_id_than_allocator()))),
-        spec.entails(always(lift_state(VRSCluster::busy_disabled()))),
         spec.entails(always(lift_state(VRSCluster::pod_event_disabled()))),
         spec.entails(always(lift_action(VRSCluster::next()))),
         spec.entails(tla_forall(|i| VRSCluster::kubernetes_api_next().weak_fairness(i))),
         spec.entails(tla_forall(|i| VRSCluster::external_api_next().weak_fairness(i))),
-        spec.entails(always(lift_state(VRSCluster::desired_state_is(vrs)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(no_pending_update_or_update_status_request_on_pods())))),
 {
     let requirements = |msg: VRSMessage, s: VRSCluster| {
@@ -42,8 +39,6 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
 
     let stronger_next = |s: VRSCluster, s_prime: VRSCluster| {
         &&& VRSCluster::next()(s, s_prime)
-        &&& VRSCluster::desired_state_is(vrs)(s)
-        &&& VRSCluster::each_object_in_etcd_is_well_formed()(s)
         &&& VRSCluster::pod_event_disabled()(s)
     };
 
@@ -67,9 +62,7 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
     invariant_n!(
         spec, lift_action(stronger_next), 
         lift_action(VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
-        lift_action(VRSCluster::next()), 
-        lift_state(VRSCluster::desired_state_is(vrs)),
-        lift_state(VRSCluster::each_object_in_etcd_is_well_formed()),
+        lift_action(VRSCluster::next()),
         lift_state(VRSCluster::pod_event_disabled())
     );
 

--- a/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/helper_invariants/proof.rs
@@ -46,7 +46,20 @@ pub proof fn lemma_eventually_always_no_pending_update_or_update_status_request_
     };
 
     assert forall |s: VRSCluster, s_prime: VRSCluster| #[trigger]  #[trigger] stronger_next(s, s_prime) implies VRSCluster::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
-        assume(false);
+        assert forall |msg: VRSMessage| (!s.in_flight().contains(msg) || requirements(msg, s)) && #[trigger] s_prime.in_flight().contains(msg)
+        implies requirements(msg, s_prime) by {
+            if s.in_flight().contains(msg) {
+                assert(requirements(msg, s));
+                assert(requirements(msg, s_prime));
+            } else {
+                let step = choose |step| VRSCluster::next_step(s, s_prime, step);
+                match step {
+                    _ => {
+                        assert(requirements(msg, s_prime));
+                    }
+                }
+            }
+        }
     }
 
     invariant_n!(

--- a/src/controller_examples/v_replica_set_controller/proof/liveness/api_actions.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/liveness/api_actions.rs
@@ -42,6 +42,7 @@ pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_
     // Dispatch through all the requests which may mutate the k-v store.
     let mutates_key = if msg.content.is_create_request() {
         let req = msg.content.get_create_request();
+        //assume(false);
         Some(ObjectRef{
             kind: req.obj.kind,
             name: if req.obj.metadata.name.is_Some() {

--- a/src/controller_examples/v_replica_set_controller/proof/liveness/api_actions.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/liveness/api_actions.rs
@@ -42,7 +42,6 @@ pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_
     // Dispatch through all the requests which may mutate the k-v store.
     let mutates_key = if msg.content.is_create_request() {
         let req = msg.content.get_create_request();
-        //assume(false);
         Some(ObjectRef{
             kind: req.obj.kind,
             name: if req.obj.metadata.name.is_Some() {

--- a/src/controller_examples/v_replica_set_controller/proof/liveness/resource_match.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/liveness/resource_match.rs
@@ -16,7 +16,7 @@ use crate::kubernetes_cluster::spec::{
 use crate::temporal_logic::{defs::*, rules::*};
 use crate::v_replica_set_controller::{
     model::reconciler::*,
-    proof::{helper_invariants, liveness::api_actions::*, predicate::*},
+    proof::{utility_lemmas::*, helper_invariants, liveness::api_actions::*, predicate::*},
     trusted::{liveness_theorem::*, spec_types::*, step::*},
 };
 use crate::vstd_ext::{map_lib::*, seq_lib::*, set_lib::*, string_view::*};

--- a/src/controller_examples/v_replica_set_controller/proof/liveness/spec.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/liveness/spec.rs
@@ -69,62 +69,6 @@ pub open spec fn spec_before_phase_n(n: nat, vrs: VReplicaSetView) -> TempPred<V
     }
 }
 
-pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(i: nat, vrs: VReplicaSetView)
-    requires 1 <= i <= 7,
-    ensures spec_before_phase_n(i, vrs).entails(true_pred().leads_to(invariants_since_phase_n(i, vrs))),
-{
-    let spec = spec_before_phase_n(i, vrs);
-    reveal_with_fuel(spec_before_phase_n, 8);
-    if i == 1 {
-        VRSCluster::lemma_true_leads_to_crash_always_disabled(spec);
-        VRSCluster::lemma_true_leads_to_busy_always_disabled(spec);
-        VRSCluster::lemma_true_leads_to_pod_event_always_disabled(spec);
-        VRSCluster::lemma_true_leads_to_always_the_object_in_schedule_has_spec_and_uid_as(spec, vrs);
-        leads_to_always_combine_n!(
-            spec,
-            true_pred(),
-            lift_state(VRSCluster::crash_disabled()),
-            lift_state(VRSCluster::busy_disabled()),
-            lift_state(VRSCluster::pod_event_disabled()),
-            lift_state(VRSCluster::the_object_in_schedule_has_spec_and_uid_as(vrs))
-        );
-    } else {
-        assume(false);
-        // terminate::reconcile_eventually_terminates(spec, vrs);
-        // if i == 2 {
-        //     VRSCluster::lemma_true_leads_to_always_the_object_in_reconcile_has_spec_and_uid_as(spec, vrs);
-        // } else if i == 3 {
-        //     helper_invariants::lemma_always_vrs_is_well_formed(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_every_resource_create_request_implies_at_after_create_resource_step_forall(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr_forall(spec, vrs);
-        //     let a_to_p_1 = |sub_resource: SubResource| lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, vrs));
-        //     let a_to_p_2 = |sub_resource: SubResource| lift_state(helper_invariants::object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(sub_resource, vrs));
-        //     helper_invariants::lemma_eventually_always_every_zk_set_data_request_implies_at_after_update_zk_node_step(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_every_zk_create_node_request_implies_at_after_create_zk_node_step(spec, vrs);
-        //     leads_to_always_combine_n!(
-        //         spec, true_pred(), tla_forall(a_to_p_1), tla_forall(a_to_p_2),
-        //         lift_state(helper_invariants::every_zk_set_data_request_implies_at_after_update_zk_node_step(vrs)),
-        //         lift_state(helper_invariants::every_zk_create_node_request_implies_at_after_create_zk_node_step(vrs))
-        //     );
-        // } else if i == 4 {
-        //     helper_invariants::lemma_eventually_always_resource_object_only_has_owner_reference_pointing_to_current_cr_forall(spec, vrs);
-        // } else if i == 5 {
-        //     helper_invariants::lemma_eventually_always_no_delete_resource_request_msg_in_flight_forall(spec, vrs);
-        // } else if i == 6 {
-        //     helper_invariants::lemma_eventually_always_every_resource_update_request_implies_at_after_update_resource_step_forall(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_object_in_response_at_after_create_resource_step_is_same_as_etcd_forall(spec, vrs);
-        //     helper_invariants::lemma_eventually_always_object_in_response_at_after_update_resource_step_is_same_as_etcd_forall(spec, vrs);
-        //     let a_to_p_1 = |sub_resource: SubResource| lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(sub_resource, vrs));
-        //     leads_to_always_combine_n!(
-        //         spec, true_pred(),
-        //         tla_forall(a_to_p_1), lift_state(helper_invariants::object_in_response_at_after_create_resource_step_is_same_as_etcd(SubResource::ConfigMap, vrs)), lift_state(helper_invariants::object_in_response_at_after_update_resource_step_is_same_as_etcd(SubResource::ConfigMap, vrs))
-        //     );
-        // } else if i == 7 {
-        //     helper_invariants::lemma_eventually_always_cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated_forall(spec, vrs);
-        // }
-    }
-}
-
 #[verifier(external_body)]
 pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(i: nat, vrs: VReplicaSetView)
     requires 1 <= i <= 7,
@@ -155,6 +99,7 @@ pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(i: nat, v
         }
     }
 }
+
 
 #[verifier(external_body)]
 pub proof fn assumption_and_invariants_of_all_phases_is_stable(vrs: VReplicaSetView)

--- a/src/controller_examples/v_replica_set_controller/proof/liveness/spec.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/liveness/spec.rs
@@ -69,6 +69,62 @@ pub open spec fn spec_before_phase_n(n: nat, vrs: VReplicaSetView) -> TempPred<V
     }
 }
 
+pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(i: nat, vrs: VReplicaSetView)
+    requires 1 <= i <= 7,
+    ensures spec_before_phase_n(i, vrs).entails(true_pred().leads_to(invariants_since_phase_n(i, vrs))),
+{
+    let spec = spec_before_phase_n(i, vrs);
+    reveal_with_fuel(spec_before_phase_n, 8);
+    if i == 1 {
+        VRSCluster::lemma_true_leads_to_crash_always_disabled(spec);
+        VRSCluster::lemma_true_leads_to_busy_always_disabled(spec);
+        VRSCluster::lemma_true_leads_to_pod_event_always_disabled(spec);
+        VRSCluster::lemma_true_leads_to_always_the_object_in_schedule_has_spec_and_uid_as(spec, vrs);
+        leads_to_always_combine_n!(
+            spec,
+            true_pred(),
+            lift_state(VRSCluster::crash_disabled()),
+            lift_state(VRSCluster::busy_disabled()),
+            lift_state(VRSCluster::pod_event_disabled()),
+            lift_state(VRSCluster::the_object_in_schedule_has_spec_and_uid_as(vrs))
+        );
+    } else {
+        assume(false);
+        // terminate::reconcile_eventually_terminates(spec, vrs);
+        // if i == 2 {
+        //     VRSCluster::lemma_true_leads_to_always_the_object_in_reconcile_has_spec_and_uid_as(spec, vrs);
+        // } else if i == 3 {
+        //     helper_invariants::lemma_always_vrs_is_well_formed(spec, vrs);
+        //     helper_invariants::lemma_eventually_always_every_resource_create_request_implies_at_after_create_resource_step_forall(spec, vrs);
+        //     helper_invariants::lemma_eventually_always_object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr_forall(spec, vrs);
+        //     let a_to_p_1 = |sub_resource: SubResource| lift_state(helper_invariants::every_resource_create_request_implies_at_after_create_resource_step(sub_resource, vrs));
+        //     let a_to_p_2 = |sub_resource: SubResource| lift_state(helper_invariants::object_in_every_resource_update_request_only_has_owner_references_pointing_to_current_cr(sub_resource, vrs));
+        //     helper_invariants::lemma_eventually_always_every_zk_set_data_request_implies_at_after_update_zk_node_step(spec, vrs);
+        //     helper_invariants::lemma_eventually_always_every_zk_create_node_request_implies_at_after_create_zk_node_step(spec, vrs);
+        //     leads_to_always_combine_n!(
+        //         spec, true_pred(), tla_forall(a_to_p_1), tla_forall(a_to_p_2),
+        //         lift_state(helper_invariants::every_zk_set_data_request_implies_at_after_update_zk_node_step(vrs)),
+        //         lift_state(helper_invariants::every_zk_create_node_request_implies_at_after_create_zk_node_step(vrs))
+        //     );
+        // } else if i == 4 {
+        //     helper_invariants::lemma_eventually_always_resource_object_only_has_owner_reference_pointing_to_current_cr_forall(spec, vrs);
+        // } else if i == 5 {
+        //     helper_invariants::lemma_eventually_always_no_delete_resource_request_msg_in_flight_forall(spec, vrs);
+        // } else if i == 6 {
+        //     helper_invariants::lemma_eventually_always_every_resource_update_request_implies_at_after_update_resource_step_forall(spec, vrs);
+        //     helper_invariants::lemma_eventually_always_object_in_response_at_after_create_resource_step_is_same_as_etcd_forall(spec, vrs);
+        //     helper_invariants::lemma_eventually_always_object_in_response_at_after_update_resource_step_is_same_as_etcd_forall(spec, vrs);
+        //     let a_to_p_1 = |sub_resource: SubResource| lift_state(helper_invariants::every_resource_update_request_implies_at_after_update_resource_step(sub_resource, vrs));
+        //     leads_to_always_combine_n!(
+        //         spec, true_pred(),
+        //         tla_forall(a_to_p_1), lift_state(helper_invariants::object_in_response_at_after_create_resource_step_is_same_as_etcd(SubResource::ConfigMap, vrs)), lift_state(helper_invariants::object_in_response_at_after_update_resource_step_is_same_as_etcd(SubResource::ConfigMap, vrs))
+        //     );
+        // } else if i == 7 {
+        //     helper_invariants::lemma_eventually_always_cm_rv_is_the_same_as_etcd_server_cm_if_cm_updated_forall(spec, vrs);
+        // }
+    }
+}
+
 #[verifier(external_body)]
 pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(i: nat, vrs: VReplicaSetView)
     requires 1 <= i <= 7,

--- a/src/controller_examples/v_replica_set_controller/proof/mod.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/mod.rs
@@ -3,3 +3,4 @@
 pub mod helper_invariants;
 pub mod liveness;
 pub mod predicate;
+pub mod utility_lemmas;

--- a/src/controller_examples/v_replica_set_controller/proof/utility_lemmas.rs
+++ b/src/controller_examples/v_replica_set_controller/proof/utility_lemmas.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: MIT
+#![allow(unused_imports)]
+use crate::kubernetes_api_objects::spec::{
+    api_method::*, common::*, prelude::*, resource::*, stateful_set::*,
+};
+use crate::kubernetes_cluster::proof::controller_runtime::*;
+use crate::kubernetes_cluster::spec::{
+    cluster::*,
+    cluster_state_machine::Step,
+    controller::types::{ControllerActionInput, ControllerStep},
+    message::*,
+};
+use crate::temporal_logic::defs::*;
+use crate::v_replica_set_controller::model::{reconciler::*};
+use crate::v_replica_set_controller::trusted::{
+    liveness_theorem::*, spec_types::*, step::*,
+};
+use crate::v_replica_set_controller::proof::{
+    predicate::*,
+};
+use vstd::{prelude::*, math::abs};
+
+verus! {
+
+#[verifier(external_body)]
+pub proof fn lemma_filtered_pods_set_equals_matching_pods(
+    s: VRSCluster, vrs: VReplicaSetView, resp_msg: VRSMessage
+)
+    ensures
+        ({
+            let objs = resp_msg.content.get_list_response().res.unwrap();
+            let pods_or_none = objects_to_pods(objs);
+            let pods = pods_or_none.unwrap();
+            let filtered_pods = filter_pods(pods, vrs);
+            &&& filtered_pods.no_duplicates()
+            &&& filtered_pods.len() == matching_pod_entries(vrs, s.resources()).len()
+            &&& filtered_pods.map_values(|p: PodView| p.marshal()).to_set() == matching_pod_entries(vrs, s.resources()).values()
+        }),
+{}
+//
+// TODO: Prove this.
+//
+// filter_pods filters pods in a very similar way to matching_pods, but the former
+// works on a sequence of PodViews, while the latter works on the key-value store directly.
+// I need to do some manual effort to make the two representations work together.
+//
+// Once proven, this will supplant the earlier lemma
+// lemma_filtered_pods_len_equals_matching_pods_len.
+//
+
+}

--- a/src/controller_examples/v_replica_set_controller/trusted/liveness_theorem.rs
+++ b/src/controller_examples/v_replica_set_controller/trusted/liveness_theorem.rs
@@ -37,7 +37,8 @@ pub open spec fn resource_state_matches(vrs: VReplicaSetView, resources: StoredS
 
 pub open spec fn owned_selector_match_is(vrs: VReplicaSetView, obj: DynamicObjectView) -> bool {
     &&& obj.kind == PodView::kind()
-    &&& obj.metadata.namespace.unwrap() == vrs.metadata.namespace.unwrap()
+    &&& obj.metadata.namespace.is_Some()
+    &&& obj.metadata.namespace == vrs.metadata.namespace
     &&& obj.metadata.owner_references_contains(vrs.controller_owner_ref())
     &&& vrs.spec.selector.matches(obj.metadata.labels.unwrap_or(Map::empty()))
     &&& obj.metadata.deletion_timestamp.is_None()

--- a/src/kubernetes_cluster/proof/cluster_safety.rs
+++ b/src/kubernetes_cluster/proof/cluster_safety.rs
@@ -107,6 +107,22 @@ pub proof fn lemma_always_each_object_in_etcd_is_well_formed(spec: TempPred<Self
     init_invariant(spec, Self::init(), Self::next(), invariant);
 }
 
+// TODO: Prove this.
+pub open spec fn each_object_in_etcd_has_at_most_one_controller_owner() -> StatePred<Self> {
+    |s: Self| {
+        forall |key: ObjectRef|
+            #[trigger] s.resources().contains_key(key)
+                ==> {
+                    let obj = s.resources()[key];
+                    let owners = obj.metadata.owner_references.get_Some_0();
+                    let controller_owners = owners.filter(
+                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                    );
+                    obj.metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                }
+    }
+}
+
 pub open spec fn each_scheduled_object_has_consistent_key_and_valid_metadata() -> StatePred<Self> {
     |s: Self| {
         forall |key: ObjectRef|


### PR DESCRIPTION
The following invariants have been proven:
`every_create_matching_pod_request_implies_at_after_create_pod_step`
`every_delete_matching_pod_request_implies_at_after_delete_pod_step` (partially).

Investigating the latter led to addition of delete preconditions to the V2 state machine to which the controller will be ported.

