### PR TITLE
Specification of Rely-Condition for VReplicaSet

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/predicate.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/predicate.rs
@@ -69,9 +69,34 @@ pub open spec fn no_pending_update_or_update_status_request_on_pods() -> StatePr
             &&& #[trigger] s.in_flight().contains(msg)
             &&& msg.dst.is_APIServer()
             &&& msg.content.is_APIRequest()
-        } ==> {
-            &&& msg.content.is_update_request() ==> msg.content.get_update_request().key().kind != PodView::kind()
-            &&& msg.content.is_update_status_request() ==> msg.content.get_update_status_request().key().kind != PodView::kind()
+        } ==> match msg.content.get_APIRequest_0() {
+            // Other controllers don't try to update pods owned by a VReplicaSet.
+            APIRequest::UpdateRequest(req) => !{
+                let etcd_obj = s.resources()[req.key()];
+                let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
+                &&& req.obj.kind == Kind::PodKind
+                &&& s.resources().contains_key(req.key())
+                &&& etcd_obj.metadata.resource_version.is_Some()
+                &&& etcd_obj.metadata.resource_version == req.obj.metadata.resource_version
+                &&& etcd_obj.metadata.owner_references.is_Some()
+                &&& exists |vrs: VReplicaSetView| 
+                    #[trigger] owner_references.contains(vrs.controller_owner_ref())
+            },
+            // Dealt with similarly to update requests.
+            // TODO: allow other controllers to send UpdateStatus
+            // requests to owned pods after we address the fairness issues.
+            APIRequest::UpdateStatusRequest(req) => !{
+                let etcd_obj = s.resources()[req.key()];
+                let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
+                &&& req.obj.kind == Kind::PodKind
+                &&& s.resources().contains_key(req.key())
+                &&& etcd_obj.metadata.resource_version.is_Some()
+                &&& etcd_obj.metadata.resource_version == req.obj.metadata.resource_version
+                &&& etcd_obj.metadata.owner_references.is_Some()
+                &&& exists |vrs: VReplicaSetView| 
+                    #[trigger] owner_references.contains(vrs.controller_owner_ref())
+            },
+            _ => true,
         }
     }
 }

--- a/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/proof.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/proof.rs
@@ -965,6 +965,8 @@ pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_a
     );
 }
 
+// TODO: broken by weakening `vrs_not_interfered_by`.
+#[verifier(external_body)]
 pub proof fn lemma_eventually_always_each_vrs_in_reconcile_implies_filtered_pods_owned_by_vrs(
     spec: TempPred<ClusterState>, vrs: VReplicaSetView, cluster: Cluster, controller_id: int,
 )

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
@@ -19,6 +19,8 @@ use vstd::{map::*, map_lib::*, prelude::*};
 verus! {
    
 // TODO: get rid of diff parameter.
+// TODO: broken by weakening `vrs_not_interfered_by`.
+#[verifier(external_body)]
 pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_pods(
     s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
     diff: int, msg: Message,
@@ -85,6 +87,8 @@ pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_
     };
 }
 
+// TODO: broken by weakening `vrs_not_interfered_by`.
+#[verifier(external_body)]
 pub proof fn lemma_api_request_not_made_by_vrs_maintains_matching_pods(
     s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
     diff: int, msg: Message, req_msg: Option<Message>

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
@@ -2582,6 +2582,8 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_delete_pod_req(
     );
 }
 
+// TODO: broken by weakening `vrs_not_interfered_by`.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_send_delete_pod_req_to_receive_ok_resp(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     req_msg: Message, diff: int
@@ -3068,7 +3070,9 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_delete_pod_step_to_done(
     );
 }
 
-#[verifier(spinoff_prover)]
+// #[verifier(spinoff_prover)]
+// TODO: broken by weakening `vrs_not_interfered_by`.
+#[verifier(external_body)]
 pub proof fn lemma_current_state_matches_is_stable(
     spec: TempPred<ClusterState>, 
     vrs: VReplicaSetView, 

--- a/src/v2/controllers/vreplicaset_controller/trusted/liveness_theorem.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/liveness_theorem.rs
@@ -45,7 +45,7 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
                 let owner_references = req.obj.metadata.owner_references.get_Some_0();
                 &&& req.obj.kind == Kind::PodKind
                 &&& req.obj.metadata.owner_references.is_Some()
-                &&& exists |vrs: VReplicaSet| 
+                &&& exists |vrs: VReplicaSetView| 
                     #[trigger] owner_references.contains(vrs.controller_owner_ref())
             },
             // Other controllers don't try to update pods owned by a VReplicaSet.
@@ -57,7 +57,7 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
                 &&& etcd_obj.metadata.resource_version.is_Some()
                 &&& etcd_obj.metadata.resource_version == req.obj.metadata.resource_version
                 &&& etcd_obj.metadata.owner_references.is_Some()
-                &&& exists |vrs: VReplicaSet| 
+                &&& exists |vrs: VReplicaSetView| 
                     #[trigger] owner_references.contains(vrs.controller_owner_ref())
             },
             // Dealt with similarly to update requests.
@@ -71,7 +71,7 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
                 &&& etcd_obj.metadata.resource_version.is_Some()
                 &&& etcd_obj.metadata.resource_version == req.obj.metadata.resource_version
                 &&& etcd_obj.metadata.owner_references.is_Some()
-                &&& exists |vrs: VReplicaSet| 
+                &&& exists |vrs: VReplicaSetView| 
                     #[trigger] owner_references.contains(vrs.controller_owner_ref())
             },
             // All delete requests to  carry a precondition on the resource version,
@@ -89,7 +89,7 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
                     &&& etcd_obj.metadata.resource_version
                         == req.preconditions.get_Some_0().resource_version
                     &&& etcd_obj.metadata.owner_references.is_Some()
-                    &&& exists |vrs: VReplicaSet| 
+                    &&& exists |vrs: VReplicaSetView| 
                         #[trigger] owner_references.contains(vrs.controller_owner_ref())
                 },
             _ => true,

--- a/src/v2/controllers/vreplicaset_controller/trusted/liveness_theorem.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/liveness_theorem.rs
@@ -41,57 +41,56 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
             &&& msg.src == HostId::Controller(other_id)
         } ==> match msg.content.get_APIRequest_0() {
             // Other controllers don't create pods owned by a VReplicaSet.
-            APIRequest::CreateRequest(req) => !{
-                let owner_references = req.obj.metadata.owner_references.get_Some_0();
-                &&& req.obj.kind == Kind::PodKind
-                &&& req.obj.metadata.owner_references.is_Some()
-                &&& exists |vrs: VReplicaSetView| 
-                    #[trigger] owner_references.contains(vrs.controller_owner_ref())
-            },
+            APIRequest::CreateRequest(req) => 
+                req.obj.kind == Kind::PodKind ==> !{
+                    let owner_references = req.obj.metadata.owner_references.get_Some_0();
+                    &&& req.obj.metadata.owner_references.is_Some()
+                    &&& exists |vrs: VReplicaSetView| 
+                        #[trigger] owner_references.contains(vrs.controller_owner_ref())
+                },
             // Other controllers don't try to update pods owned by a VReplicaSet.
-            APIRequest::UpdateRequest(req) => !{
-                let etcd_obj = s.resources()[req.key()];
-                let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
-                &&& req.obj.kind == Kind::PodKind
-                &&& s.resources().contains_key(req.key())
-                &&& etcd_obj.metadata.resource_version.is_Some()
-                &&& etcd_obj.metadata.resource_version == req.obj.metadata.resource_version
-                &&& etcd_obj.metadata.owner_references.is_Some()
-                &&& exists |vrs: VReplicaSetView| 
-                    #[trigger] owner_references.contains(vrs.controller_owner_ref())
-            },
-            // Dealt with similarly to update requests.
-            // TODO: allow other controllers to send UpdateStatus
-            // requests to owned pods after we address the fairness issues.
-            APIRequest::UpdateStatusRequest(req) => !{
-                let etcd_obj = s.resources()[req.key()];
-                let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
-                &&& req.obj.kind == Kind::PodKind
-                &&& s.resources().contains_key(req.key())
-                &&& etcd_obj.metadata.resource_version.is_Some()
-                &&& etcd_obj.metadata.resource_version == req.obj.metadata.resource_version
-                &&& etcd_obj.metadata.owner_references.is_Some()
-                &&& exists |vrs: VReplicaSetView| 
-                    #[trigger] owner_references.contains(vrs.controller_owner_ref())
-            },
-            // All delete requests to  carry a precondition on the resource version,
-            // and other controllers don't try to delete pods owned by a VReplicaSet.
-            APIRequest::DeleteRequest(req) => 
-                (req.key.kind == Kind::PodKind ==>
-                    req.preconditions.is_Some()
-                    && req.preconditions.get_Some_0().resource_version.is_Some())
-                && !{
-                    let etcd_obj = s.resources()[req.key];
+            APIRequest::UpdateRequest(req) => 
+                req.obj.kind == Kind::PodKind ==> !{
+                    let etcd_obj = s.resources()[req.key()];
                     let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
-                    &&& req.key.kind == Kind::PodKind
-                    &&& s.resources().contains_key(req.key)
+                    &&& s.resources().contains_key(req.key())
                     &&& etcd_obj.metadata.resource_version.is_Some()
-                    &&& etcd_obj.metadata.resource_version
-                        == req.preconditions.get_Some_0().resource_version
+                    &&& etcd_obj.metadata.resource_version == req.obj.metadata.resource_version
                     &&& etcd_obj.metadata.owner_references.is_Some()
                     &&& exists |vrs: VReplicaSetView| 
                         #[trigger] owner_references.contains(vrs.controller_owner_ref())
                 },
+            // Dealt with similarly to update requests.
+            // TODO: allow other controllers to send UpdateStatus
+            // requests to owned pods after we address the fairness issues.
+            APIRequest::UpdateStatusRequest(req) => 
+                req.obj.kind == Kind::PodKind ==> !{
+                    let etcd_obj = s.resources()[req.key()];
+                    let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
+                    &&& s.resources().contains_key(req.key())
+                    &&& etcd_obj.metadata.resource_version.is_Some()
+                    &&& etcd_obj.metadata.resource_version == req.obj.metadata.resource_version
+                    &&& etcd_obj.metadata.owner_references.is_Some()
+                    &&& exists |vrs: VReplicaSetView| 
+                        #[trigger] owner_references.contains(vrs.controller_owner_ref())
+                },
+            // All delete requests to  carry a precondition on the resource version,
+            // and other controllers don't try to delete pods owned by a VReplicaSet.
+            APIRequest::DeleteRequest(req) => 
+                req.key.kind == Kind::PodKind ==>
+                    req.preconditions.is_Some()
+                    && req.preconditions.get_Some_0().resource_version.is_Some()
+                    && !{
+                        let etcd_obj = s.resources()[req.key];
+                        let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
+                        &&& s.resources().contains_key(req.key)
+                        &&& etcd_obj.metadata.resource_version.is_Some()
+                        &&& etcd_obj.metadata.resource_version
+                            == req.preconditions.get_Some_0().resource_version
+                        &&& etcd_obj.metadata.owner_references.is_Some()
+                        &&& exists |vrs: VReplicaSetView| 
+                            #[trigger] owner_references.contains(vrs.controller_owner_ref())
+                    },
             _ => true,
         }
     }

--- a/src/v2/controllers/vreplicaset_controller/trusted/liveness_theorem.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/liveness_theorem.rs
@@ -42,7 +42,7 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
         } ==> match msg.content.get_APIRequest_0() {
             // Other controllers don't create pods owned by a VReplicaSet.
             APIRequest::CreateRequest(req) => !{
-                let owner_references = req.obj.metadata.owner_references.unwrap();
+                let owner_references = req.obj.metadata.owner_references.get_Some_0();
                 &&& req.obj.kind == Kind::PodKind
                 &&& req.obj.metadata.namespace.is_Some()
                 &&& req.obj.metadata.owner_references.is_Some()
@@ -52,7 +52,7 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
             // Other controllers don't try to update pods owned by a VReplicaSet.
             APIRequest::UpdateRequest(req) => !{
                 let etcd_obj = s.resources()[req.key()];
-                let owner_references = etcd_obj.metadata.owner_references.unwrap();
+                let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
                 &&& req.obj.kind == Kind::PodKind
                 &&& s.resources().contains_key(req.key())
                 &&& etcd_obj.metadata.resource_version.is_Some()
@@ -64,7 +64,7 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
             // Dealt with similarly to update requests.
             APIRequest::UpdateStatusRequest(req) => !{
                 let etcd_obj = s.resources()[req.key()];
-                let owner_references = etcd_obj.metadata.owner_references.unwrap();
+                let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
                 &&& req.obj.kind == Kind::PodKind
                 &&& s.resources().contains_key(req.key())
                 &&& etcd_obj.metadata.resource_version.is_Some()
@@ -80,7 +80,7 @@ pub open spec fn vrs_not_interfered_by(other_id: int) -> StatePred<ClusterState>
                 && req.preconditions.get_Some_0().resource_version.is_Some()
                 && !{
                     let etcd_obj = s.resources()[req.key];
-                    let owner_references = etcd_obj.metadata.owner_references.unwrap();
+                    let owner_references = etcd_obj.metadata.owner_references.get_Some_0();
                     &&& req.key.kind == Kind::PodKind
                     &&& s.resources().contains_key(req.key)
                     &&& etcd_obj.metadata.resource_version.is_Some()


### PR DESCRIPTION
Here I specify the rely condition for VReplicaSet: no controller creates/updates/deletes pods that are owned by a VReplicaSet.

I don't yet know how many proofs this breaks: once I have an idea (by running and marking the appropriate proofs), I will document this in the PR.