### PR TITLE
Additional vstd lemmas proved

### DIFF
--- a/src/vstd_ext/map_lib.rs
+++ b/src/vstd_ext/map_lib.rs
@@ -10,17 +10,14 @@ pub open spec fn map_to_seq<K, V>(m: Map<K, V>, f: spec_fn(V) -> bool) -> Seq<V>
     m.values().filter(f).to_seq()
 }
 
-#[verifier(external_body)]
 pub proof fn a_submap_of_a_finite_map_is_finite<K, V>(m1: Map<K, V>, m2: Map<K, V>)
     requires 
         m1.submap_of(m2),
         m2.dom().finite(),
-    ensures m1.dom().finite();
-//
-// TODO: Prove this -- Trivial.
-//
-// A submap of a finite map is in turn finite.
-//
-
+    ensures
+        m1.dom().finite(),
+{
+    assert(m1.dom()===m2.dom().intersect(m1.dom()));
+}
 
 }

--- a/src/vstd_ext/seq_lib.rs
+++ b/src/vstd_ext/seq_lib.rs
@@ -103,34 +103,111 @@ pub proof fn seq_unequal_preserved_by_add_auto<A>(suffix: Seq<A>)
     };
 }
 
-#[verifier(external_body)]
 pub proof fn seq_pred_false_on_all_elements_is_equivalent_to_empty_filter<A>(s: Seq<A>, pred: spec_fn(A) -> bool)
-    ensures (forall |e: A| #[trigger] s.contains(e) ==> !pred(e)) <==> s.filter(pred).len() == 0;
-//
-// TODO: Prove this -- Trivial.
-//
-// If `pred` is false on every element, filter will return an empty sequence.
-//
+    ensures (forall |e: A| #[trigger] s.contains(e) ==> !pred(e)) <==> s.filter(pred).len() == 0,
+{
+    if s.len() != 0 {
+        assert((forall |e: A| s.contains(e) ==> !pred(e)) ==> s.filter(pred).len() == 0) by {
+            assume(forall |e: A| s.contains(e) ==> !pred(e));
+            seq_pred_false_on_all_elements_implies_empty_filter(s, pred);
+        }
+        assert(s.filter(pred).len() == 0 ==> (forall |e: A| s.contains(e) ==> !pred(e))) by {
+            assume(s.filter(pred).len() == 0);
+            empty_filter_implies_seq_pred_false_on_all_elements(s, pred);
+        }
+    }
+}
 
-#[verifier(external_body)]
+proof fn seq_pred_false_on_all_elements_implies_empty_filter<A>(s: Seq<A>, pred: spec_fn(A) -> bool)
+    requires forall |e: A| #![auto] s.contains(e) ==> !pred(e),
+    ensures s.filter(pred).len() == 0,
+    decreases s.len()
+    // If `pred` is false on every element, filter will return an empty sequence.
+{
+    reveal(Seq::filter);
+    if s.len() != 0 {
+        let subseq = s.drop_last();
+        // prove precondition for subseq and recursive call
+        assert(forall |e: A| subseq.contains(e) ==> !pred(e)) by {
+            assert(forall |i: int| 0 <= i < subseq.len() ==> s.contains(#[trigger] s[i]) ==> !pred(subseq[i]));
+        }
+        seq_pred_false_on_all_elements_implies_empty_filter(subseq, pred);
+        assert(subseq.filter(pred) == s.filter(pred)) by {
+            assert(!pred(s.last())) by {
+                assert(s.contains(s.last()) ==> !pred(s.last()));
+            };
+        } // s.filter(pred) == subseq.filter(pred) == ... == Seq::empty()
+    }
+}
+
+proof fn empty_filter_implies_seq_pred_false_on_all_elements<A>(s: Seq<A>, pred: spec_fn(A) -> bool)
+    requires s.filter(pred).len() == 0,
+    ensures forall |e: A| #![auto] s.contains(e) ==> !pred(e)
+    decreases s.len()
+    // If `pred` is false on every element, filter will return an empty sequence.
+{
+    if s.len() != 0 {
+        let subseq = s.drop_last();
+        assert(!pred(s.last())) by {
+            // assert(s.filter(pred).len() == 0);
+            reveal(Seq::filter);
+            assert(s.filter(pred) == {
+                if pred(s.last()) {
+                    subseq.filter(pred).push(s.last())
+                } else {
+                    subseq.filter(pred)
+                }
+            })
+        }
+        assert(s.filter(pred) == subseq.filter(pred)) by {
+            reveal(Seq::filter);
+            assert(!pred(s.last()));
+        }
+        empty_filter_implies_seq_pred_false_on_all_elements(s.drop_last(), pred);
+        assert forall |e: A| #![auto] s.contains(e) ==> !pred(e) by {
+            assert(forall |i: int| 0 <= i < subseq.len() ==> (subseq.contains(#[trigger] subseq[i]) ==> !pred(subseq[i])));
+            assert(forall |i: int| 0 <= i < subseq.len() ==> s[i] == subseq[i]);
+            // assert(!pred(s.last()) && s.contains(s.last()));
+        }
+    }
+}
+
 pub proof fn seq_filter_preserves_no_duplicates<A>(s: Seq<A>, pred: spec_fn(A) -> bool)
     requires s.no_duplicates(),
-    ensures s.filter(pred).no_duplicates();
-//
-// TODO: Prove this -- Trivial.
-//
-// Since the parent sequence has no duplicates, and the filtered sequence only removes elements,
-// that sequence also has no duplicates.
-//
+    ensures s.filter(pred).no_duplicates()
+    decreases s.len()
+{
+    reveal(Seq::filter);
+    if s.len() != 0 {
+        seq_filter_preserves_no_duplicates(s.drop_last(), pred);
+        if pred(s.last()) {
+            seq_filter_is_a_subset_of_original_seq(s.drop_last(), pred);
+        }
+    }
+}
 
-#[verifier(external_body)]
 pub proof fn seq_filter_contains_implies_seq_contains<A>(s: Seq<A>, pred: spec_fn(A) -> bool, elt: A)
     requires s.filter(pred).contains(elt),
-    ensures s.contains(elt);
-//
-// TODO: Prove this -- Trivial.
-//
-// Anything in the 
-//
+    ensures s.contains(elt)
+{
+    seq_filter_is_a_subset_of_original_seq(s, pred);
+}
+
+// useful theorem to prove the 2 above
+pub proof fn seq_filter_is_a_subset_of_original_seq<A>(s: Seq<A>, pred: spec_fn(A) -> bool)
+    ensures
+        forall |e: A| s.filter(pred).contains(e) ==> #[trigger] s.contains(e),
+        forall |i: int| 0 <= i < s.filter(pred).len() ==> s.contains(#[trigger] s.filter(pred)[i]), // 2nd form
+    decreases s.len()
+{
+    reveal(Seq::filter);
+    if s.filter(pred).len() != 0 {
+        let subseq = s.drop_last();
+        seq_filter_is_a_subset_of_original_seq(s.drop_last(), pred);
+        assert(forall |i: int| 0 <= i < subseq.filter(pred).len() ==> subseq.contains(#[trigger] subseq.filter(pred)[i]));
+        // assert(forall |i: int| 0 <= i < s.filter(pred).len() ==> s.contains(#[trigger] s.filter(pred)[i]));
+        // assert(forall |e: A| s.filter(pred).contains(e) ==> #[trigger] s.contains(e));
+    }
+}
 
 }

--- a/src/vstd_ext/set_lib.rs
+++ b/src/vstd_ext/set_lib.rs
@@ -66,6 +66,4 @@ proof fn element_in_seq_exists_in_original_finite_set<A>(s: Set<A>, e: A)
     }
 }
 
-fn main(){}
-
 }

--- a/src/vstd_ext/set_lib.rs
+++ b/src/vstd_ext/set_lib.rs
@@ -7,25 +7,65 @@ use vstd::set_lib::*;
 
 verus! {
 
-#[verifier(external_body)]
 pub proof fn finite_set_to_seq_contains_all_set_elements<A>(s: Set<A>)
     requires s.finite(),
-    ensures forall |e: A| #![auto] s.contains(e) <==> s.to_seq().contains(e);
-//
-// TODO: Prove this -- Trivial.
-// 
-// Anything in a finite set will be in a sequence composed of its elements; likewise
-// anything in that constructed sequence will be part of the original set.
-//
+    ensures forall |e: A| #![auto] s.contains(e) <==> s.to_seq().contains(e)
+{
+    if s.len() != 0 {
+        assert forall |e: A| #[trigger] s.contains(e) implies s.to_seq().contains(e) by {
+            element_in_finite_set_exists_in_set_to_seq(s, e);
+        }
+        assert forall |e: A| #[trigger] s.to_seq().contains(e) implies s.contains(e) by {
+            element_in_seq_exists_in_original_finite_set(s, e);
+        }
+    }
+}
 
-#[verifier(external_body)]
 pub proof fn finite_set_to_seq_has_no_duplicates<A>(s: Set<A>)
     requires s.finite(),
-    ensures s.to_seq().no_duplicates();
-//
-// TODO: Prove this -- Trivial.
-// 
-// The `to_seq()` construction applied to a set will not introduce duplicates.
-//
+    ensures s.to_seq().no_duplicates(),
+    decreases s.len()
+{
+    reveal(Set::to_seq);
+    if s.len() != 0 {
+        let x = s.choose();
+        finite_set_to_seq_has_no_duplicates(s.remove(x));
+        finite_set_to_seq_contains_all_set_elements(s.remove(x));
+    }
+}
+
+proof fn element_in_finite_set_exists_in_set_to_seq<A>(s: Set<A>, e: A)
+    requires s.finite(), s.contains(e),
+    ensures s.to_seq().contains(e),
+    decreases s.len()
+{
+    if s.len() != 0 {
+        // need choose() to be not-random
+        let x = s.choose();
+        if x == e {
+            assert(s.to_seq() == Seq::empty().push(e) + s.remove(e).to_seq());
+            assert(s.to_seq()[0] == e);
+        } else {
+            element_in_finite_set_exists_in_set_to_seq(s.remove(x), e);
+            assert(s.to_seq().subrange(1, s.to_seq().len() as int) == s.remove(x).to_seq());
+        }
+    }
+}
+
+proof fn element_in_seq_exists_in_original_finite_set<A>(s: Set<A>, e: A)
+    requires s.finite(), s.to_seq().contains(e),
+    ensures s.contains(e),
+    decreases s.len()
+{
+    if s.len() != 0 {
+        // need choose() to be not-random
+        let x = s.choose();
+        if x != e {
+            element_in_seq_exists_in_original_finite_set(s.remove(x), e);
+        }
+    }
+}
+
+fn main(){}
 
 }


### PR DESCRIPTION
Proved lemmas:
- `a_submap_of_a_finite_map_is_finite`
- `seq_pred_false_on_all_elements_is_equivalent_to_empty_filter`
- `finite_set_to_seq_contains_all_set_elements`
- `seq_filter_is_a_subset_of_original_seq`
- `seq_filter_contains_implies_seq_contains`
- `seq_filter_preserves_no_duplicates`
- `finite_set_to_seq_has_no_duplicates`

This PR reworked those in #578

I'll continue to work on this branch if any new lemma is added and create PR for more proofs