### PR TITLE
Fix broken CI, add cache support for Verus build result, update CI OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           ./tools/get-z3.sh
           . "$HOME/.cargo/env"
           . ../tools/activate
+          echo $VARGO_TOOLCHAIN
+          rustup show active-toolchain
           vargo clean
           vargo build --release
       - name: Cache verus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install Rust toolchain
         run:
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Download Verus
         uses: actions/checkout@v2
         with:
@@ -44,13 +45,14 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
             verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
-      - name: Verify fluent controllerc
+      - name: Verify fluent controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh fluent_controller.rs --time --rlimit 50
   rabbitmq-verification:
     runs-on: ubuntu-22.04
@@ -58,6 +60,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -72,6 +75,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -86,6 +90,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -100,6 +105,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -114,6 +120,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -128,6 +135,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -144,6 +152,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -168,6 +177,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -182,6 +192,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -203,6 +214,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Deploy fluent controller
         run: ./local-test.sh fluent
       - name: Run fluent e2e tests
@@ -220,6 +232,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests
@@ -237,6 +250,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for scaling
@@ -254,6 +268,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for ephemeral
@@ -271,6 +286,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests
@@ -288,6 +304,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests for scaling
@@ -305,6 +322,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          source .cargo/env
       - name: Deploy vreplicaset controller
         run: ./local-test.sh vreplicaset
       - name: Run vreplicaset e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -63,6 +64,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -80,6 +82,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -97,6 +100,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -114,6 +118,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -131,6 +136,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -194,6 +200,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -211,6 +218,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
       - name: Pin home to version 0.5.9 (workaround)
         run: |
           mv verus ../verus
+          ls -al
           cargo update home --precise 0.5.9
       - name: Run unit tests
         run: cargo test unit_tests
@@ -200,6 +201,7 @@ jobs:
       - name: Pin home to version 0.5.9 (workaround)
         run: |
           mv verus ../verus
+          ls -al
           cargo update home --precise 0.5.9
       - name: Run conformance tests
         run: cargo test conformance_tests -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Download Verus
         uses: actions/checkout@v2
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -75,7 +75,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -90,7 +90,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -105,7 +105,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -120,7 +120,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -135,7 +135,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -152,7 +152,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -177,7 +177,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -192,7 +192,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -214,7 +214,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Deploy fluent controller
         run: ./local-test.sh fluent
       - name: Run fluent e2e tests
@@ -232,7 +232,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests
@@ -250,7 +250,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for scaling
@@ -268,7 +268,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for ephemeral
@@ -286,7 +286,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests
@@ -304,7 +304,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests for scaling
@@ -322,7 +322,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . .cargo/env
+          . "$HOME/.cargo/env"
       - name: Deploy vreplicaset controller
         run: ./local-test.sh vreplicaset
       - name: Run vreplicaset e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           . "$HOME/.cargo/env"
-          rustup --version
-          rustup toolchain install
+          rustup toolchain install 1.82.0-x86_64-unknown-linux-gnu
       - name: Download Verus
         uses: actions/checkout@v2
         with:
@@ -29,11 +28,11 @@ jobs:
           ref: 6b278074651d520825ea62fe2079ed1e3959cb69
       - name: Build Verus
         run: |
-          . "$HOME/.cargo/env"
           cd verus/source
           ./tools/get-z3.sh
+          . "$HOME/.cargo/env"
           . ../tools/activate
-          rustup show active-toolchain
+          vargo clean
           vargo build --release
       - name: Cache verus
         uses: actions/cache@v4
@@ -49,7 +48,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -64,7 +63,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -79,7 +78,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -94,7 +93,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -109,7 +108,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -124,7 +123,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -139,7 +138,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -156,7 +155,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -181,7 +180,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -196,7 +195,7 @@ jobs:
     steps:
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -217,7 +216,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Deploy fluent controller
         run: ./local-test.sh fluent
       - name: Run fluent e2e tests
@@ -234,7 +233,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests
@@ -251,7 +250,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for scaling
@@ -268,7 +267,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for ephemeral
@@ -285,7 +284,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests
@@ -302,7 +301,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests for scaling
@@ -319,7 +318,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
       - name: Deploy vreplicaset controller
         run: ./local-test.sh vreplicaset
       - name: Run vreplicaset e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Download Verus if cache is missing
         if: steps.cache-verus.outputs.cache-hit != 'true'
@@ -35,8 +35,7 @@ jobs:
       - name: Build Verus if cache is missing
         if: steps.cache-verus.outputs.cache-hit != 'true'
         run: |
-          mv verus ../verus
-          cd ../verus
+          cd verus
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           . "$HOME/.cargo/env"
           rustup toolchain install
@@ -59,10 +58,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify fluent controller
-        run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh fluent_controller.rs --time --rlimit 50
+        run: VERUS_DIR="${PWD}/verus" ./build.sh fluent_controller.rs --time --rlimit 50
   rabbitmq-verification:
     needs: build-verus
     runs-on: ubuntu-22.04
@@ -77,10 +76,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify rabbitmq controller
-        run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh rabbitmq_controller.rs --time --rlimit 50
+        run: VERUS_DIR="${PWD}/verus" ./build.sh rabbitmq_controller.rs --time --rlimit 50
   zookeeper-verification:
     needs: build-verus
     runs-on: ubuntu-22.04
@@ -95,10 +94,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify zookeeper controller
-        run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh zookeeper_controller.rs --time --rlimit 100
+        run: VERUS_DIR="${PWD}/verus" ./build.sh zookeeper_controller.rs --time --rlimit 100
   vreplicaset-verification:
     needs: build-verus
     runs-on: ubuntu-22.04
@@ -113,10 +112,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vreplicaset controller
-        run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh vreplicaset_controller.rs --time
+        run: VERUS_DIR="${PWD}/verus" ./build.sh vreplicaset_controller.rs --time
   v2-vreplicaset-verification:
     needs: build-verus
     runs-on: ubuntu-22.04
@@ -131,10 +130,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vreplicaset controller
-        run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vreplicaset_controller.rs --rlimit 50 --time
+        run: VERUS_DIR="${PWD}/verus" ./build.sh v2_vreplicaset_controller.rs --rlimit 50 --time
   v2-vdeployment-verification:
     needs: build-verus
     runs-on: ubuntu-22.04
@@ -149,10 +148,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vdeployment controller
-        run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vdeployment_controller.rs --rlimit 50 --time
+        run: VERUS_DIR="${PWD}/verus" ./build.sh v2_vdeployment_controller.rs --rlimit 50 --time
   unit-tests:
     needs: build-verus
     runs-on: ubuntu-22.04
@@ -167,7 +166,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Pin home to version 0.5.9 (workaround)
         run: cargo update home --precise 0.5.9
@@ -186,7 +185,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -214,10 +213,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify conformance of the executable model
-        run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil.rs --crate-type lib --time
+        run: VERUS_DIR="${PWD}/verus" ./build.sh anvil.rs --crate-type lib --time
   framework-v2-verification:
     needs: build-verus
     runs-on: ubuntu-22.04
@@ -232,10 +231,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/source
+            verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify conformance of the executable model
-        run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil_v2.rs --crate-type lib --rlimit 50 --time
+        run: VERUS_DIR="${PWD}/verus" ./build.sh anvil_v2.rs --crate-type lib --rlimit 50 --time
   fluent-e2e-test:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,9 @@ jobs:
             verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Pin home to version 0.5.9 (workaround)
-        run: cargo update home --precise 0.5.9
+        run: |
+          mv verus ../verus
+          cargo update home --precise 0.5.9
       - name: Run unit tests
         run: cargo test unit_tests
   conformance-tests:
@@ -196,7 +198,9 @@ jobs:
       - name: Set up a kind cluster
         run: kind create cluster
       - name: Pin home to version 0.5.9 (workaround)
-        run: cargo update home --precise 0.5.9
+        run: |
+          mv verus ../verus
+          cargo update home --precise 0.5.9
       - name: Run conformance tests
         run: cargo test conformance_tests -- --nocapture
   framework-verification:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Download Verus
         uses: actions/checkout@v2
         with:
@@ -27,6 +26,7 @@ jobs:
           ref: 6b278074651d520825ea62fe2079ed1e3959cb69
       - name: Build Verus
         run: |
+          . "$HOME/.cargo/env"
           cd verus/source
           ./tools/get-z3.sh
           . ../tools/activate
@@ -40,12 +40,12 @@ jobs:
           restore-keys: |
             verus-
   fluent-verification:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -55,12 +55,12 @@ jobs:
       - name: Verify fluent controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh fluent_controller.rs --time --rlimit 50
   rabbitmq-verification:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -70,12 +70,12 @@ jobs:
       - name: Verify rabbitmq controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh rabbitmq_controller.rs --time --rlimit 50
   zookeeper-verification:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -85,12 +85,12 @@ jobs:
       - name: Verify zookeeper controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh zookeeper_controller.rs --time --rlimit 100
   vreplicaset-verification:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -100,12 +100,12 @@ jobs:
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh vreplicaset_controller.rs --time
   v2-vreplicaset-verification:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -115,12 +115,12 @@ jobs:
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vreplicaset_controller.rs --rlimit 50 --time
   v2-vdeployment-verification:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -130,12 +130,12 @@ jobs:
       - name: Verify vdeployment controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vdeployment_controller.rs --rlimit 50 --time
   unit-tests:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -147,12 +147,12 @@ jobs:
       - name: Run unit tests
         run: cargo test unit_tests
   conformance-tests:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -172,12 +172,12 @@ jobs:
       - name: Run conformance tests
         run: cargo test conformance_tests -- --nocapture
   framework-verification:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -187,12 +187,12 @@ jobs:
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil.rs --crate-type lib --time
   framework-v2-verification:
+    needs: build-verus
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -214,7 +214,6 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Deploy fluent controller
         run: ./local-test.sh fluent
       - name: Run fluent e2e tests
@@ -232,7 +231,6 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests
@@ -250,7 +248,6 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for scaling
@@ -268,7 +265,6 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for ephemeral
@@ -286,7 +282,6 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests
@@ -304,7 +299,6 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests for scaling
@@ -322,7 +316,6 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          . "$HOME/.cargo/env"
       - name: Deploy vreplicaset controller
         run: ./local-test.sh vreplicaset
       - name: Run vreplicaset e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,7 @@ jobs:
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Pin home to version 0.5.9 (workaround)
         run: |
-          mv verus ../verus
-          ls -al
+          sed -i "s/\.\.\/verus/verus/g" Cargo.toml
           cargo update home --precise 0.5.9
       - name: Run unit tests
         run: cargo test unit_tests
@@ -179,6 +178,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -200,8 +200,7 @@ jobs:
         run: kind create cluster
       - name: Pin home to version 0.5.9 (workaround)
         run: |
-          mv verus ../verus
-          ls -al
+          sed -i "s/\.\.\/verus/verus/g" Cargo.toml
           cargo update home --precise 0.5.9
       - name: Run conformance tests
         run: cargo test conformance_tests -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   #     - "doc/**"
   pull_request:
   merge_group:
-  workflow_dispatch:env:
+  workflow_dispatch:
 env:
   verus_commit: 6b278074651d520825ea62fe2079ed1e3959cb69
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,199 +12,150 @@ on:
   merge_group:
   workflow_dispatch:
 jobs:
-  fluent-verification:
-    runs-on: ubuntu-20.04
+  build-verus:
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        run:
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
       - name: Download Verus
         uses: actions/checkout@v2
         with:
           repository: verus-lang/verus
           path: verus
           ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
-      - name: Install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
           ./tools/get-z3.sh
           source ../tools/activate
           vargo build --release
-      - name: Verify fluent controller
+      - name: Cache verus
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
+          restore-keys: |
+            verus-
+  fluent-verification:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
+      - name: Verify fluent controllerc
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh fluent_controller.rs --time --rlimit 50
   rabbitmq-verification:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify rabbitmq controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh rabbitmq_controller.rs --time --rlimit 50
   zookeeper-verification:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify zookeeper controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh zookeeper_controller.rs --time --rlimit 100
   vreplicaset-verification:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh vreplicaset_controller.rs --time
   v2-vreplicaset-verification:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vreplicaset_controller.rs --rlimit 50 --time
   v2-vdeployment-verification:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify vdeployment controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vdeployment_controller.rs --rlimit 50 --time
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Pin home to version 0.5.9 (workaround)
         run: cargo update home --precise 0.5.9
       - name: Run unit tests
         run: cargo test unit_tests
   conformance-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
           go-version: "^1.20"
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.23.0
-      - name: Install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Set up a kind cluster
         run: kind create cluster
       - name: Pin home to version 0.5.9 (workaround)
@@ -212,53 +163,35 @@ jobs:
       - name: Run conformance tests
         run: cargo test conformance_tests -- --nocapture
   framework-verification:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil.rs --crate-type lib --time
   framework-v2-verification:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Download Verus
-        uses: actions/checkout@v2
-        with:
-          repository: verus-lang/verus
-          path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Move Verus
-        run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
-      - name: Build Verus
-        run: |
-          cd ../verus/source
-          ./tools/get-z3.sh
-          source ../tools/activate
-          vargo build --release
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            verus
+          key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil_v2.rs --crate-type lib --rlimit 50 --time
   fluent-e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -269,13 +202,13 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
       - name: Deploy fluent controller
         run: ./local-test.sh fluent
       - name: Run fluent e2e tests
         run: cd e2e && cargo run -- fluent
   rabbitmq-e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -286,13 +219,13 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests
         run: cd e2e && cargo run -- rabbitmq
   rabbitmq-scaling-e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -303,13 +236,13 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for scaling
         run: cd e2e && cargo run -- rabbitmq-scaling
   rabbitmq-ephemeral-e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -320,13 +253,13 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for ephemeral
         run: cd e2e && cargo run -- rabbitmq-ephemeral
   zookeeper-e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -337,13 +270,13 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests
         run: cd e2e && cargo run -- zookeeper
   zookeeper-scaling-e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -354,13 +287,13 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests for scaling
         run: cd e2e && cargo run -- zookeeper-scaling
   vreplicaset-e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go
@@ -371,7 +304,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
       - name: Deploy vreplicaset controller
         run: ./local-test.sh vreplicaset
       - name: Run vreplicaset e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Rust toolchain
-        run:
+        run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Download Verus
         uses: actions/checkout@v2
         with:
@@ -29,7 +29,7 @@ jobs:
         run: |
           cd verus/source
           ./tools/get-z3.sh
-          source ../tools/activate
+          . ../tools/activate
           vargo build --release
       - name: Cache verus
         uses: actions/cache@v4
@@ -45,7 +45,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -75,7 +75,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -90,7 +90,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -105,7 +105,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -120,7 +120,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -135,7 +135,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -152,7 +152,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -177,7 +177,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -192,7 +192,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Restore build cache
         uses: actions/cache@v4
         with:
@@ -214,7 +214,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Deploy fluent controller
         run: ./local-test.sh fluent
       - name: Run fluent e2e tests
@@ -232,7 +232,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests
@@ -250,7 +250,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for scaling
@@ -268,7 +268,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for ephemeral
@@ -286,7 +286,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests
@@ -304,7 +304,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests for scaling
@@ -322,7 +322,7 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
-          source .cargo/env
+          . .cargo/env
       - name: Deploy vreplicaset controller
         run: ./local-test.sh vreplicaset
       - name: Run vreplicaset e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,38 +10,41 @@ on:
   #     - "doc/**"
   pull_request:
   merge_group:
-  workflow_dispatch:
+  workflow_dispatch:env:
+env:
+  verus_commit: 6b278074651d520825ea62fe2079ed1e3959cb69
+
 jobs:
   build-verus:
     runs-on: ubuntu-22.04
     steps:
-      - name: Install Rust toolchain
-        run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
-          . "$HOME/.cargo/env"
-          rustup toolchain install
-      - name: Download Verus
-        uses: actions/checkout@v2
+      - name: Find Verus build from cache
+        id: cache-verus
+        uses: actions/cache@v4
+        with:
+          path: |
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
+      - name: Download Verus if cache is missing
+        if: steps.cache-verus.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
         with:
           repository: verus-lang/verus
           path: verus
-          ref: 6b278074651d520825ea62fe2079ed1e3959cb69
-      - name: Build Verus
+          ref: ${{ env.verus_commit }}
+      - name: Build Verus if cache is missing
+        if: steps.cache-verus.outputs.cache-hit != 'true'
         run: |
           mv verus ../verus
-          cd ../verus/source
+          cd ../verus
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
+          cd source
           ./tools/get-z3.sh
           . ../tools/activate
           vargo clean
           vargo build --release
-      - name: Cache verus
-        uses: actions/cache@v4
-        with:
-          path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
-          restore-keys: |
-            verus-
   fluent-verification:
     needs: build-verus
     runs-on: ubuntu-22.04
@@ -56,8 +59,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify fluent controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh fluent_controller.rs --time --rlimit 50
   rabbitmq-verification:
@@ -74,8 +77,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify rabbitmq controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh rabbitmq_controller.rs --time --rlimit 50
   zookeeper-verification:
@@ -92,8 +95,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify zookeeper controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh zookeeper_controller.rs --time --rlimit 100
   vreplicaset-verification:
@@ -110,8 +113,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh vreplicaset_controller.rs --time
   v2-vreplicaset-verification:
@@ -128,8 +131,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vreplicaset_controller.rs --rlimit 50 --time
   v2-vdeployment-verification:
@@ -146,8 +149,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vdeployment controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vdeployment_controller.rs --rlimit 50 --time
   unit-tests:
@@ -163,8 +166,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Pin home to version 0.5.9 (workaround)
         run: cargo update home --precise 0.5.9
       - name: Run unit tests
@@ -182,10 +185,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
       - name: Install kind
@@ -210,8 +213,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil.rs --crate-type lib --time
   framework-v2-verification:
@@ -228,16 +231,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus
-          key: verus-${{ hashFiles('source/Cargo.lock') }}
+            ../verus/target/release/
+          key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil_v2.rs --crate-type lib --rlimit 50 --time
   fluent-e2e-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
       - name: Install kind
@@ -254,9 +257,9 @@ jobs:
   rabbitmq-e2e-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
       - name: Install kind
@@ -273,9 +276,9 @@ jobs:
   rabbitmq-scaling-e2e-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
       - name: Install kind
@@ -292,9 +295,9 @@ jobs:
   rabbitmq-ephemeral-e2e-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
       - name: Install kind
@@ -311,9 +314,9 @@ jobs:
   zookeeper-e2e-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
       - name: Install kind
@@ -330,9 +333,9 @@ jobs:
   zookeeper-scaling-e2e-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
       - name: Install kind
@@ -349,9 +352,9 @@ jobs:
   vreplicaset-e2e-test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: "^1.20"
       - name: Install kind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Download Verus if cache is missing
         if: steps.cache-verus.outputs.cache-hit != 'true'
@@ -59,6 +60,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify fluent controller
         run: VERUS_DIR="${PWD}/verus" ./build.sh fluent_controller.rs --time --rlimit 50
@@ -77,6 +79,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify rabbitmq controller
         run: VERUS_DIR="${PWD}/verus" ./build.sh rabbitmq_controller.rs --time --rlimit 50
@@ -95,6 +98,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify zookeeper controller
         run: VERUS_DIR="${PWD}/verus" ./build.sh zookeeper_controller.rs --time --rlimit 100
@@ -113,6 +117,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="${PWD}/verus" ./build.sh vreplicaset_controller.rs --time
@@ -131,6 +136,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="${PWD}/verus" ./build.sh v2_vreplicaset_controller.rs --rlimit 50 --time
@@ -149,6 +155,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vdeployment controller
         run: VERUS_DIR="${PWD}/verus" ./build.sh v2_vdeployment_controller.rs --rlimit 50 --time
@@ -167,6 +174,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Pin home to version 0.5.9 (workaround)
         run: |
@@ -189,6 +197,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -219,6 +228,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="${PWD}/verus" ./build.sh anvil.rs --crate-type lib --time
@@ -237,6 +247,7 @@ jobs:
         with:
           path: |
             verus/source
+            verus/dependencies
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="${PWD}/verus" ./build.sh anvil_v2.rs --crate-type lib --rlimit 50 --time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Download Verus if cache is missing
         if: steps.cache-verus.outputs.cache-hit != 'true'
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify fluent controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh fluent_controller.rs --time --rlimit 50
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify rabbitmq controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh rabbitmq_controller.rs --time --rlimit 50
@@ -95,7 +95,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify zookeeper controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh zookeeper_controller.rs --time --rlimit 100
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh vreplicaset_controller.rs --time
@@ -131,7 +131,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vreplicaset_controller.rs --rlimit 50 --time
@@ -149,7 +149,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify vdeployment controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vdeployment_controller.rs --rlimit 50 --time
@@ -157,6 +157,7 @@ jobs:
     needs: build-verus
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
@@ -166,7 +167,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Pin home to version 0.5.9 (workaround)
         run: cargo update home --precise 0.5.9
@@ -185,7 +186,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -213,7 +214,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil.rs --crate-type lib --time
@@ -231,7 +232,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ../verus/target/release/
+            ../verus/source
           key: verus-${{ runner.os }}-${{ env.verus_commit }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil_v2.rs --crate-type lib --rlimit 50 --time

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           . "$HOME/.cargo/env"
-          rustup toolchain install 1.82.0-x86_64-unknown-linux-gnu
+          which rustup
+          rustup --version
+          rustup toolchain install
       - name: Download Verus
         uses: actions/checkout@v2
         with:
@@ -30,7 +32,6 @@ jobs:
         run: |
           cd verus/source
           ./tools/get-z3.sh
-          . "$HOME/.cargo/env"
           . ../tools/activate
           echo $VARGO_TOOLCHAIN
           rustup show active-toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnu -y
+          . "$HOME/.cargo/env"
+          rustup --version
+          rustup toolchain install
       - name: Download Verus
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           cd verus/source
           ./tools/get-z3.sh
           . ../tools/activate
+          rustup show active-toolchain
           vargo build --release
       - name: Cache verus
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -49,7 +49,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -72,7 +72,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -95,7 +95,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -118,7 +118,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -141,7 +141,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -164,7 +164,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -189,7 +189,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -204,7 +204,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Set up a kind cluster
         run: kind create cluster
       - name: Pin home to version 0.5.9 (workaround)
@@ -225,7 +225,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -248,7 +248,7 @@ jobs:
         run: mv verus ../verus
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Build Verus
         run: |
           cd ../verus/source
@@ -269,7 +269,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Deploy fluent controller
         run: ./local-test.sh fluent
       - name: Run fluent e2e tests
@@ -286,7 +286,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests
@@ -303,7 +303,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for scaling
@@ -320,7 +320,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for ephemeral
@@ -337,7 +337,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests
@@ -354,7 +354,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests for scaling
@@ -371,7 +371,7 @@ jobs:
         run: go install sigs.k8s.io/kind@v0.23.0
       - name: Install Rust toolchain
         run: |
-          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain 1.82.0-x86_64-unknown-linux-gnue -y
       - name: Deploy vreplicaset controller
         run: ./local-test.sh vreplicaset
       - name: Run vreplicaset e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
           . "$HOME/.cargo/env"
-          which rustup
-          rustup --version
           rustup toolchain install
       - name: Download Verus
         uses: actions/checkout@v2
@@ -30,18 +28,17 @@ jobs:
           ref: 6b278074651d520825ea62fe2079ed1e3959cb69
       - name: Build Verus
         run: |
-          cd verus/source
+          mv verus ../verus
+          cd ../verus/source
           ./tools/get-z3.sh
           . ../tools/activate
-          echo $VARGO_TOOLCHAIN
-          rustup show active-toolchain
           vargo clean
           vargo build --release
       - name: Cache verus
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
           restore-keys: |
             verus-
@@ -52,11 +49,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify fluent controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh fluent_controller.rs --time --rlimit 50
@@ -67,11 +66,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify rabbitmq controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh rabbitmq_controller.rs --time --rlimit 50
@@ -82,11 +83,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify zookeeper controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh zookeeper_controller.rs --time --rlimit 100
@@ -97,11 +100,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh vreplicaset_controller.rs --time
@@ -112,11 +117,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify vreplicaset controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vreplicaset_controller.rs --rlimit 50 --time
@@ -127,11 +134,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify vdeployment controller
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh v2_vdeployment_controller.rs --rlimit 50 --time
@@ -142,11 +151,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Pin home to version 0.5.9 (workaround)
         run: cargo update home --precise 0.5.9
@@ -159,11 +170,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Setup Go
         uses: actions/setup-go@v2
@@ -184,11 +197,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil.rs --crate-type lib --time
@@ -199,11 +214,13 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: |
-            verus
+            ../verus
           key: verus-${{ hashFiles('source/Cargo.lock') }}
       - name: Verify conformance of the executable model
         run: VERUS_DIR="$(dirname "${PWD}")/verus" ./build.sh anvil_v2.rs --crate-type lib --rlimit 50 --time
@@ -220,6 +237,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Deploy fluent controller
         run: ./local-test.sh fluent
       - name: Run fluent e2e tests
@@ -237,6 +256,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests
@@ -254,6 +275,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for scaling
@@ -271,6 +294,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Deploy rabbitmq controller
         run: ./local-test.sh rabbitmq
       - name: Run rabbitmq e2e tests for ephemeral
@@ -288,6 +313,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests
@@ -305,6 +332,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Deploy zookeeper controller
         run: ./local-test.sh zookeeper
       - name: Run zookeeper e2e tests for scaling
@@ -322,6 +351,8 @@ jobs:
       - name: Install Rust toolchain
         run: |
           curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          . "$HOME/.cargo/env"
+          rustup toolchain install
       - name: Deploy vreplicaset controller
         run: ./local-test.sh vreplicaset
       - name: Run vreplicaset e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           ref: 6b278074651d520825ea62fe2079ed1e3959cb69
       - name: Build Verus
         run: |
-          cd ../verus/source
+          cd verus/source
           ./tools/get-z3.sh
           source ../tools/activate
           vargo build --release

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-c"]
 
 COPY . .
 
-RUN apt install -y pkg-config libssl-dev
+RUN apt-get update && apt-get install -y pkg-config libssl-dev
 
 RUN VERUS_DIR=/verus ./build.sh ${APP}_controller.rs --no-verify --time
 RUN mv /anvil/src/${APP}_controller /anvil/src/controller


### PR DESCRIPTION
- Fixed broken CI caused by rust toolchain update
- Added cache support for Verus build
  - As we checked out the commit ID the cache will always be reused, so we could save 3mins for every jobs in CI
- Bumped Github action API call version and runner OS version
  - Cache for Go environment is enabled by default since V4

However, as action cache does not support caching on relative path (we put Verus in `../verus` before), and there is no convenient way to get runner root dir instead of project root dir. There are 2 ways to workaround:
1. Export runner root dir in action runtime to action env, cache `${{env.runer_root}}/verus`, and reuse in each cache fetch
2. Just put verus in project root, which expands to `anvil/verus`. Require some runtime modification on CI jobs, together with runtime modification in `Cargo.toml`.

Currently I'm using the 2nd way.

BTW, if we switch to vargo from cargo we can(?) also skip the installation of rust toolchains for most of the jobs.