### PR TITLE
Add helper function for installing reconcile model

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/model/install.rs
+++ b/src/v2/controllers/vreplicaset_controller/model/install.rs
@@ -1,40 +1,12 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-use crate::external_api::spec::EmptyTypeView;
 use crate::kubernetes_api_objects::{error::*, spec::prelude::*};
-use crate::kubernetes_cluster::spec::{
-    api_server::types::InstalledType,
-    cluster::ControllerModel,
-    controller::types::{ReconcileModel, RequestContent, ResponseContent},
-    install_helpers::*,
-};
-use crate::reconciler::spec::io::{RequestView, ResponseView};
-use crate::reconciler::spec::reconciler::Reconciler;
+use crate::kubernetes_cluster::spec::cluster::{Cluster, ControllerModel};
 use crate::vreplicaset_controller::model::reconciler::*;
 use crate::vreplicaset_controller::trusted::spec_types::*;
 use vstd::prelude::*;
 
 verus! {
-
-pub open spec fn vrs_installed_type() -> InstalledType {
-    InstalledType {
-        unmarshallable_spec: |v| {
-            InstallTypeHelper::<VReplicaSetView>::unmarshal_spec(v)
-        },
-        unmarshallable_status: |v| {
-            InstallTypeHelper::<VReplicaSetView>::unmarshal_status(v)
-        },
-        valid_object: |obj| {
-            InstallTypeHelper::<VReplicaSetView>::valid_object(obj)
-        },
-        valid_transition: |obj, old_obj| {
-            InstallTypeHelper::<VReplicaSetView>::valid_transition(obj, old_obj)
-        },
-        marshalled_default_status: || {
-            InstallTypeHelper::<VReplicaSetView>::marshalled_default_status()
-        }
-    }
-}
 
 impl Marshallable for VReplicaSetReconcileState {
     spec fn marshal(self) -> Value;
@@ -47,48 +19,9 @@ impl Marshallable for VReplicaSetReconcileState {
     {}
 }
 
-impl Marshallable for EmptyTypeView {
-    spec fn marshal(self) -> Value;
-
-    spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
-
-    #[verifier(external_body)]
-    proof fn marshal_preserves_integrity()
-        ensures forall |o: Self| Self::unmarshal(#[trigger] o.marshal()).is_Ok() && o == Self::unmarshal(o.marshal()).get_Ok_0()
-    {}
-}
-
-pub open spec fn vrs_reconcile_model() -> ReconcileModel {
-    ReconcileModel {
-        kind: VReplicaSetView::kind(),
-        init: || VReplicaSetReconciler::reconcile_init_state().marshal(),
-        transition: |obj, resp_o, s| {
-            let obj_um = VReplicaSetView::unmarshal(obj).get_Ok_0();
-            let resp_o_um = match resp_o {
-                None => None,
-                Some(resp) => Some(match resp {
-                    ResponseContent::KubernetesResponse(api_resp) => ResponseView::<EmptyTypeView>::KResponse(api_resp),
-                    ResponseContent::ExternalResponse(ext_resp) => ResponseView::<EmptyTypeView>::ExternalResponse(EmptyTypeView::unmarshal(ext_resp).get_Ok_0()),
-                })
-            };
-            let s_um = VReplicaSetReconcileState::unmarshal(s).get_Ok_0();
-            let (s_prime_um, req_o_um) = VReplicaSetReconciler::reconcile_core(obj_um, resp_o_um, s_um);
-            (s_prime_um.marshal(), match req_o_um {
-                None => None,
-                Some(req) => Some(match req {
-                    RequestView::<EmptyTypeView>::KRequest(api_req) => RequestContent::KubernetesRequest(api_req),
-                    RequestView::<EmptyTypeView>::ExternalRequest(ext_req) => RequestContent::ExternalRequest(ext_req.marshal()),
-                })
-            })
-        },
-        done: |s| VReplicaSetReconciler::reconcile_done(VReplicaSetReconcileState::unmarshal(s).get_Ok_0()),
-        error: |s| VReplicaSetReconciler::reconcile_error(VReplicaSetReconcileState::unmarshal(s).get_Ok_0()),
-    }
-}
-
 pub open spec fn vrs_controller_model() -> ControllerModel {
     ControllerModel {
-        reconcile_model: vrs_reconcile_model(),
+        reconcile_model: Cluster::installed_reconcile_model::<VReplicaSetReconciler>(),
         external_model: None,
     }
 }

--- a/src/v2/controllers/vreplicaset_controller/model/reconciler.rs
+++ b/src/v2/controllers/vreplicaset_controller/model/reconciler.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::external_api::spec::*;
 use crate::kubernetes_api_objects::spec::prelude::*;
 use crate::reconciler::spec::{io::*, reconciler::*};
 use crate::vreplicaset_controller::trusted::{spec_types::*, step::*};
@@ -9,25 +8,32 @@ use vstd::{prelude::*, string::*};
 
 verus! {
 
-impl Reconciler for VReplicaSetReconciler {
-    type T = VReplicaSetReconcileState;
-    type K = VReplicaSetView;
-    type E = EmptyAPI;
+pub struct VReplicaSetReconciler {}
 
-    open spec fn reconcile_init_state() -> VReplicaSetReconcileState {
+pub struct VReplicaSetReconcileState {
+    pub reconcile_step: VReplicaSetReconcileStep,
+    pub filtered_pods: Option<Seq<PodView>>,
+}
+
+impl Reconciler for VReplicaSetReconciler {
+    type S = VReplicaSetReconcileState;
+    type K = VReplicaSetView;
+    type EReq = VoidEReqView;
+    type EResp = VoidERespView;
+
+    open spec fn reconcile_init_state() -> Self::S {
         reconcile_init_state()
     }
 
-    open spec fn reconcile_core(fb: VReplicaSetView, resp_o: Option<ResponseView<EmptyTypeView>>, state: VReplicaSetReconcileState)
-    -> (VReplicaSetReconcileState, Option<RequestView<EmptyTypeView>>) {
+    open spec fn reconcile_core(fb: Self::K, resp_o: Option<ResponseView<Self::EResp>>, state: Self::S) -> (Self::S, Option<RequestView<Self::EReq>>) {
         reconcile_core(fb, resp_o, state)
     }
 
-    open spec fn reconcile_done(state: VReplicaSetReconcileState) -> bool {
+    open spec fn reconcile_done(state: Self::S) -> bool {
         reconcile_done(state)
     }
 
-    open spec fn reconcile_error(state: VReplicaSetReconcileState) -> bool {
+    open spec fn reconcile_error(state: Self::S) -> bool {
         reconcile_error(state)
     }
 }
@@ -53,9 +59,7 @@ pub open spec fn reconcile_error(state: VReplicaSetReconcileState) -> bool {
     }
 }
 
-pub open spec fn reconcile_core(
-    v_replica_set: VReplicaSetView, resp_o: Option<ResponseView<EmptyTypeView>>, state: VReplicaSetReconcileState
-) -> (VReplicaSetReconcileState, Option<RequestView<EmptyTypeView>>) {
+pub open spec fn reconcile_core(v_replica_set: VReplicaSetView, resp_o: Option<ResponseView<VoidERespView>>, state: VReplicaSetReconcileState) -> (VReplicaSetReconcileState, Option<RequestView<VoidEReqView>>) {
     let namespace = v_replica_set.metadata.namespace.unwrap();
     match &state.reconcile_step {
         VReplicaSetReconcileStep::Init => {

--- a/src/v2/controllers/vreplicaset_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/exec_types.rs
@@ -12,42 +12,6 @@ use vstd::prelude::*;
 
 verus! {
 
-// VReplicaSetReconcileState describes the local state with which the reconcile functions makes decisions.
-pub struct VReplicaSetReconcileState {
-    pub reconcile_step: VReplicaSetReconcileStep,
-    pub filtered_pods: Option<Vec<Pod>>,
-}
-
-// impl std::clone::Clone for VReplicaSetReconcileState {
-
-//     #[verifier(external_body)]
-//     fn clone(&self) -> (result: VReplicaSetReconcileState)
-//         ensures result == self
-//     {
-//         VReplicaSetReconcileState {
-//             reconcile_step: self.reconcile_step,
-//             filtered_pods: match self.filtered_pods {
-//                 Some(fp) => Some(fp.clone()),
-//                 None => None,
-//             },
-//         }
-//     }
-// }
-
-impl View for VReplicaSetReconcileState {
-    type V = spec_types::VReplicaSetReconcileState;
-
-    open spec fn view(&self) -> spec_types::VReplicaSetReconcileState {
-        spec_types::VReplicaSetReconcileState {
-            reconcile_step: self.reconcile_step,
-            filtered_pods: match self.filtered_pods {
-                Some(fp) => Some(fp@.map_values(|p: Pod| p@)),
-                None => None,
-            },
-        }
-    }
-}
-
 #[verifier(external_body)]
 pub struct VReplicaSet {
     inner: deps_hack::VReplicaSet

--- a/src/v2/controllers/vreplicaset_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/spec_types.rs
@@ -1,6 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-use crate::external_api::spec::{EmptyAPI, EmptyTypeView};
 use crate::kubernetes_api_objects::error::*;
 use crate::kubernetes_api_objects::spec::{
     api_resource::*, label_selector::*, pod_template_spec::*, prelude::*,
@@ -12,13 +11,6 @@ use vstd::prelude::*;
 
 verus! {
 
-pub struct VReplicaSetReconciler {}
-
-pub struct VReplicaSetReconcileState {
-    pub reconcile_step: VReplicaSetReconcileStep,
-    pub filtered_pods: Option<Seq<PodView>>,
-}
-
 pub struct VReplicaSetView {
     pub metadata: ObjectMetaView,
     pub spec: VReplicaSetSpecView,
@@ -28,6 +20,7 @@ pub struct VReplicaSetView {
 pub type VReplicaSetStatusView = EmptyStatusView;
 
 impl VReplicaSetView {
+    // TODO: well_formed should just call state_validation
     pub open spec fn well_formed(self) -> bool {
         &&& self.metadata.name.is_Some()
         &&& self.metadata.namespace.is_Some()

--- a/src/v2/kubernetes_cluster/proof/objects_in_store.rs
+++ b/src/v2/kubernetes_cluster/proof/objects_in_store.rs
@@ -140,16 +140,6 @@ pub open spec fn each_custom_object_in_etcd_is_well_formed<T: CustomResourceView
     }
 }
 
-pub open spec fn type_is_installed_in_cluster<T: CustomResourceView>(self) -> bool {
-    let string = T::kind().get_CustomResourceKind_0();
-    &&& self.installed_types.contains_key(string)
-    &&& self.installed_types[string].unmarshallable_spec == |v: Value| InstallTypeHelper::<T>::unmarshal_spec(v)
-    &&& self.installed_types[string].unmarshallable_status == |v: Value| InstallTypeHelper::<T>::unmarshal_status(v)
-    &&& self.installed_types[string].valid_object == |obj: DynamicObjectView| InstallTypeHelper::<T>::valid_object(obj)
-    &&& self.installed_types[string].valid_transition == |obj, old_obj: DynamicObjectView| InstallTypeHelper::<T>::valid_transition(obj, old_obj)
-    &&& self.installed_types[string].marshalled_default_status == || InstallTypeHelper::<T>::marshalled_default_status()
-}
-
 pub proof fn lemma_always_each_custom_object_in_etcd_is_well_formed<T: CustomResourceView>(self, spec: TempPred<ClusterState>)
     requires
         spec.entails(lift_state(self.init())),

--- a/src/v2/kubernetes_cluster/spec/install_helpers.rs
+++ b/src/v2/kubernetes_cluster/spec/install_helpers.rs
@@ -1,35 +1,65 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::spec::prelude::*;
-use crate::kubernetes_cluster::spec::{api_server::types::*, controller::types::*};
+use crate::kubernetes_cluster::spec::{
+    api_server::types::*, cluster::Cluster, controller::types::*,
+};
+use crate::reconciler::spec::{io::*, reconciler::*};
 use vstd::prelude::*;
 
 verus! {
 
-pub struct InstallTypeHelper<T: CustomResourceView> {
-    dummy: core::marker::PhantomData<T>,
+impl Cluster {
+
+pub open spec fn installed_type<T: CustomResourceView>() -> InstalledType {
+    InstalledType {
+        unmarshallable_spec: |v: Value| T::unmarshal_spec(v).is_Ok(),
+        unmarshallable_status: |v: Value| T::unmarshal_status(v).is_Ok(),
+        valid_object: |obj: DynamicObjectView| T::unmarshal(obj).get_Ok_0().state_validation(),
+        valid_transition: |obj, old_obj: DynamicObjectView| T::unmarshal(obj).get_Ok_0().transition_validation(T::unmarshal(old_obj).get_Ok_0()),
+        marshalled_default_status: || T::marshal_status(T::default().status()),
+    }
 }
 
-impl<T: CustomResourceView> InstallTypeHelper<T> {
-    pub open spec fn unmarshal_spec(v: Value) -> bool {
-        T::unmarshal_spec(v).is_Ok()
-    }
+pub open spec fn type_is_installed_in_cluster<T: CustomResourceView>(self) -> bool {
+    let string = T::kind().get_CustomResourceKind_0();
+    &&& self.installed_types.contains_key(string)
+    &&& self.installed_types[string] == Self::installed_type::<T>()
+}
 
-    pub open spec fn unmarshal_status(v: Value) -> bool {
-        T::unmarshal_status(v).is_Ok()
+pub open spec fn installed_reconcile_model<R: Reconciler>() -> ReconcileModel
+    where
+        R::S: Marshallable,
+        R::EReq: Marshallable,
+        R::EResp: Marshallable,
+{
+    ReconcileModel {
+        kind: R::K::kind(),
+        init: || R::reconcile_init_state().marshal(),
+        transition: |obj, resp_o, s| {
+            let obj_um = R::K::unmarshal(obj).get_Ok_0();
+            let resp_o_um = match resp_o {
+                None => None,
+                Some(resp) => Some(match resp {
+                    ResponseContent::KubernetesResponse(api_resp) => ResponseView::<R::EResp>::KResponse(api_resp),
+                    ResponseContent::ExternalResponse(ext_resp) => ResponseView::<R::EResp>::ExternalResponse(R::EResp::unmarshal(ext_resp).get_Ok_0()),
+                })
+            };
+            let s_um = R::S::unmarshal(s).get_Ok_0();
+            let (s_prime_um, req_o_um) = R::reconcile_core(obj_um, resp_o_um, s_um);
+            (s_prime_um.marshal(), match req_o_um {
+                None => None,
+                Some(req) => Some(match req {
+                    RequestView::<R::EReq>::KRequest(api_req) => RequestContent::KubernetesRequest(api_req),
+                    RequestView::<R::EReq>::ExternalRequest(ext_req) => RequestContent::ExternalRequest(ext_req.marshal()),
+                })
+            })
+        },
+        done: |s| R::reconcile_done(R::S::unmarshal(s).get_Ok_0()),
+        error: |s| R::reconcile_error(R::S::unmarshal(s).get_Ok_0()),
     }
+}
 
-    pub open spec fn valid_object(obj: DynamicObjectView) -> bool {
-        T::unmarshal(obj).get_Ok_0().state_validation()
-    }
-
-    pub open spec fn valid_transition(obj: DynamicObjectView, old_obj: DynamicObjectView) -> bool {
-        T::unmarshal(obj).get_Ok_0().transition_validation(T::unmarshal(old_obj).get_Ok_0())
-    }
-
-    pub open spec fn marshalled_default_status() -> Value {
-        T::marshal_status(T::default().status())
-    }
 }
 
 }

--- a/src/v2/reconciler/exec/io.rs
+++ b/src/v2/reconciler/exec/io.rs
@@ -9,6 +9,20 @@ use vstd::pervasive::unreached;
 
 verus! {
 
+pub struct VoidEReq {}
+
+impl View for VoidEReq {
+    type V = VoidEReqView;
+    spec fn view(&self) -> VoidEReqView;
+}
+
+pub struct VoidEResp {}
+
+impl View for VoidEResp {
+    type V = VoidERespView;
+    spec fn view(&self) -> VoidERespView;
+}
+
 // Third-party libraries can also receive requests from reconciler.
 // T: The input type of the third-party library of the reconciler which should also be defined by the developer.
 // Typically, T can be an enum type, which lists all the possible supporting handlings the developer need support from the

--- a/src/v2/reconciler/exec/reconciler.rs
+++ b/src/v2/reconciler/exec/reconciler.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::external_api::exec::*;
 use crate::kubernetes_api_objects::exec::api_method::*;
 use crate::reconciler::exec::io::*;
 use crate::reconciler::spec::io::*;
@@ -9,16 +8,17 @@ use vstd::prelude::*;
 
 verus! {
 
-pub trait Reconciler{
-    type R;
-    type T;
-    type ExternalAPIType: ExternalAPIShimLayer;
-    spec fn well_formed(cr: &Self::R) -> bool;
-    fn reconcile_init_state() -> Self::T;
-    fn reconcile_core(cr: &Self::R, resp_o: Option<Response<<Self::ExternalAPIType as ExternalAPIShimLayer>::Output>>, state: Self::T) -> (Self::T, Option<Request<<Self::ExternalAPIType as ExternalAPIShimLayer>::Input>>)
+pub trait Reconciler {
+    type S;
+    type K;
+    type EReq: View;
+    type EResp: View;
+    spec fn well_formed(cr: &Self::K) -> bool;
+    fn reconcile_init_state() -> Self::S;
+    fn reconcile_core(cr: &Self::K, resp_o: Option<Response<Self::EResp>>, state: Self::S) -> (Self::S, Option<Request<Self::EReq>>)
         requires Self::well_formed(cr);
-    fn reconcile_done(state: &Self::T) -> bool;
-    fn reconcile_error(state: &Self::T) -> bool;
+    fn reconcile_done(state: &Self::S) -> bool;
+    fn reconcile_error(state: &Self::S) -> bool;
 }
 
 }

--- a/src/v2/reconciler/spec/io.rs
+++ b/src/v2/reconciler/spec/io.rs
@@ -1,11 +1,40 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
-use crate::kubernetes_api_objects::spec::{api_method::*, common::*, resource::*};
+use crate::kubernetes_api_objects::{
+    error::UnmarshalError,
+    spec::{api_method::*, common::*, resource::*},
+};
 use crate::kubernetes_cluster::spec::message::*;
 use vstd::prelude::*;
 
 verus! {
+
+pub struct VoidEReqView {}
+
+pub struct VoidERespView {}
+
+impl Marshallable for VoidEReqView {
+    spec fn marshal(self) -> Value;
+
+    spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
+
+    #[verifier(external_body)]
+    proof fn marshal_preserves_integrity()
+        ensures forall |o: Self| Self::unmarshal(#[trigger] o.marshal()).is_Ok() && o == Self::unmarshal(o.marshal()).get_Ok_0()
+    {}
+}
+
+impl Marshallable for VoidERespView {
+    spec fn marshal(self) -> Value;
+
+    spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
+
+    #[verifier(external_body)]
+    proof fn marshal_preserves_integrity()
+        ensures forall |o: Self| Self::unmarshal(#[trigger] o.marshal()).is_Ok() && o == Self::unmarshal(o.marshal()).get_Ok_0()
+    {}
+}
 
 #[is_variant]
 pub enum RequestView<T> {

--- a/src/v2/reconciler/spec/reconciler.rs
+++ b/src/v2/reconciler/spec/reconciler.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 VMware, Inc.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIS
 #![allow(unused_imports)]
-use crate::external_api::spec::*;
 use crate::kubernetes_api_objects::spec::{api_method::*, common::*, dynamic::*, resource::*};
 use crate::kubernetes_cluster::spec::message::*;
 use crate::reconciler::spec::io::*;
@@ -12,29 +11,31 @@ verus! {
 // Reconciler is used to specify the custom controller as a state machine
 // and install it to the Kubernetes cluster state machine.
 pub trait Reconciler {
-    // T: type of the reconciler state of the reconciler.
-    type T;
+    // S: type of the reconciler state of the reconciler.
+    type S;
     // K: type of the custom resource.
     type K: CustomResourceView;
-    // E: type of request and response via which the controller interacts with external systems (if any).
-    type E: ExternalAPI;
+    // EReq: type of request the controller sends to the external systems (if any).
+    type EReq;
+    // EResp: type of response the controller receives from the external systems (if any).
+    type EResp;
 
     // reconcile_init_state returns the initial local state that the reconciler starts
     // its reconcile function with.
-    spec fn reconcile_init_state() -> Self::T;
+    spec fn reconcile_init_state() -> Self::S;
 
     // reconcile_core describes the logic of reconcile function and is the key logic we want to verify.
     // Each reconcile_core should take the local state and a response of the previous request (if any) as input
     // and outputs the next local state and the request to send to Kubernetes API (if any).
-    spec fn reconcile_core(cr: Self::K, resp_o: Option<ResponseView<<Self::E as ExternalAPI>::Output>>, state: Self::T) -> (Self::T, Option<RequestView<<Self::E as ExternalAPI>::Input>>);
+    spec fn reconcile_core(cr: Self::K, resp_o: Option<ResponseView<Self::EResp>>, state: Self::S) -> (Self::S, Option<RequestView<Self::EReq>>);
 
     // reconcile_done is used to tell the controller_runtime whether this reconcile round is done.
     // If it is true, controller_runtime will requeue the reconcile.
-    spec fn reconcile_done(state: Self::T) -> bool;
+    spec fn reconcile_done(state: Self::S) -> bool;
 
     // reconcile_error is used to tell the controller_runtime whether this reconcile round returns with error.
     // If it is true, controller_runtime will requeue the reconcile with a shorter waiting time.
-    spec fn reconcile_error(state: Self::T) -> bool;
+    spec fn reconcile_error(state: Self::S) -> bool;
 }
 
 }

--- a/src/v2/reconciler/spec/reconciler.rs
+++ b/src/v2/reconciler/spec/reconciler.rs
@@ -1,5 +1,5 @@
 // Copyright 2022 VMware, Inc.
-// SPDX-License-Identifier: MIS
+// SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
 use crate::kubernetes_api_objects::spec::{api_method::*, common::*, dynamic::*, resource::*};
 use crate::kubernetes_cluster::spec::message::*;

--- a/src/v2_vreplicaset_controller.rs
+++ b/src/v2_vreplicaset_controller.rs
@@ -8,7 +8,7 @@ pub mod kubernetes_api_objects;
 pub mod kubernetes_cluster;
 #[path = "v2/reconciler/mod.rs"]
 pub mod reconciler;
-pub mod shim_layer;
+// pub mod shim_layer;
 pub mod state_machine;
 pub mod temporal_logic;
 #[path = "v2/controllers/vreplicaset_controller/mod.rs"]
@@ -22,25 +22,25 @@ use deps_hack::serde_yaml;
 use deps_hack::tokio;
 use deps_hack::tracing::{error, info};
 use deps_hack::tracing_subscriber;
-use shim_layer::controller_runtime::run_controller;
+// use shim_layer::controller_runtime::run_controller;
 use std::env;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
-    let args: Vec<String> = env::args().collect();
-    let cmd = args[1].clone();
+    // tracing_subscriber::fmt::init();
+    // let args: Vec<String> = env::args().collect();
+    // let cmd = args[1].clone();
 
-    if cmd == String::from("export") {
-        println!("{}", serde_yaml::to_string(&deps_hack::VReplicaSet::crd())?);
-    } else if cmd == String::from("run") {
-        info!("running v-replica-set-controller");
-        run_controller::<deps_hack::VReplicaSet, VReplicaSetReconciler>(false).await?;
-    } else if cmd == String::from("crash") {
-        info!("running v-replica-set-controller in crash-testing mode");
-        run_controller::<deps_hack::VReplicaSet, VReplicaSetReconciler>(true).await?;
-    } else {
-        error!("wrong command; please use \"export\", \"run\" or \"crash\"");
-    }
+    // if cmd == String::from("export") {
+    //     println!("{}", serde_yaml::to_string(&deps_hack::VReplicaSet::crd())?);
+    // } else if cmd == String::from("run") {
+    //     info!("running v-replica-set-controller");
+    //     run_controller::<deps_hack::VReplicaSet, VReplicaSetReconciler>(false).await?;
+    // } else if cmd == String::from("crash") {
+    //     info!("running v-replica-set-controller in crash-testing mode");
+    //     run_controller::<deps_hack::VReplicaSet, VReplicaSetReconciler>(true).await?;
+    // } else {
+    //     error!("wrong command; please use \"export\", \"run\" or \"crash\"");
+    // }
     Ok(())
 }


### PR DESCRIPTION
This PR adds a helper function `installed_reconcile_model` that allows developers to easily install their reconciler into the v2 cluster state machine.

This PR also introduces some cosmetic changes including:
- simplifying the `Reconciler` trait to make it no longer depend on the `ExternalAPI` trait
- defining `VoidEReq` and `VoidEResp` in the `reconciler` mod for the controllers that do not depend on external systems
- moving some definitions out of `trusted`

The current shim layer cannot work with the new `Reconciler` trait. We will add a new compatible shim layer.
