### PR TITLE
Model errors of create with `generate_name`

### DIFF
--- a/src/v2/kubernetes_cluster/spec/cluster.rs
+++ b/src/v2/kubernetes_cluster/spec/cluster.rs
@@ -420,7 +420,8 @@ impl Cluster {
     // * Non-deterministic requests get rejected by API server. For example, when
     //   creating an object using a generate_name, API server will try to create
     //   the object using a randomly generated name, and retry if it fails. If all
-    //   attempts fail, the request will fail with AlreadyExists error.
+    //   attempts fail, the request will fail with AlreadyExists error. For more
+    //   details, see https://github.com/kubernetes/kubernetes/blob/v1.30.0/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go#L435.
     pub open spec fn drop_req(self) -> Action<ClusterState, (Message, APIError), ()> {
         let result = |input: (Message, APIError), s: ClusterState| {
             let req_msg = input.0;


### PR DESCRIPTION
By removing the precondition on the API error type from `drop_req`, we generalize our fault model by including a new type of error: creation request with `generate_name` fails to create the object when all the creation attempts conflict with existing objects. This type of error is non-deterministic because the API server uses a name randomly generated when handling a creation request whose `name` is empty and `generate_name` is in use. We treat it as a transient error and assume that it will eventually disappear. Otherwise, there is no way for controllers that issue creation requests with `generate_name` to finish reconciliation.