### PR TITLE
Prove some basic lemmas about reconcile_id

### DIFF
--- a/src/v2/kubernetes_cluster/spec/cluster.rs
+++ b/src/v2/kubernetes_cluster/spec/cluster.rs
@@ -57,8 +57,18 @@ impl ClusterState {
         self.controller_and_externals[controller_id].controller.scheduled_reconciles
     }
 
+    #[verifier(inline)]
+    pub open spec fn reconcile_id_allocator(self, controller_id: int) -> ReconcileIdAllocator {
+        self.controller_and_externals[controller_id].controller.reconcile_id_allocator
+    }
+
     pub open spec fn has_rpc_id_counter_no_smaller_than(self, rpc_id: nat) -> bool {
         self.rpc_id_allocator.rpc_id_counter >= rpc_id
+    }
+
+    pub open spec fn has_reconcile_id_counter_no_smaller_than(self, controller_id: int, reconcile_id: nat) -> bool {
+        self.controller_and_externals[controller_id].controller.reconcile_id_allocator.reconcile_id_counter
+            >= reconcile_id
     }
 }
 


### PR DESCRIPTION
Here some properties of the recently-introduced `reconcile_id` are proved. Recall that these are parameterized per `controller_id`, or per controller installed.

- If the `reconcile_id_allocator` is at a certain state, all started reconciles after that point have a greater `reconcile_id`.
- All ongoing reconciles have a `reconcile_id` less than the corresponding allocator.
- All ongoing reconciles have different `reconcile_id` fields.