### PR TITLE
Add a reconcile_id to each ongoing reconcile

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
@@ -606,6 +606,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_create_pod_req(
 }
 
 // TODO: Investigate flaky proof.
+#[verifier(rlimit(4000))]
 pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     req_msg: Message, diff: int

--- a/src/v2/kubernetes_cluster/spec/cluster.rs
+++ b/src/v2/kubernetes_cluster/spec/cluster.rs
@@ -358,6 +358,9 @@ impl Cluster {
     // is equivalent to the behavior that a controller no longer gets scheduled from t1 and
     // then restarts at t2, as long as a crashed controller won't trigger new actions.
     //
+    // Note that to simplify reasoning, although restarting a controller will stop
+    // all ongoing_reconciles, a restart will preserve the reconcile_id_allocator.
+    //
     // Note that weak fairness on the controller's action is not a problem here:
     // weak fairness only says that the controller eventually takes a step if it remains enabled,
     // so even with weak fairness the controller can still stay "offline" from t1 to t2.
@@ -375,6 +378,7 @@ impl Cluster {
                     controller: ControllerState {
                         scheduled_reconciles: Map::<ObjectRef, DynamicObjectView>::empty(),
                         ongoing_reconciles: Map::<ObjectRef, OngoingReconcile>::empty(),
+                        reconcile_id_allocator: controller_and_external_state.controller.reconcile_id_allocator,
                     },
                     ..controller_and_external_state
                 };


### PR DESCRIPTION
This introduces a `reconcile_id` field for each `OngoingReconcile` for a controller. When a reconcile is started, the allocator is queried for a new `reconcile_id`, and then is incremented. The `reconcile_id_allocator` is unique to each controller installed in the cluster, but is preserved across controller restarts for easier reasoning.

This addition slows down the proof for `lemma_from_after_send_create_pod_req_to_receive_ok_resp`, where I had to increase `rlimit`.

This is in service of a proof for the lemma proposed in https://github.com/anvil-verifier/anvil/pull/580 . 