### PR TITLE
Add new lemma stating all reconciles will eventually satisfy a set of requirements

### DIFF
--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -977,7 +977,7 @@ pub proof fn p_leads_to_q_is_stable<T>(p: TempPred<T>, q: TempPred<T>)
 //     forall |a| |= stable(p -> q(a))
 // post:
 //     |= stable(tla_forall(|a| p -> q(a)))
-pub proof fn tla_forall_a_p_leads_to_q_a_is_stable<T, A>(spec: TempPred<T>, p: TempPred<T>, a_to_q: spec_fn(A) -> TempPred<T>)
+pub proof fn tla_forall_a_p_leads_to_q_a_is_stable<T, A>(p: TempPred<T>, a_to_q: spec_fn(A) -> TempPred<T>)
     requires forall |a: A| #[trigger] valid(stable(p.leads_to(a_to_q(a)))),
     ensures valid(stable(tla_forall(|a: A| p.leads_to(a_to_q(a))))),
 {

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -972,6 +972,31 @@ pub proof fn p_leads_to_q_is_stable<T>(p: TempPred<T>, q: TempPred<T>)
     always_p_is_stable(p.implies(eventually(q)));
 }
 
+// Forall a leads-to predicate p -> q(a) is stable.
+// pre:
+//     forall |a| |= stable(p -> q(a))
+// post:
+//     |= stable(tla_forall(|a| p -> q(a)))
+pub proof fn tla_forall_a_p_leads_to_q_a_is_stable<T, A>(spec: TempPred<T>, p: TempPred<T>, a_to_q: spec_fn(A) -> TempPred<T>)
+    requires forall |a: A| #[trigger] valid(stable(p.leads_to(a_to_q(a)))),
+    ensures valid(stable(tla_forall(|a: A| p.leads_to(a_to_q(a))))),
+{
+    let target = tla_forall(|a: A| p.leads_to(a_to_q(a)));
+    assert forall |ex| (forall |a: A| #[trigger] valid(stable(p.leads_to(a_to_q(a))))) implies #[trigger] stable(target).satisfied_by(ex) by {
+        assert forall |i| (forall |a: A| #[trigger] valid(stable(p.leads_to(a_to_q(a))))) implies 
+                    (target.satisfied_by(ex) ==> #[trigger] target.satisfied_by(ex.suffix(i))) by {
+            assert forall |a: A| (forall |a: A| #[trigger] valid(stable(p.leads_to(a_to_q(a))))) implies 
+                        (p.leads_to(a_to_q(a)).satisfied_by(ex) ==> #[trigger] p.leads_to(a_to_q(a)).satisfied_by(ex.suffix(i))) by {
+                assert(valid(stable(p.leads_to(a_to_q(a)))));
+                assert(stable(p.leads_to(a_to_q(a))).satisfied_by(ex));
+                if (p.leads_to(a_to_q(a)).satisfied_by(ex)) {
+                    assert(p.leads_to(a_to_q(a)).satisfied_by(ex.suffix(i)));
+                }
+            }
+        }
+    }
+}
+
 // p and q is stable if both p and q are stable.
 // pre:
 //     |= stable(p)

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -753,11 +753,15 @@ pub proof fn lemma_true_leads_to_always_every_ongoing_reconcile_satisfies(
 )
     requires
         spec.entails(always(lift_action(self.next()))),
+        self.controller_models.contains_key(controller_id),
         // Weak fairness for controller steps.
         spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+        // Every new reconcile satisfies the requirements.
+        spec.entails(always(lift_action(Self::every_new_ongoing_reconcile_satisfies(controller_id, requirements)))),
         // Controller termination.
         spec.entails(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))),
-        self.controller_models.contains_key(controller_id),
+        // There is the controller state.
+        spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements)))));
 
 }

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -7,7 +7,7 @@ use crate::kubernetes_cluster::spec::{
     message::*,
 };
 use crate::temporal_logic::{defs::*, rules::*};
-use vstd::prelude::*;
+use vstd::{map::*, prelude::*, set_lib::*};
 
 verus! {
 
@@ -737,6 +737,14 @@ pub open spec fn every_new_ongoing_reconcile_satisfies(
     }
 }
 
+pub open spec fn no_reconcile_before_reconcile_id_is_ongoing(controller_id: int, reconcile_id: ReconcileId) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        forall |key: ObjectRef|
+            #[trigger] s.ongoing_reconciles(controller_id).contains_key(key)
+                ==> s.ongoing_reconciles(controller_id)[key].reconcile_id >= reconcile_id
+    }
+}
+
 // This lemma shows that if spec ensures every newly started reconcile for a given controller_id
 // satisfies some requirements, the system will eventually reaches a state where all ongoing reconciles
 // of that controller_id satisfy those requirements.
@@ -757,6 +765,10 @@ pub proof fn lemma_true_leads_to_always_every_ongoing_reconcile_satisfies(
         spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)))),
         // Every new reconcile satisfies the requirements.
         spec.entails(always(lift_action(Self::every_new_ongoing_reconcile_satisfies(controller_id, requirements)))),
+        // Every reconcile has lower id than allocator.
+        spec.entails(always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)))),
+        // There are finitely many ongoing reconciles.
+        spec.entails(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))),
         // Controller termination.
         spec.entails(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))),
         // There is the controller state.
@@ -785,23 +797,643 @@ pub proof fn lemma_true_leads_to_always_every_ongoing_reconcile_satisfies(
     );
 }
 
-#[verifier(external_body)]
 pub proof fn lemma_some_reconcile_id_leads_to_always_every_ongoing_reconcile_satisfies_with_reconcile_id(
     self, 
     spec: TempPred<ClusterState>,
     controller_id: int,
     requirements: spec_fn(OngoingReconcile, ClusterState) -> bool,
-    reconcile_id: nat,
+    reconcile_id: ReconcileId,
 )
     requires
         spec.entails(always(lift_action(self.next()))),
         self.controller_models.contains_key(controller_id),
         spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)))),
         spec.entails(always(lift_action(Self::every_new_ongoing_reconcile_satisfies(controller_id, requirements)))),
+        spec.entails(always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)))),
+        spec.entails(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))),
         spec.entails(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))),
         spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
     ensures spec.entails(lift_state(Self::reconcile_id_counter_is(controller_id, reconcile_id))
-                        .leads_to(always(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements)))));
+                        .leads_to(always(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements)))))
+{
+    // Use the stable part of spec, show the stability of stable_spec and also spec |= stable_spec
+    let always_spec = always(lift_action(Self::every_new_ongoing_reconcile_satisfies(controller_id, requirements)))
+                    .and(always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id))))
+                    .and(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id))))
+                    .and(always(lift_state(Self::there_is_the_controller_state(controller_id))))
+                    .and(always(lift_action(self.next())));
+    let stable_spec = always_spec.and(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1))))
+                        .and(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key)))));
+
+    stable_and_always_n!(
+        lift_action(Self::every_new_ongoing_reconcile_satisfies(controller_id, requirements)),
+        lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)),
+        lift_state(Self::ongoing_reconciles_is_finite(controller_id)),
+        lift_state(Self::there_is_the_controller_state(controller_id)),
+        lift_action(self.next())
+    );
+    self.tla_forall_controller_next_weak_fairness_is_stable(controller_id);
+
+    // Prove termination is stable.
+    let term_closure = |key: ObjectRef| lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key));
+    assert forall |key: ObjectRef| #[trigger] valid(stable(true_pred().leads_to(term_closure(key)))) by {
+        p_leads_to_q_is_stable(
+            true_pred(),
+            lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))
+        );
+    };
+    tla_forall_a_p_leads_to_q_a_is_stable(
+        true_pred(),
+        |key: ObjectRef| lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key)),
+    );
+    assert(valid(stable(tla_forall(|key: ObjectRef| true_pred().leads_to(term_closure(key))))));
+    assert_by(
+        tla_forall(|key: ObjectRef| true_pred().leads_to(term_closure(key)))
+        == tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key)))),
+        {
+            let lhs = tla_forall(|key: ObjectRef| true_pred().leads_to(term_closure(key)));
+            let rhs = tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))));
+            let lhs_inner = |key: ObjectRef| true_pred().leads_to(term_closure(key));
+            let rhs_inner = |key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key)));
+
+            assert forall |ex| #[trigger] lhs.satisfied_by(ex) implies rhs.satisfied_by(ex) by {
+                assert(tla_forall(lhs_inner).satisfied_by(ex));
+                assert(forall |key: ObjectRef| #[trigger] lhs_inner(key).satisfied_by(ex));
+                assert(forall |key: ObjectRef| lhs_inner(key).satisfied_by(ex) ==> #[trigger] rhs_inner(key).satisfied_by(ex));
+                assert(tla_forall(rhs_inner).satisfied_by(ex));
+            }
+            assert forall |ex| #[trigger] rhs.satisfied_by(ex) implies lhs.satisfied_by(ex) by {
+                assert(tla_forall(rhs_inner).satisfied_by(ex));
+                assert(forall |key: ObjectRef| #[trigger] rhs_inner(key).satisfied_by(ex));
+                assert(forall |key: ObjectRef| rhs_inner(key).satisfied_by(ex) ==> #[trigger] lhs_inner(key).satisfied_by(ex));
+                assert(tla_forall(lhs_inner).satisfied_by(ex));
+            }
+            temp_pred_equality(lhs, rhs);
+        }
+    );
+
+    stable_and_n!(
+        always_spec, 
+        tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1))),
+        tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))
+    );
+    entails_and_n!(
+        spec,
+        always(lift_action(Self::every_new_ongoing_reconcile_satisfies(controller_id, requirements))),
+        always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id))),
+        always(lift_state(Self::ongoing_reconciles_is_finite(controller_id))),
+        always(lift_state(Self::there_is_the_controller_state(controller_id))),
+        always(lift_action(self.next())),
+        tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1))),
+        tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))
+    );
+
+    let spec_with_reconcile_id = stable_spec.and(lift_state(Self::reconcile_id_counter_is(controller_id, reconcile_id)));
+    
+    eliminate_always(spec_with_reconcile_id, lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)));
+
+    // With reconcile_id known, we first prove that spec /\ reconcile_id |= true ~> []every_ongoing_reconcile_satisfies
+    // We divide the proof into three steps:
+    // (1) Prove an invariant that forall reconciles with a reconcile_id no smaller than `reconcile_id`, it satisfies the given predicate.
+    // (2) Prove that spec |= true ~> []reconciles_with_lower_id_all_gone.
+    // (3) With the first invariant, prove that reconciles_with_lower_id_all_gone implies all ongoing reconciles are expected.
+    assert_by(
+        spec_with_reconcile_id.entails(true_pred().leads_to(always(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements))))),
+        {
+            self.lemma_always_has_reconcile_id_counter_no_smaller_than(spec_with_reconcile_id, controller_id, reconcile_id);
+            let invariant = |s: ClusterState| {
+                forall |key: ObjectRef| {
+                    &&& #[trigger] s.ongoing_reconciles(controller_id).contains_key(key)
+                    &&& s.ongoing_reconciles(controller_id)[key].reconcile_id >= reconcile_id
+                } ==> requirements(s.ongoing_reconciles(controller_id)[key], s)
+            };
+            assert_by(
+                spec_with_reconcile_id.entails(always(lift_state(invariant))),
+                {
+                    let init = |s: ClusterState| {
+                        Self::reconcile_id_counter_is(controller_id, reconcile_id)(s)
+                        && Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)(s)
+                    };
+                    entails_and_temp(
+                        spec_with_reconcile_id, 
+                        lift_state(Self::reconcile_id_counter_is(controller_id, reconcile_id)), 
+                        lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id))
+                    );
+                    temp_pred_equality(
+                        lift_state(init),
+                        lift_state(Self::reconcile_id_counter_is(controller_id, reconcile_id))
+                            .and(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)))
+                    );
+                    let stronger_next = |s, s_prime| {
+                        self.next()(s, s_prime)
+                        && Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)(s)
+                        && Self::every_new_ongoing_reconcile_satisfies(controller_id, requirements)(s, s_prime)
+                        && Self::there_is_the_controller_state(controller_id)(s)
+                    };
+
+                    combine_spec_entails_always_n!(
+                        spec_with_reconcile_id, lift_action(stronger_next), 
+                        lift_action(self.next()),
+                        lift_state(Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)),
+                        lift_action(Self::every_new_ongoing_reconcile_satisfies(controller_id, requirements)),
+                        lift_state(Self::there_is_the_controller_state(controller_id))
+                    );
+                    init_invariant(spec_with_reconcile_id, init, stronger_next, invariant);
+                }
+            );
+
+            self.lemma_true_leads_to_always_no_reconcile_before_reconcile_id_is_ongoing(
+                spec_with_reconcile_id, controller_id, reconcile_id
+            );           
+
+            entails_preserved_by_always(
+                lift_state(invariant),
+                lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id))
+                .implies(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements)))
+            );
+            entails_trans(
+                spec_with_reconcile_id, always(lift_state(invariant)),
+                always(lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id))
+                    .implies(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements))))
+            );
+            always_implies_preserved_by_always(spec_with_reconcile_id, lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id)), lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements)));
+            leads_to_weaken(
+                spec_with_reconcile_id,
+                true_pred(), always(lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id))),
+                true_pred(), always(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements)))
+            );
+        }
+    );
+
+    // Then unpack the condition from spec.
+    unpack_conditions_from_spec(
+        stable_spec, lift_state(Self::reconcile_id_counter_is(controller_id, reconcile_id)), true_pred(),
+        always(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements)))
+    );
+    temp_pred_equality(true_pred().and(lift_state(Self::reconcile_id_counter_is(controller_id, reconcile_id))), lift_state(Self::reconcile_id_counter_is(controller_id, reconcile_id)));
+    assert(spec.entails(stable_spec));
+    entails_trans(
+        spec, 
+        stable_spec, 
+        lift_state(Self::reconcile_id_counter_is(controller_id, reconcile_id))
+            .leads_to(always(lift_state(Self::every_ongoing_reconcile_satisfies(controller_id, requirements))))
+    );
+}
+
+// All ongoing reconciles with a smaller id than reconcile_id will eventually terminate.
+// The intuition is that (1) The number of such reconciles are bounded by rpc_id,
+// and (2) weak fairness assumption ensures each message will eventually be handled by Kubernetes.
+pub proof fn lemma_true_leads_to_always_no_reconcile_before_reconcile_id_is_ongoing(
+    self, 
+    spec: TempPred<ClusterState>,
+    controller_id: int,
+    reconcile_id: ReconcileId,
+)
+    requires
+        spec.entails(always(lift_action(self.next()))),
+        self.controller_models.contains_key(controller_id),
+        spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
+        spec.entails(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))),
+        spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+        spec.entails(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))),
+        spec.entails(always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)))),
+        spec.entails(always(lift_state(Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)))),
+    ensures spec.entails(true_pred().leads_to(always(lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id)))))
+{
+    self.lemma_eventually_no_reconcile_before_reconcile_id_is_ongoing(
+        spec, controller_id, reconcile_id
+    );
+
+    let stronger_next = |s, s_prime| {
+        &&& self.next()(s, s_prime)
+        &&& Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)(s)
+        &&& Self::there_is_the_controller_state(controller_id)(s)
+    };
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
+        lift_action(self.next()),
+        lift_state(Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)),
+        lift_state(Self::there_is_the_controller_state(controller_id))
+    );
+
+    leads_to_stable(spec, lift_action(stronger_next), true_pred(), lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id)));
+}
+
+pub open spec fn ongoing_reconcile_before(controller_id: int, reconcile_id: ReconcileId, key: ObjectRef) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        let ongoing_reconciles = s.ongoing_reconciles(controller_id);
+        ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id
+    }
+}
+
+pub open spec fn ongoing_reconciles_num_is_n(controller_id: int, reconcile_id: ReconcileId, rec_num: nat) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        let ongoing_reconciles = s.ongoing_reconciles(controller_id);
+        let reconciles_before_id = Map::new(
+            |key| ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id,
+            |key| ongoing_reconciles[key]
+        );
+        reconciles_before_id.dom().finite()
+        && reconciles_before_id.len() == rec_num
+    }
+}
+
+// need this due to controller failures
+pub open spec fn ongoing_reconciles_num_is_at_most_n(controller_id: int, reconcile_id: ReconcileId, rec_num: nat) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        let ongoing_reconciles = s.ongoing_reconciles(controller_id);
+        let reconciles_before_id = Map::new(
+            |key| ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id,
+            |key| ongoing_reconciles[key]
+        );
+        reconciles_before_id.dom().finite()
+        && reconciles_before_id.len() <= rec_num
+    }
+}
+
+pub proof fn lemma_eventually_no_reconcile_before_reconcile_id_is_ongoing(
+    self, 
+    spec: TempPred<ClusterState>,
+    controller_id: int,
+    reconcile_id: ReconcileId,
+)
+    requires
+        spec.entails(always(lift_action(self.next()))),
+        self.controller_models.contains_key(controller_id),
+        spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
+        spec.entails(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))),
+        spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+        spec.entails(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))),
+        spec.entails(always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)))),
+        spec.entails(always(lift_state(Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)))),
+    ensures spec.entails(true_pred().leads_to(lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id))))
+{
+    let no_more_ongoing_reconciles = lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id));
+
+    // Here we split the cases on the number of ongoing reconciles
+    // and prove that for all numbers, all the reconciles will eventually terminate.
+    assert forall |rec_num: nat|
+        spec.entails(#[trigger] lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))
+                    .leads_to(no_more_ongoing_reconciles)) 
+    by {
+        self.lemma_ongoing_reconciles_num_is_n_leads_to_no_ongoing_reconciles(
+            spec, controller_id, reconcile_id, rec_num
+        );
+    }
+    leads_to_exists_intro(spec, |rec_num| lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)), no_more_ongoing_reconciles);
+
+    // Now we merge all the cases on different numbers of reconciles together to get true_pred()
+    assert_by(spec.entails(always(true_pred().implies(tla_exists(|rec_num| lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)))))), {
+        assert forall |ex| #[trigger] spec.satisfied_by(ex) 
+            implies always(true_pred().implies(tla_exists(|rec_num| lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))))).satisfied_by(ex) by {
+            assert forall |i| spec.satisfied_by(ex) implies #[trigger] true_pred().satisfied_by(ex.suffix(i)) ==> tla_exists(|rec_num| lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))).satisfied_by(ex.suffix(i)) by {
+                let ongoing_reconciles = ex.suffix(i).head().ongoing_reconciles(controller_id);
+                let reconciles_before_id = Map::new(
+                    |key| ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id,
+                    |key| ongoing_reconciles[key]
+                );
+                let rec_num = reconciles_before_id.len();
+
+                // machinery to prove ongoing_reconciles at dom is finite
+                assert(spec.entails(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))));
+                assert(forall |ex| #[trigger] spec.implies(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))).satisfied_by(ex));
+                assert(spec.implies(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))).satisfied_by(ex));
+                assert(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id))).satisfied_by(ex));
+                assert(forall |i| #[trigger] lift_state(Self::ongoing_reconciles_is_finite(controller_id)).satisfied_by(ex.suffix(i)));
+                assert(lift_state(Self::ongoing_reconciles_is_finite(controller_id)).satisfied_by(ex.suffix(i)));
+                assert(ongoing_reconciles.dom().finite());
+
+                assert(reconciles_before_id.dom().subset_of(ongoing_reconciles.dom()));
+                lemma_len_subset(reconciles_before_id.dom(), ongoing_reconciles.dom());
+                assert(reconciles_before_id.dom().finite());
+                assert(lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)).satisfied_by(ex.suffix(i)));
+                assert((|rec_num| lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)))(rec_num).satisfied_by(ex.suffix(i)));
+                assert(tla_exists(|rec_num| lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))).satisfied_by(ex.suffix(i)));
+            }
+        }
+    });
+
+    always_implies_to_leads_to(
+        spec,
+        true_pred(),
+        tla_exists(|rec_num| lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)))
+    );
+
+    leads_to_trans(
+        spec,
+        true_pred(),
+        tla_exists(|rec_num| lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))),
+        lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id))
+    );
+}
+
+pub proof fn lemma_ongoing_reconciles_num_is_n_leads_to_no_ongoing_reconciles(
+    self, 
+    spec: TempPred<ClusterState>,
+    controller_id: int,
+    reconcile_id: ReconcileId,
+    rec_num: nat
+)
+    requires
+        spec.entails(always(lift_action(self.next()))),
+        self.controller_models.contains_key(controller_id),
+        spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
+        spec.entails(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))),
+        spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+        spec.entails(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))),
+        spec.entails(always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)))),
+        spec.entails(always(lift_state(Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)))),
+    ensures 
+        spec.entails(
+            lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))
+            .leads_to(lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id)))
+        ),
+    decreases 
+        rec_num
+{
+    if rec_num == 0 {
+        // base case
+        let no_more_ongoing_reconciles = Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id);
+
+        assert_by(valid(lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, 0)).implies(lift_state(no_more_ongoing_reconciles))), {
+            assert forall |s| #[trigger] Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, 0)(s) implies no_more_ongoing_reconciles(s) by {
+                assert forall |key| Self::ongoing_reconcile_before(controller_id, reconcile_id, key)(s) implies !(#[trigger] s.ongoing_reconciles(controller_id).contains_key(key)) by {
+                    let ongoing_reconciles = s.ongoing_reconciles(controller_id);
+                    let reconciles_before_id = Map::new(
+                        |key| ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id,
+                        |key| ongoing_reconciles[key]
+                    );
+                    assert(reconciles_before_id.contains_key(key));
+                    assert(reconciles_before_id.len() > 0);
+                }
+            }
+        });
+
+        entails_implies_leads_to(spec, lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, 0)), lift_state(no_more_ongoing_reconciles));
+    } else {
+        // induction step
+        let no_more_ongoing_reconciles = lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id));
+        let reconcile_ongoing = |key: ObjectRef| lift_state(|s: ClusterState|
+            s.ongoing_reconciles(controller_id).contains_key(key) && s.ongoing_reconciles(controller_id)[key].reconcile_id < reconcile_id
+        );
+        let ongoing_reconciles_num_is_n_and_reconcile_ongoing = |key: ObjectRef| 
+            lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))
+                .and(reconcile_ongoing(key));
+
+        // prove that "there are rec_num reconciles" ~> "there are at most rec_num - 1 reconciles"
+        assert forall |key: ObjectRef|
+            spec.entails(#[trigger] ongoing_reconciles_num_is_n_and_reconcile_ongoing(key)
+                        .leads_to(lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat)))) by {
+            self.lemma_ongoing_reconciles_num_decreases(
+                spec, controller_id, reconcile_id, rec_num, key
+            );
+        }
+        leads_to_exists_intro(
+            spec, ongoing_reconciles_num_is_n_and_reconcile_ongoing, lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat))
+        );
+
+        // merge all the cases on different keys together
+        assert_by(
+            tla_exists(ongoing_reconciles_num_is_n_and_reconcile_ongoing) == lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)),
+            {
+                assert forall |ex| #[trigger] lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)).satisfied_by(ex) 
+                implies tla_exists(ongoing_reconciles_num_is_n_and_reconcile_ongoing).satisfied_by(ex) by {
+                    let ongoing_reconciles = ex.head().ongoing_reconciles(controller_id);
+                    let reconciles_before_id = Map::new(
+                        |key| ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id,
+                        |key| ongoing_reconciles[key]
+                    );
+                    let key = reconciles_before_id.dom().choose();
+                    assert(reconciles_before_id.contains_key(key));
+                    assert(lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)).satisfied_by(ex));
+                    assert(reconcile_ongoing(key).satisfied_by(ex));
+                    assert((|key| ongoing_reconciles_num_is_n_and_reconcile_ongoing(key))(key).satisfied_by(ex));
+                }
+                temp_pred_equality(tla_exists(ongoing_reconciles_num_is_n_and_reconcile_ongoing), lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)));
+            }
+        );
+
+        assert_by(
+            spec.entails(
+                lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat))
+                .leads_to(lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id)))
+            ), 
+            {
+                assert forall |ex| #[trigger] lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat)).satisfied_by(ex)
+                    implies tla_exists(|n: nat| lift_state(|s| {
+                        &&& Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, n)(s)
+                        &&& n < rec_num
+                    })).satisfied_by(ex) by {
+                    let ongoing_reconciles = ex.head().ongoing_reconciles(controller_id);
+                    let reconciles_before_id = Map::new(
+                        |key| ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id,
+                        |key| ongoing_reconciles[key]
+                    );
+                    let n = reconciles_before_id.len();
+
+                    assert(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, n)(ex.head()));
+                    assert(n < rec_num);
+                    assert((|s| {
+                        &&& Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, n)(s)
+                        &&& n < rec_num
+                    })(ex.head()));
+                    assert(lift_state(|s| {
+                        &&& Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, n)(s)
+                        &&& n < rec_num
+                    }).satisfied_by(ex));
+                    assert((|n: nat| lift_state(|s| {
+                        &&& Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, n)(s)
+                        &&& n < rec_num
+                    }))(n).satisfied_by(ex));
+                }
+
+                let ongoing_reconciles_num_is_n_and_less_than_rec_num = |n: nat| lift_state(|s| {
+                    &&& Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, n)(s)
+                    &&& n < rec_num
+                });
+                entails_implies_leads_to(
+                    spec, 
+                    lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat)), 
+                    tla_exists(ongoing_reconciles_num_is_n_and_less_than_rec_num)
+                );
+
+                assert forall |n: nat| n < rec_num implies #[trigger] spec.entails(
+                    ongoing_reconciles_num_is_n_and_less_than_rec_num(n)
+                    .leads_to(lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id)))) by {
+                    
+                    self.lemma_ongoing_reconciles_num_is_n_leads_to_no_ongoing_reconciles(
+                        spec, controller_id, reconcile_id, n
+                    );
+
+                    leads_to_weaken(
+                        spec, lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, n)), lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id)),
+                        ongoing_reconciles_num_is_n_and_less_than_rec_num(n), lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id))
+                    );
+                }
+
+                leads_to_exists_intro(
+                    spec, ongoing_reconciles_num_is_n_and_less_than_rec_num, lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id))
+                );
+
+                leads_to_trans(
+                    spec,
+                    lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat)),
+                    tla_exists(ongoing_reconciles_num_is_n_and_less_than_rec_num),
+                    lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id))
+                );
+            }
+        );
+        
+        leads_to_trans(
+            spec, 
+            lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num)),
+            lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat)),
+            no_more_ongoing_reconciles
+        );
+
+        assert(spec.entails(lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))
+                .leads_to(lift_state(Self::no_reconcile_before_reconcile_id_is_ongoing(controller_id, reconcile_id)))));
+    }
+}
+
+pub proof fn lemma_ongoing_reconciles_num_decreases(
+    self, 
+    spec: TempPred<ClusterState>,
+    controller_id: int,
+    reconcile_id: ReconcileId,
+    rec_num: nat,
+    key: ObjectRef,
+)
+    requires
+        spec.entails(always(lift_action(self.next()))),
+        self.controller_models.contains_key(controller_id),
+        spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
+        spec.entails(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))),
+        spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+        spec.entails(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))))),
+        spec.entails(always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)))),
+        spec.entails(always(lift_state(Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)))),
+        rec_num > 0,
+    ensures 
+        spec.entails(
+            lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))
+                .and(lift_state(|s: ClusterState| s.ongoing_reconciles(controller_id).contains_key(key) 
+                    && s.ongoing_reconciles(controller_id)[key].reconcile_id < reconcile_id))
+                .leads_to(lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat)))
+        )
+{
+    let reconcile_ongoing = |key: ObjectRef| lift_state(|s: ClusterState|
+        s.ongoing_reconciles(controller_id).contains_key(key) && s.ongoing_reconciles(controller_id)[key].reconcile_id < reconcile_id
+    );
+    let ongoing_reconciles_num_is_n_and_reconcile_ongoing = |key: ObjectRef| 
+        lift_state(Self::ongoing_reconciles_num_is_n(controller_id, reconcile_id, rec_num))
+            .and(reconcile_ongoing(key));
+
+
+    // Set up wf1_variant_temp argument.
+    let invariant = |s: ClusterState| {
+        &&& Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, rec_num)(s)
+        &&& s.ongoing_reconciles(controller_id).contains_key(key)
+        &&& s.ongoing_reconciles(controller_id)[key].reconcile_id < reconcile_id
+    };
+
+    let stronger_next = |s, s_prime| {
+        self.next()(s, s_prime)
+        && Self::there_is_the_controller_state(controller_id)(s)
+        && Self::ongoing_reconciles_is_finite(controller_id)(s)
+        && Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)(s)
+        && Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id)(s)
+    };
+
+    // show spec |= [](p /\ next => p' \/ q')
+    assert forall |s, s_prime| invariant(s) && #[trigger] stronger_next(s, s_prime) 
+        implies invariant(s_prime) || Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat)(s_prime) by {
+
+        let step = choose |step| self.next_step(s, s_prime, step);
+        match step {
+            Step::ControllerStep((id, _, key_opt)) => {
+                let some_key = key_opt.unwrap();
+                if id == controller_id {
+                    let ongoing_reconciles = s.ongoing_reconciles(controller_id);
+                    let ongoing_reconciles_prime = s_prime.ongoing_reconciles(controller_id);
+
+                    let reconciles_before_id = Map::new(
+                        |key| ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id,
+                        |key| ongoing_reconciles[key]
+                    );
+                    let reconciles_before_id_prime = Map::new(
+                        |key| ongoing_reconciles_prime.contains_key(key) && ongoing_reconciles_prime[key].reconcile_id < reconcile_id,
+                        |key| ongoing_reconciles_prime[key]
+                    );
+
+                    if ongoing_reconciles_prime.len() > ongoing_reconciles.len() {
+                        assert(reconciles_before_id.dom() =~= reconciles_before_id_prime.dom());
+                    } else if ongoing_reconciles_prime.len() == ongoing_reconciles.len() {
+                        assert(reconciles_before_id.dom() =~= reconciles_before_id_prime.dom());
+                    } else {
+                        assert(reconciles_before_id.dom().remove(some_key) =~= reconciles_before_id_prime.dom());
+                    }
+                }
+            },
+            Step::RestartControllerStep(id) => {
+                if id == controller_id {
+                    let ongoing_reconciles = s_prime.ongoing_reconciles(controller_id);
+                    let reconciles_before_id = Map::new(
+                        |key| ongoing_reconciles.contains_key(key) && ongoing_reconciles[key].reconcile_id < reconcile_id,
+                        |key| ongoing_reconciles[key]
+                    );
+                    assert(ongoing_reconciles =~= reconciles_before_id);
+                    assert(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat)(s_prime));
+                }
+            },
+            _ => {}
+        }
+    }
+
+    // show spec |= []next.    
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next),
+        lift_action(self.next()),
+        lift_state(Self::there_is_the_controller_state(controller_id)),
+        lift_state(Self::ongoing_reconciles_is_finite(controller_id)),
+        lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)),
+        lift_state(Self::reconcile_id_counter_is_no_smaller_than(controller_id, reconcile_id))
+    );
+
+    // show spec |= []p ~> forward.
+    use_tla_forall(spec, |key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))), key);
+    entails_implies_leads_to(
+        spec,
+        always(lift_state(invariant)),
+        true_pred()
+    );
+    leads_to_trans(
+        spec,
+        always(lift_state(invariant)),
+        true_pred(),
+        lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key))
+    );
+
+    // apply wf1 argument.
+    wf1_variant_temp(
+        spec, lift_action(stronger_next), 
+        lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key)), 
+        lift_state(invariant), 
+        lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat))
+    );
+
+    entails_implies_leads_to(
+        spec,
+        ongoing_reconciles_num_is_n_and_reconcile_ongoing(key),
+        lift_state(invariant)
+    );
+    leads_to_trans(
+        spec,
+        ongoing_reconciles_num_is_n_and_reconcile_ongoing(key),
+        lift_state(invariant),
+        lift_state(Self::ongoing_reconciles_num_is_at_most_n(controller_id, reconcile_id, (rec_num - 1) as nat))
+    );
+}
 
 }
 

--- a/src/v2/kubernetes_cluster/proof/stability.rs
+++ b/src/v2/kubernetes_cluster/proof/stability.rs
@@ -1,4 +1,5 @@
-use crate::kubernetes_cluster::spec::cluster::*;
+use crate::kubernetes_cluster::spec::{cluster::*, message::Message};
+use crate::kubernetes_api_objects::spec::prelude::ObjectRef;
 use crate::state_machine::action::*;
 use crate::temporal_logic::{defs::*, rules::*};
 use vstd::prelude::*;
@@ -26,6 +27,21 @@ pub proof fn tla_forall_action_weak_fairness_is_stable<Input, Output>(
     let split_always = |input| always(lift_state(action.pre(input))).implies(eventually(lift_action(action.forward(input))));
     tla_forall_always_equality_variant::<ClusterState, Input>(|input| action.weak_fairness(input), split_always);
     always_p_is_stable::<ClusterState>(tla_forall(split_always));
+}
+
+// Prove weak_fairness for controller_next is stable.
+pub proof fn tla_forall_controller_next_weak_fairness_is_stable(
+    self, controller_id: int
+)
+    ensures
+        valid(stable(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1))))),
+{
+    let split_always = |i: (Option<Message>, Option<ObjectRef>)| {
+        always(lift_state(self.controller_next().pre((controller_id, i.0, i.1))))
+            .implies(eventually(lift_action(self.controller_next().forward((controller_id, i.0, i.1)))))
+    };
+    tla_forall_always_equality_variant(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)), split_always);
+    always_p_is_stable(tla_forall(split_always));
 }
 
 }


### PR DESCRIPTION
This lemma shows that if the spec ensures every newly started reconcile for a given controller_id satisfies some requirements (including termination of reconciles), the system will eventually reaches a state where all ongoing reconciles of that controller_id satisfy those requirements.