### PR TITLE
Document design choices behind the API server model

### DIFF
--- a/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -298,8 +298,6 @@ pub open spec fn handle_create_request(installed_types: InstalledTypes, req: Cre
             // Creation succeeds.
             (APIServerState {
                 resources: s.resources.insert(created_obj.object_ref(), created_obj),
-                // The object just gets created so it is not stable yet: built-in controller might update it
-                stable_resources: s.stable_resources.remove(created_obj.object_ref()),
                 uid_counter: s.uid_counter + 1,
                 resource_version_counter: s.resource_version_counter + 1,
                 ..s
@@ -506,8 +504,6 @@ pub open spec fn handle_update_request(installed_types: InstalledTypes, req: Upd
                     // or has at least one finalizer.
                     (APIServerState {
                         resources: s.resources.insert(req.key(), updated_obj_with_new_rv),
-                        // The object just gets updated so it is not stable yet: built-in controller might update it
-                        stable_resources: s.stable_resources.remove(req.key()),
                         resource_version_counter: s.resource_version_counter + 1, // Advance the rv counter
                         ..s
                     }, UpdateResponse{res: Ok(updated_obj_with_new_rv)})
@@ -686,8 +682,7 @@ pub open spec fn handle_request(installed_types: InstalledTypes) -> APIServerAct
 pub open spec fn api_server(installed_types: InstalledTypes) -> APIServerStateMachine {
     StateMachine {
         init: |s: APIServerState| {
-            &&& s.resources == Map::<ObjectRef, DynamicObjectView>::empty()
-            &&& s.stable_resources == Set::<ObjectRef>::empty()
+            s.resources == Map::<ObjectRef, DynamicObjectView>::empty()
         },
         actions: set![handle_request(installed_types)],
         step_to_action: |step: APIServerStep| {

--- a/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -371,7 +371,7 @@ pub open spec fn handle_delete_request(req: DeleteRequest, s: APIServerState) ->
         } else {
             // The object can be immediately removed from the key-value store.
             //
-            // NOTE: In some very corner case, the API server SEEMS to first updates the object (to update its finalizers)
+            // NOTE: In some very corner case, the API server *seems* to first updates the object (to update its finalizers)
             // and then deletes the object immediately, which makes the entire Delete operation not atomic.
             // However, this only happens in the orphan or foreground deletion mode, so we do not model this
             // seemingly non-atomic behavior for now.

--- a/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -541,6 +541,11 @@ pub open spec fn handle_update_request(installed_types: InstalledTypes, req: Upd
                     // More generally speaking, this modeling won't affect the correctness of any controller that
                     // treats a terminating object without finalizers as a non-existing object --- a good practice
                     // controllers should follow.
+                    //
+                    // NOTE: the API server should also check whether the deletion grace period in the metadata
+                    // is set to 0 before deleting the object in case of graceful deletion
+                    // (see https://github.com/kubernetes/kubernetes/blob/v1.30.0/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go#L533).
+                    // Here we omit that condition because graceful deletion is not supported.
                     (APIServerState {
                         resources: s.resources.remove(updated_obj_with_new_rv.object_ref()),
                         resource_version_counter: s.resource_version_counter + 1, // Advance the rv counter

--- a/src/v2/kubernetes_cluster/spec/api_server/types.rs
+++ b/src/v2/kubernetes_cluster/spec/api_server/types.rs
@@ -15,7 +15,6 @@ pub struct APIServerState {
     pub resources: StoredState,
     pub uid_counter: Uid,
     pub resource_version_counter: ResourceVersion,
-    pub stable_resources: Set<ObjectRef>,
 }
 
 pub type InstalledTypes = Map<StringView, InstalledType>;


### PR DESCRIPTION
This PR also removes the `stable_resources` field and fixes a proof broken due to the removal (unpredictability of SMT solver again!).