### PR TITLE
Reduce boilerplate code using macro

### DIFF
--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -4,7 +4,6 @@ pub use chrono;
 pub use futures;
 pub use k8s_openapi;
 pub use kube;
-use kube::Resource;
 pub use kube_client;
 pub use kube_core;
 pub use kube_derive;

--- a/src/deps_hack/src/lib.rs
+++ b/src/deps_hack/src/lib.rs
@@ -4,6 +4,7 @@ pub use chrono;
 pub use futures;
 pub use k8s_openapi;
 pub use kube;
+use kube::Resource;
 pub use kube_client;
 pub use kube_core;
 pub use kube_derive;
@@ -17,8 +18,8 @@ pub use thiserror;
 pub use tokio;
 pub use tracing;
 pub use tracing_subscriber;
-pub use zookeeper;
 pub use warp;
+pub use zookeeper;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -272,7 +273,13 @@ pub struct FluentBitConfigSpec {
 }
 
 #[derive(
-    kube::CustomResource, Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+    kube::CustomResource,
+    Default,
+    Debug,
+    Clone,
+    serde::Deserialize,
+    serde::Serialize,
+    schemars::JsonSchema,
 )]
 #[kube(group = "anvil.dev", version = "v1", kind = "VReplicaSet")]
 #[kube(shortname = "vrs", namespaced)]
@@ -280,6 +287,22 @@ pub struct VReplicaSetSpec {
     pub replicas: Option<i32>,
     pub selector: k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector,
     pub template: Option<k8s_openapi::api::core::v1::PodTemplateSpec>,
+}
+
+impl VReplicaSet {
+    pub fn default() -> Self {
+        Self {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta::default(),
+            spec: VReplicaSetSpec::default(),
+        }
+    }
+
+    pub fn clone(&self) -> Self {
+        Self {
+            metadata: self.metadata.clone(),
+            spec: self.spec.clone(),
+        }
+    }
 }
 
 #[derive(

--- a/src/kubernetes_api_objects/exec/affinity.rs
+++ b/src/kubernetes_api_objects/exec/affinity.rs
@@ -25,4 +25,4 @@ impl Affinity {
 
 }
 
-implement_resource_wrapper!(Affinity, deps_hack::k8s_openapi::api::core::v1::Affinity);
+implement_resource_wrapper_trait!(Affinity, deps_hack::k8s_openapi::api::core::v1::Affinity);

--- a/src/kubernetes_api_objects/exec/affinity.rs
+++ b/src/kubernetes_api_objects/exec/affinity.rs
@@ -23,11 +23,6 @@ impl Affinity {
     pub spec fn view(&self) -> AffinityView;
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::Affinity> for Affinity {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Affinity) -> Affinity { Affinity { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Affinity { self.inner }
 }
 
-}
+implement_resource_wrapper!(Affinity, deps_hack::k8s_openapi::api::core::v1::Affinity);

--- a/src/kubernetes_api_objects/exec/api_method.rs
+++ b/src/kubernetes_api_objects/exec/api_method.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::error::*;
-use crate::kubernetes_api_objects::exec::{api_resource::*, dynamic::*, preconditions::*};
+use crate::kubernetes_api_objects::exec::{
+    api_resource::*, dynamic::*, preconditions::*, resource::*,
+};
 use crate::kubernetes_api_objects::spec::{api_method::*, common::ObjectRef};
 use crate::vstd_ext::option_lib::*;
 use vstd::prelude::*;

--- a/src/kubernetes_api_objects/exec/api_method.rs
+++ b/src/kubernetes_api_objects/exec/api_method.rs
@@ -338,187 +338,6 @@ impl View for KubeAPIResponse {
     }
 }
 
-impl KubeAPIResponse {
-    pub fn is_get_response(&self) -> (res: bool)
-        ensures
-            res == self.is_GetResponse(),
-    {
-        match self {
-            KubeAPIResponse::GetResponse(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn as_get_response_ref(&self) -> (resp: &KubeGetResponse)
-        requires self.is_GetResponse(),
-        ensures resp == self.get_GetResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::GetResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn into_get_response(self) -> (resp: KubeGetResponse)
-        requires self.is_GetResponse(),
-        ensures resp == self.get_GetResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::GetResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn is_list_response(&self) -> (res: bool)
-        ensures
-            res == self.is_ListResponse(),
-    {
-        match self {
-            KubeAPIResponse::ListResponse(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn as_list_response_ref(&self) -> (resp: &KubeListResponse)
-        requires self.is_ListResponse(),
-        ensures resp == self.get_ListResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::ListResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn into_list_response(self) -> (resp: KubeListResponse)
-        requires self.is_ListResponse(),
-        ensures resp == self.get_ListResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::ListResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn is_create_response(&self) -> (res: bool)
-        ensures
-            res == self.is_CreateResponse(),
-    {
-        match self {
-            KubeAPIResponse::CreateResponse(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn as_create_response_ref(&self) -> (resp: &KubeCreateResponse)
-        requires self.is_CreateResponse(),
-        ensures resp == self.get_CreateResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::CreateResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn into_create_response(self) -> (resp: KubeCreateResponse)
-        requires self.is_CreateResponse(),
-        ensures resp == self.get_CreateResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::CreateResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn is_update_response(&self) -> (res: bool)
-        ensures res == self.is_UpdateResponse(),
-    {
-        match self {
-            KubeAPIResponse::UpdateResponse(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn as_update_response_ref(&self) -> (resp: &KubeUpdateResponse)
-        requires self.is_UpdateResponse(),
-        ensures resp == self.get_UpdateResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::UpdateResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn into_update_response(self) -> (resp: KubeUpdateResponse)
-        requires self.is_UpdateResponse(),
-        ensures resp == self.get_UpdateResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::UpdateResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn is_update_status_response(&self) -> (res: bool)
-        ensures
-            res == self.is_UpdateStatusResponse(),
-    {
-        match self {
-            KubeAPIResponse::UpdateStatusResponse(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn as_update_status_response_ref(&self) -> (resp: &KubeUpdateStatusResponse)
-        requires self.is_UpdateStatusResponse(),
-        ensures resp == self.get_UpdateStatusResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::UpdateStatusResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn into_update_status_response(self) -> (resp: KubeUpdateStatusResponse)
-        requires self.is_UpdateStatusResponse(),
-        ensures resp == self.get_UpdateStatusResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::UpdateStatusResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn is_delete_response(&self) -> (res: bool)
-        ensures
-            res == self.is_DeleteResponse(),
-    {
-        match self {
-            KubeAPIResponse::DeleteResponse(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn as_delete_response_ref(&self) -> (resp: &KubeDeleteResponse)
-        requires self.is_DeleteResponse(),
-        ensures resp == self.get_DeleteResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::DeleteResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-
-    pub fn into_delete_response(self) -> (resp: KubeDeleteResponse)
-        requires self.is_DeleteResponse(),
-        ensures resp == self.get_DeleteResponse_0(),
-    {
-        match self {
-            KubeAPIResponse::DeleteResponse(resp) => resp,
-            _ => unreached(),
-        }
-    }
-}
-
 // TODO: replace it with option_view
 pub open spec fn opt_resp_to_view(resp: &Option<KubeAPIResponse>) -> Option<APIResponse> {
     match resp {
@@ -528,3 +347,96 @@ pub open spec fn opt_resp_to_view(resp: &Option<KubeAPIResponse>) -> Option<APIR
 }
 
 }
+
+macro_rules! declare_kube_api_response_helper_methods {
+    ($resp_type:ty, $resp_view_type:ty, $is_fun:ident, $as_ref_fun:ident, $into_fun:ident, $project:ident) => {
+        verus! {
+
+        impl KubeAPIResponse {
+            pub fn $is_fun(&self) -> (res: bool)
+                ensures res == self is $resp_type,
+            {
+                match self {
+                    KubeAPIResponse::$resp_type(_) => true,
+                    _ => false,
+                }
+            }
+
+            pub fn $as_ref_fun(&self) -> (resp: &$resp_view_type)
+                requires self is $resp_type,
+                ensures resp == self->$project,
+            {
+                match self {
+                    KubeAPIResponse::$resp_type(resp) => resp,
+                    _ => unreached(),
+                }
+            }
+
+            pub fn $into_fun(self) -> (resp: $resp_view_type)
+                requires self is $resp_type,
+                ensures resp == self->$project,
+            {
+                match self {
+                    KubeAPIResponse::$resp_type(resp) => resp,
+                    _ => unreached(),
+                }
+            }
+        }
+
+        }
+    };
+}
+
+declare_kube_api_response_helper_methods!(
+    GetResponse,
+    KubeGetResponse,
+    is_get_response,
+    as_get_response_ref,
+    into_get_response,
+    GetResponse_0
+);
+
+declare_kube_api_response_helper_methods!(
+    ListResponse,
+    KubeListResponse,
+    is_list_response,
+    as_list_response_ref,
+    into_list_response,
+    ListResponse_0
+);
+
+declare_kube_api_response_helper_methods!(
+    CreateResponse,
+    KubeCreateResponse,
+    is_create_response,
+    as_create_response_ref,
+    into_create_response,
+    CreateResponse_0
+);
+
+declare_kube_api_response_helper_methods!(
+    DeleteResponse,
+    KubeDeleteResponse,
+    is_delete_response,
+    as_delete_response_ref,
+    into_delete_response,
+    DeleteResponse_0
+);
+
+declare_kube_api_response_helper_methods!(
+    UpdateResponse,
+    KubeUpdateResponse,
+    is_update_response,
+    as_update_response_ref,
+    into_update_response,
+    UpdateResponse_0
+);
+
+declare_kube_api_response_helper_methods!(
+    UpdateStatusResponse,
+    KubeUpdateStatusResponse,
+    is_update_status_response,
+    as_update_response_status_ref,
+    into_update_status_response,
+    UpdateStatusResponse_0
+);

--- a/src/kubernetes_api_objects/exec/api_method.rs
+++ b/src/kubernetes_api_objects/exec/api_method.rs
@@ -349,7 +349,7 @@ pub open spec fn opt_resp_to_view(resp: &Option<KubeAPIResponse>) -> Option<APIR
 }
 
 macro_rules! declare_kube_api_response_helper_methods {
-    ($resp_type:ty, $resp_view_type:ty, $is_fun:ident, $as_ref_fun:ident, $into_fun:ident, $project:ident) => {
+    ($is_fun:ident, $as_ref_fun:ident, $into_fun:ident, $resp_type:ty, $kube_resp_type:ty, $project:ident) => {
         verus! {
 
         impl KubeAPIResponse {
@@ -362,7 +362,7 @@ macro_rules! declare_kube_api_response_helper_methods {
                 }
             }
 
-            pub fn $as_ref_fun(&self) -> (resp: &$resp_view_type)
+            pub fn $as_ref_fun(&self) -> (resp: &$kube_resp_type)
                 requires self is $resp_type,
                 ensures resp == self.$project(),
             {
@@ -372,7 +372,7 @@ macro_rules! declare_kube_api_response_helper_methods {
                 }
             }
 
-            pub fn $into_fun(self) -> (resp: $resp_view_type)
+            pub fn $into_fun(self) -> (resp: $kube_resp_type)
                 requires self is $resp_type,
                 ensures resp == self.$project(),
             {
@@ -388,55 +388,55 @@ macro_rules! declare_kube_api_response_helper_methods {
 }
 
 declare_kube_api_response_helper_methods!(
-    GetResponse,
-    KubeGetResponse,
     is_get_response,
     as_get_response_ref,
     into_get_response,
+    GetResponse,
+    KubeGetResponse,
     get_GetResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
-    ListResponse,
-    KubeListResponse,
     is_list_response,
     as_list_response_ref,
     into_list_response,
+    ListResponse,
+    KubeListResponse,
     get_ListResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
-    CreateResponse,
-    KubeCreateResponse,
     is_create_response,
     as_create_response_ref,
     into_create_response,
+    CreateResponse,
+    KubeCreateResponse,
     get_CreateResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
-    DeleteResponse,
-    KubeDeleteResponse,
     is_delete_response,
     as_delete_response_ref,
     into_delete_response,
+    DeleteResponse,
+    KubeDeleteResponse,
     get_DeleteResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
-    UpdateResponse,
-    KubeUpdateResponse,
     is_update_response,
     as_update_response_ref,
     into_update_response,
+    UpdateResponse,
+    KubeUpdateResponse,
     get_UpdateResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
-    UpdateStatusResponse,
-    KubeUpdateStatusResponse,
     is_update_status_response,
     as_update_response_status_ref,
     into_update_status_response,
+    UpdateStatusResponse,
+    KubeUpdateStatusResponse,
     get_UpdateStatusResponse_0
 );

--- a/src/kubernetes_api_objects/exec/api_method.rs
+++ b/src/kubernetes_api_objects/exec/api_method.rs
@@ -364,7 +364,7 @@ macro_rules! declare_kube_api_response_helper_methods {
 
             pub fn $as_ref_fun(&self) -> (resp: &$resp_view_type)
                 requires self is $resp_type,
-                ensures resp == self->$project,
+                ensures resp == self.$project(),
             {
                 match self {
                     KubeAPIResponse::$resp_type(resp) => resp,
@@ -374,7 +374,7 @@ macro_rules! declare_kube_api_response_helper_methods {
 
             pub fn $into_fun(self) -> (resp: $resp_view_type)
                 requires self is $resp_type,
-                ensures resp == self->$project,
+                ensures resp == self.$project(),
             {
                 match self {
                     KubeAPIResponse::$resp_type(resp) => resp,
@@ -393,7 +393,7 @@ declare_kube_api_response_helper_methods!(
     is_get_response,
     as_get_response_ref,
     into_get_response,
-    GetResponse_0
+    get_GetResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
@@ -402,7 +402,7 @@ declare_kube_api_response_helper_methods!(
     is_list_response,
     as_list_response_ref,
     into_list_response,
-    ListResponse_0
+    get_ListResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
@@ -411,7 +411,7 @@ declare_kube_api_response_helper_methods!(
     is_create_response,
     as_create_response_ref,
     into_create_response,
-    CreateResponse_0
+    get_CreateResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
@@ -420,7 +420,7 @@ declare_kube_api_response_helper_methods!(
     is_delete_response,
     as_delete_response_ref,
     into_delete_response,
-    DeleteResponse_0
+    get_DeleteResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
@@ -429,7 +429,7 @@ declare_kube_api_response_helper_methods!(
     is_update_response,
     as_update_response_ref,
     into_update_response,
-    UpdateResponse_0
+    get_UpdateResponse_0
 );
 
 declare_kube_api_response_helper_methods!(
@@ -438,5 +438,5 @@ declare_kube_api_response_helper_methods!(
     is_update_status_response,
     as_update_response_status_ref,
     into_update_status_response,
-    UpdateStatusResponse_0
+    get_UpdateStatusResponse_0
 );

--- a/src/kubernetes_api_objects/exec/api_resource.rs
+++ b/src/kubernetes_api_objects/exec/api_resource.rs
@@ -23,4 +23,4 @@ impl ApiResource {
 
 }
 
-implement_resource_wrapper!(ApiResource, deps_hack::kube::api::ApiResource);
+implement_resource_wrapper_trait!(ApiResource, deps_hack::kube::api::ApiResource);

--- a/src/kubernetes_api_objects/exec/api_resource.rs
+++ b/src/kubernetes_api_objects/exec/api_resource.rs
@@ -19,24 +19,8 @@ pub struct ApiResource {
 
 impl ApiResource {
     pub spec fn view(&self) -> ApiResourceView;
-
-    #[verifier(external)]
-    pub fn as_kube_ref(&self) -> &deps_hack::kube::api::ApiResource {
-        &self.inner
-    }
-}
-
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::kube::api::ApiResource> for ApiResource {
-    fn from_kube(inner: deps_hack::kube::api::ApiResource) -> ApiResource {
-        ApiResource {
-            inner: inner
-        }
-    }
-
-    fn into_kube(self) -> deps_hack::kube::api::ApiResource {
-        self.inner
-    }
 }
 
 }
+
+implement_resource_wrapper!(ApiResource, deps_hack::kube::api::ApiResource);

--- a/src/kubernetes_api_objects/exec/config_map.rs
+++ b/src/kubernetes_api_objects/exec/config_map.rs
@@ -109,11 +109,6 @@ impl ConfigMap {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::ConfigMap> for ConfigMap {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ConfigMap) -> ConfigMap { ConfigMap { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ConfigMap { self.inner }
 }
 
-}
+implement_resource_wrapper!(ConfigMap, deps_hack::k8s_openapi::api::core::v1::ConfigMap);

--- a/src/kubernetes_api_objects/exec/config_map.rs
+++ b/src/kubernetes_api_objects/exec/config_map.rs
@@ -8,8 +8,6 @@ use crate::kubernetes_api_objects::spec::{config_map::*, resource::*};
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
-verus! {
-
 // ConfigMap is a type of API object used to store non-confidential data in key-value pairs.
 // A ConfigMap object can be used to set environment variables or configuration files
 // in a Volume mounted to a Pod.
@@ -20,39 +18,15 @@ verus! {
 //
 // More detailed information: https://kubernetes.io/docs/concepts/configuration/configmap/.
 
-#[verifier(external_body)]
-pub struct ConfigMap {
-    inner: deps_hack::k8s_openapi::api::core::v1::ConfigMap,
-}
+implement_wrapper_type!(
+    ConfigMap,
+    deps_hack::k8s_openapi::api::core::v1::ConfigMap,
+    ConfigMapView
+);
 
-impl View for ConfigMap {
-    type V = ConfigMapView;
-
-    spec fn view(&self) -> ConfigMapView;
-}
+verus! {
 
 impl ConfigMap {
-    #[verifier(external_body)]
-    pub fn default() -> (config_map: ConfigMap)
-        ensures config_map@ == ConfigMapView::default(),
-    {
-        ConfigMap { inner: deps_hack::k8s_openapi::api::core::v1::ConfigMap::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (c: Self)
-        ensures c@ == self@,
-    {
-        ConfigMap { inner: self.inner.clone() }
-    }
-
-    #[verifier(external_body)]
-    pub fn metadata(&self) -> (metadata: ObjectMeta)
-        ensures metadata@ == self@.metadata,
-    {
-        ObjectMeta::from_kube(self.inner.metadata.clone())
-    }
-
     #[verifier(external_body)]
     pub fn data(&self) -> (data: Option<StringMap>)
         ensures
@@ -66,49 +40,13 @@ impl ConfigMap {
     }
 
     #[verifier(external_body)]
-    pub fn set_metadata(&mut self, metadata: ObjectMeta)
-        ensures self@ == old(self)@.with_metadata(metadata@),
-    {
-        self.inner.metadata = metadata.into_kube();
-    }
-
-    #[verifier(external_body)]
     pub fn set_data(&mut self, data: StringMap)
         ensures self@ == old(self)@.with_data(data@),
     {
         self.inner.data = Some(data.into_rust_map())
     }
-
-    #[verifier(external_body)]
-    pub fn api_resource() -> (res: ApiResource)
-        ensures res@.kind == ConfigMapView::kind(),
-    {
-        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::ConfigMap>(&()))
-    }
-
-    #[verifier(external_body)]
-    pub fn marshal(self) -> (obj: DynamicObject)
-        ensures obj@ == self@.marshal(),
-    {
-        DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
-    }
-
-    #[verifier(external_body)]
-    pub fn unmarshal(obj: DynamicObject) -> (res: Result<ConfigMap, UnmarshalError>)
-        ensures
-            res.is_Ok() == ConfigMapView::unmarshal(obj@).is_Ok(),
-            res.is_Ok() ==> res.get_Ok_0()@ == ConfigMapView::unmarshal(obj@).get_Ok_0(),
-    {
-        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::ConfigMap>();
-        if parse_result.is_ok() {
-            let res = ConfigMap { inner: parse_result.unwrap() };
-            Ok(res)
-        } else {
-            Err(())
-        }
-    }
 }
 
 }
 
-implement_resource_wrapper!(ConfigMap, deps_hack::k8s_openapi::api::core::v1::ConfigMap);
+implement_resource_wrapper_trait!(ConfigMap, deps_hack::k8s_openapi::api::core::v1::ConfigMap);

--- a/src/kubernetes_api_objects/exec/container.rs
+++ b/src/kubernetes_api_objects/exec/container.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-use crate::kubernetes_api_objects::exec::{resource_requirements::*, volume::*};
+use crate::kubernetes_api_objects::exec::{resource::*, resource_requirements::*, volume::*};
 use crate::kubernetes_api_objects::spec::container::*;
 use crate::vstd_ext::string_view::*;
 use vstd::prelude::*;
@@ -123,12 +123,6 @@ impl Container {
     {
         self.inner.security_context = Some(security_context.into_kube())
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Container) -> Container { Container { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Container { self.inner }
 }
 
 #[verifier(external_body)]
@@ -190,12 +184,6 @@ impl ContainerPort {
     {
         self.inner.protocol.clone()
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ContainerPort) -> ContainerPort { ContainerPort { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ContainerPort { self.inner }
 }
 
 #[verifier(external_body)]
@@ -257,12 +245,6 @@ impl VolumeMount {
     {
         self.inner.mount_propagation = Some(mount_propagation)
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::VolumeMount) -> VolumeMount { VolumeMount { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::VolumeMount { self.inner }
 }
 
 #[verifier(external_body)]
@@ -335,14 +317,6 @@ impl Probe {
     {
         self.inner.timeout_seconds = Some(timeout_seconds);
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Probe) -> Probe {
-        Probe { inner: inner }
-    }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Probe { self.inner }
 }
 
 #[verifier(external_body)]
@@ -373,14 +347,6 @@ impl ExecAction {
     {
         self.inner.command = Some(command);
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ExecAction) -> ExecAction {
-        ExecAction { inner: inner }
-    }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ExecAction { self.inner }
 }
 
 #[verifier(external_body)]
@@ -418,14 +384,6 @@ impl TCPSocketAction {
     {
         self.inner.port = deps_hack::k8s_openapi::apimachinery::pkg::util::intstr::IntOrString::Int(port);
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::TCPSocketAction) -> TCPSocketAction { TCPSocketAction { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::TCPSocketAction {
-        self.inner
-    }
 }
 
 #[verifier(external_body)]
@@ -456,12 +414,6 @@ impl Lifecycle {
     {
         self.inner.pre_stop = Some(handler.into_kube());
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Lifecycle) -> Lifecycle { Lifecycle { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Lifecycle { self.inner }
 }
 
 #[verifier(external_body)]
@@ -492,14 +444,6 @@ impl LifecycleHandler {
     {
         self.inner.exec = Some(exec.into_kube());
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::LifecycleHandler) -> LifecycleHandler {
-        LifecycleHandler { inner: inner }
-    }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::LifecycleHandler { self.inner }
 }
 
 #[verifier(external_body)]
@@ -567,12 +511,6 @@ impl EnvVar {
     {
         self.inner.value_from = Some(value_from.into_kube())
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::EnvVar) -> EnvVar { EnvVar { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::EnvVar { self.inner }
 }
 
 #[verifier(external_body)]
@@ -607,12 +545,6 @@ impl EnvVarSource {
     {
         self.inner.field_ref = Some(field_ref.into_kube());
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::EnvVarSource) -> EnvVarSource { EnvVarSource { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::EnvVarSource { self.inner }
 }
 
 #[verifier(external_body)]
@@ -622,12 +554,49 @@ pub struct SecurityContext {
 
 impl SecurityContext {
     pub spec fn view(&self) -> SecurityContextView;
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::SecurityContext) -> SecurityContext { SecurityContext { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::SecurityContext { self.inner }
 }
 
 }
+
+implement_resource_wrapper!(Container, deps_hack::k8s_openapi::api::core::v1::Container);
+
+implement_resource_wrapper!(Lifecycle, deps_hack::k8s_openapi::api::core::v1::Lifecycle);
+
+implement_resource_wrapper!(
+    ContainerPort,
+    deps_hack::k8s_openapi::api::core::v1::ContainerPort
+);
+
+implement_resource_wrapper!(
+    VolumeMount,
+    deps_hack::k8s_openapi::api::core::v1::VolumeMount
+);
+
+implement_resource_wrapper!(
+    TCPSocketAction,
+    deps_hack::k8s_openapi::api::core::v1::TCPSocketAction
+);
+
+implement_resource_wrapper!(
+    LifecycleHandler,
+    deps_hack::k8s_openapi::api::core::v1::LifecycleHandler
+);
+
+implement_resource_wrapper!(
+    ExecAction,
+    deps_hack::k8s_openapi::api::core::v1::ExecAction
+);
+
+implement_resource_wrapper!(Probe, deps_hack::k8s_openapi::api::core::v1::Probe);
+
+implement_resource_wrapper!(EnvVar, deps_hack::k8s_openapi::api::core::v1::EnvVar);
+
+implement_resource_wrapper!(
+    EnvVarSource,
+    deps_hack::k8s_openapi::api::core::v1::EnvVarSource
+);
+
+implement_resource_wrapper!(
+    SecurityContext,
+    deps_hack::k8s_openapi::api::core::v1::SecurityContext
+);

--- a/src/kubernetes_api_objects/exec/container.rs
+++ b/src/kubernetes_api_objects/exec/container.rs
@@ -558,45 +558,45 @@ impl SecurityContext {
 
 }
 
-implement_resource_wrapper!(Container, deps_hack::k8s_openapi::api::core::v1::Container);
+implement_resource_wrapper_trait!(Container, deps_hack::k8s_openapi::api::core::v1::Container);
 
-implement_resource_wrapper!(Lifecycle, deps_hack::k8s_openapi::api::core::v1::Lifecycle);
+implement_resource_wrapper_trait!(Lifecycle, deps_hack::k8s_openapi::api::core::v1::Lifecycle);
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     ContainerPort,
     deps_hack::k8s_openapi::api::core::v1::ContainerPort
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     VolumeMount,
     deps_hack::k8s_openapi::api::core::v1::VolumeMount
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     TCPSocketAction,
     deps_hack::k8s_openapi::api::core::v1::TCPSocketAction
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     LifecycleHandler,
     deps_hack::k8s_openapi::api::core::v1::LifecycleHandler
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     ExecAction,
     deps_hack::k8s_openapi::api::core::v1::ExecAction
 );
 
-implement_resource_wrapper!(Probe, deps_hack::k8s_openapi::api::core::v1::Probe);
+implement_resource_wrapper_trait!(Probe, deps_hack::k8s_openapi::api::core::v1::Probe);
 
-implement_resource_wrapper!(EnvVar, deps_hack::k8s_openapi::api::core::v1::EnvVar);
+implement_resource_wrapper_trait!(EnvVar, deps_hack::k8s_openapi::api::core::v1::EnvVar);
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     EnvVarSource,
     deps_hack::k8s_openapi::api::core::v1::EnvVarSource
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     SecurityContext,
     deps_hack::k8s_openapi::api::core::v1::SecurityContext
 );

--- a/src/kubernetes_api_objects/exec/daemon_set.rs
+++ b/src/kubernetes_api_objects/exec/daemon_set.rs
@@ -8,8 +8,6 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{daemon_set::*, resource::*};
 use vstd::prelude::*;
 
-verus! {
-
 // DaemonSet is a type of API object used for managing daemon applications,
 // mainly a group of Pods and PersistentVolumeClaims attached to the Pods.
 // A DaemonSet object allows different types of Volumes attached to the pods,
@@ -22,40 +20,15 @@ verus! {
 //
 // More detailed information: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/.
 
-#[verifier(external_body)]
-pub struct DaemonSet {
-    inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSet,
-}
+implement_wrapper_type!(
+    DaemonSet,
+    deps_hack::k8s_openapi::api::apps::v1::DaemonSet,
+    DaemonSetView
+);
 
-
-impl View for DaemonSet {
-    type V = DaemonSetView;
-
-    spec fn view(&self) -> DaemonSetView;
-}
+verus! {
 
 impl DaemonSet {
-    #[verifier(external_body)]
-    pub fn default() -> (daemon_set: DaemonSet)
-        ensures daemon_set@ == DaemonSetView::default(),
-    {
-        DaemonSet { inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSet::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        DaemonSet { inner: self.inner.clone() }
-    }
-
-    #[verifier(external_body)]
-    pub fn metadata(&self) -> (metadata: ObjectMeta)
-        ensures metadata@ == self@.metadata,
-    {
-        ObjectMeta::from_kube(self.inner.metadata.clone())
-    }
-
     #[verifier(external_body)]
     pub fn spec(&self) -> (spec: Option<DaemonSetSpec>)
         ensures
@@ -66,48 +39,10 @@ impl DaemonSet {
     }
 
     #[verifier(external_body)]
-    pub fn set_metadata(&mut self, metadata: ObjectMeta)
-        ensures self@ == old(self)@.with_metadata(metadata@),
-    {
-        self.inner.metadata = metadata.into_kube();
-    }
-
-    #[verifier(external_body)]
     pub fn set_spec(&mut self, spec: DaemonSetSpec)
         ensures self@ == old(self)@.with_spec(spec@),
     {
         self.inner.spec = Some(spec.into_kube());
-    }
-
-    #[verifier(external_body)]
-    pub fn api_resource() -> (res: ApiResource)
-        ensures res@.kind == DaemonSetView::kind(),
-    {
-        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::apps::v1::DaemonSet>(&()))
-    }
-
-    // NOTE: This function assumes serde_json::to_string won't fail!
-    #[verifier(external_body)]
-    pub fn marshal(self) -> (obj: DynamicObject)
-        ensures obj@ == self@.marshal(),
-    {
-        DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
-    }
-
-    // Convert a DynamicObject to a DaemonSet
-    #[verifier(external_body)]
-    pub fn unmarshal(obj: DynamicObject) -> (res: Result<DaemonSet, UnmarshalError>)
-        ensures
-            res.is_Ok() == DaemonSetView::unmarshal(obj@).is_Ok(),
-            res.is_Ok() ==> res.get_Ok_0()@ == DaemonSetView::unmarshal(obj@).get_Ok_0(),
-    {
-        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::apps::v1::DaemonSet>();
-        if parse_result.is_ok() {
-            let res = DaemonSet { inner: parse_result.unwrap() };
-            Ok(res)
-        } else {
-            Err(())
-        }
     }
 }
 
@@ -180,14 +115,14 @@ impl DaemonSetStatus {
 
 }
 
-implement_resource_wrapper!(DaemonSet, deps_hack::k8s_openapi::api::apps::v1::DaemonSet);
+implement_resource_wrapper_trait!(DaemonSet, deps_hack::k8s_openapi::api::apps::v1::DaemonSet);
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     DaemonSetSpec,
     deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     DaemonSetStatus,
     deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus
 );

--- a/src/kubernetes_api_objects/exec/daemon_set.rs
+++ b/src/kubernetes_api_objects/exec/daemon_set.rs
@@ -111,13 +111,6 @@ impl DaemonSet {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::DaemonSet> for DaemonSet {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSet) -> DaemonSet { DaemonSet { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::DaemonSet { self.inner }
-}
-
 #[verifier(external_body)]
 pub struct DaemonSetSpec {
     inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec,
@@ -169,13 +162,6 @@ impl DaemonSetSpec {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec> for DaemonSetSpec {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec) -> DaemonSetSpec { DaemonSetSpec { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec { self.inner }
-}
-
 #[verifier(external_body)]
 pub struct DaemonSetStatus {
     inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus,
@@ -192,11 +178,16 @@ impl DaemonSetStatus {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus> for DaemonSetStatus {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus) -> DaemonSetStatus { DaemonSetStatus { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus { self.inner }
 }
 
-}
+implement_resource_wrapper!(DaemonSet, deps_hack::k8s_openapi::api::apps::v1::DaemonSet);
+
+implement_resource_wrapper!(
+    DaemonSetSpec,
+    deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec
+);
+
+implement_resource_wrapper!(
+    DaemonSetStatus,
+    deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus
+);

--- a/src/kubernetes_api_objects/exec/dynamic.rs
+++ b/src/kubernetes_api_objects/exec/dynamic.rs
@@ -49,4 +49,4 @@ impl std::fmt::Debug for DynamicObject {
 
 }
 
-implement_resource_wrapper!(DynamicObject, deps_hack::kube::api::DynamicObject);
+implement_resource_wrapper_trait!(DynamicObject, deps_hack::kube::api::DynamicObject);

--- a/src/kubernetes_api_objects/exec/dynamic.rs
+++ b/src/kubernetes_api_objects/exec/dynamic.rs
@@ -27,29 +27,12 @@ impl DynamicObject {
         &self.inner.metadata
     }
 
-    #[verifier(external)]
-    pub fn as_kube_ref(&self) -> &deps_hack::kube::api::DynamicObject {
-        &self.inner
-    }
-
-    #[verifier(external)]
-    pub fn as_kube_mut_ref(&mut self) -> &mut deps_hack::kube::api::DynamicObject {
-        &mut self.inner
-    }
-
     #[verifier(external_body)]
     pub fn metadata(&self) -> (metadata: ObjectMeta)
         ensures metadata@ == self@.metadata,
     {
         ObjectMeta::from_kube(self.inner.metadata.clone())
     }
-}
-
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::kube::api::DynamicObject> for DynamicObject {
-    fn from_kube(inner: deps_hack::kube::api::DynamicObject) -> DynamicObject { DynamicObject { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::kube::api::DynamicObject { self.inner }
 }
 
 impl std::clone::Clone for DynamicObject {
@@ -65,3 +48,5 @@ impl std::fmt::Debug for DynamicObject {
 }
 
 }
+
+implement_resource_wrapper!(DynamicObject, deps_hack::kube::api::DynamicObject);

--- a/src/kubernetes_api_objects/exec/label_selector.rs
+++ b/src/kubernetes_api_objects/exec/label_selector.rs
@@ -92,11 +92,9 @@ impl LabelSelector {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector> for LabelSelector {
-    fn from_kube(inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector) -> LabelSelector { LabelSelector { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector { self.inner }
 }
 
-}
+implement_resource_wrapper!(
+    LabelSelector,
+    deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector
+);

--- a/src/kubernetes_api_objects/exec/label_selector.rs
+++ b/src/kubernetes_api_objects/exec/label_selector.rs
@@ -94,7 +94,7 @@ impl LabelSelector {
 
 }
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     LabelSelector,
     deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector
 );

--- a/src/kubernetes_api_objects/exec/object_meta.rs
+++ b/src/kubernetes_api_objects/exec/object_meta.rs
@@ -256,11 +256,9 @@ impl ObjectMeta {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta> for ObjectMeta {
-    fn from_kube(inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta) -> ObjectMeta { ObjectMeta { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta { self.inner }
 }
 
-}
+implement_resource_wrapper!(
+    ObjectMeta,
+    deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta
+);

--- a/src/kubernetes_api_objects/exec/object_meta.rs
+++ b/src/kubernetes_api_objects/exec/object_meta.rs
@@ -258,7 +258,7 @@ impl ObjectMeta {
 
 }
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     ObjectMeta,
     deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta
 );

--- a/src/kubernetes_api_objects/exec/owner_reference.rs
+++ b/src/kubernetes_api_objects/exec/owner_reference.rs
@@ -43,11 +43,9 @@ impl OwnerReference {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference> for OwnerReference {
-    fn from_kube(inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference) -> OwnerReference { OwnerReference { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference { self.inner }
 }
 
-}
+implement_resource_wrapper!(
+    OwnerReference,
+    deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference
+);

--- a/src/kubernetes_api_objects/exec/owner_reference.rs
+++ b/src/kubernetes_api_objects/exec/owner_reference.rs
@@ -45,7 +45,7 @@ impl OwnerReference {
 
 }
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     OwnerReference,
     deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference
 );

--- a/src/kubernetes_api_objects/exec/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/exec/persistent_volume_claim.rs
@@ -110,13 +110,6 @@ impl PersistentVolumeClaim {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim> for PersistentVolumeClaim {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim) -> PersistentVolumeClaim { PersistentVolumeClaim { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim { self.inner }
-}
-
 #[verifier(external_body)]
 pub struct PersistentVolumeClaimSpec {
     inner: deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec,
@@ -163,13 +156,15 @@ impl PersistentVolumeClaimSpec {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec> for PersistentVolumeClaimSpec {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec) -> PersistentVolumeClaimSpec {
-        PersistentVolumeClaimSpec { inner: inner }
-    }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec { self.inner }
-}
 
 }
+
+implement_resource_wrapper!(
+    PersistentVolumeClaim,
+    deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaim
+);
+
+implement_resource_wrapper!(
+    PersistentVolumeClaimSpec,
+    deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec
+);

--- a/src/kubernetes_api_objects/exec/pod.rs
+++ b/src/kubernetes_api_objects/exec/pod.rs
@@ -75,15 +75,6 @@ impl Pod {
         self.inner.spec = Some(spec.into_kube());
     }
 
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Pod { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Pod) -> (pod: Pod)
-    {
-        Pod { inner: inner }
-    }
-
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures res@.kind == PodView::kind(),
@@ -252,12 +243,6 @@ impl PodSpec {
     {
         self.inner.image_pull_secrets = Some(image_pull_secrets.into_iter().map(|r: LocalObjectReference| r.into_kube()).collect())
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::PodSpec) -> PodSpec { PodSpec { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PodSpec { self.inner }
 }
 
 #[verifier(external_body)]
@@ -271,13 +256,6 @@ impl View for PodSecurityContext {
     spec fn view(&self) -> PodSecurityContextView;
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::PodSecurityContext> for PodSecurityContext {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::PodSecurityContext) -> PodSecurityContext { PodSecurityContext { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PodSecurityContext { self.inner }
-}
-
 #[verifier(external_body)]
 pub struct LocalObjectReference {
     inner: deps_hack::k8s_openapi::api::core::v1::LocalObjectReference,
@@ -289,11 +267,18 @@ impl View for LocalObjectReference {
     spec fn view(&self) -> LocalObjectReferenceView;
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::LocalObjectReference> for LocalObjectReference {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::LocalObjectReference) -> LocalObjectReference { LocalObjectReference { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::LocalObjectReference { self.inner }
 }
 
-}
+implement_resource_wrapper!(Pod, deps_hack::k8s_openapi::api::core::v1::Pod);
+
+implement_resource_wrapper!(PodSpec, deps_hack::k8s_openapi::api::core::v1::PodSpec);
+
+implement_resource_wrapper!(
+    PodSecurityContext,
+    deps_hack::k8s_openapi::api::core::v1::PodSecurityContext
+);
+
+implement_resource_wrapper!(
+    LocalObjectReference,
+    deps_hack::k8s_openapi::api::core::v1::LocalObjectReference
+);

--- a/src/kubernetes_api_objects/exec/pod_template_spec.rs
+++ b/src/kubernetes_api_objects/exec/pod_template_spec.rs
@@ -71,7 +71,7 @@ impl PodTemplateSpec {
 
 }
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     PodTemplateSpec,
     deps_hack::k8s_openapi::api::core::v1::PodTemplateSpec
 );

--- a/src/kubernetes_api_objects/exec/pod_template_spec.rs
+++ b/src/kubernetes_api_objects/exec/pod_template_spec.rs
@@ -67,14 +67,11 @@ impl PodTemplateSpec {
     {
         self.inner.spec = Some(spec.into_kube());
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::PodTemplateSpec) -> PodTemplateSpec {
-        PodTemplateSpec { inner: inner }
-    }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::PodTemplateSpec { self.inner }
 }
 
 }
+
+implement_resource_wrapper!(
+    PodTemplateSpec,
+    deps_hack::k8s_openapi::api::core::v1::PodTemplateSpec
+);

--- a/src/kubernetes_api_objects/exec/preconditions.rs
+++ b/src/kubernetes_api_objects/exec/preconditions.rs
@@ -51,4 +51,4 @@ impl Preconditions {
 
 }
 
-implement_resource_wrapper!(Preconditions, deps_hack::kube::api::Preconditions);
+implement_resource_wrapper_trait!(Preconditions, deps_hack::kube::api::Preconditions);

--- a/src/kubernetes_api_objects/exec/preconditions.rs
+++ b/src/kubernetes_api_objects/exec/preconditions.rs
@@ -47,12 +47,8 @@ impl Preconditions {
     {
         self.inner.resource_version = object_meta.into_kube().resource_version;
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::kube::api::Preconditions) -> Preconditions { Preconditions { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::kube::api::Preconditions { self.inner }
 }
 
 }
+
+implement_resource_wrapper!(Preconditions, deps_hack::kube::api::Preconditions);

--- a/src/kubernetes_api_objects/exec/resource.rs
+++ b/src/kubernetes_api_objects/exec/resource.rs
@@ -80,6 +80,27 @@ macro_rules! implement_wrapper_type {
 
 pub use implement_wrapper_type;
 
+use vstd::prelude::*;
+#[macro_export]
+macro_rules! implement_custom_wrapper_type {
+    ($t:ident, $it:ty, $vt:ty) => {
+        implement_wrapper_type!($t, $it, $vt);
+
+        verus! {
+        impl $t {
+            #[verifier(external_body)]
+            pub fn controller_owner_ref(&self) -> (owner_reference: OwnerReference)
+                ensures owner_reference@ == self@.controller_owner_ref(),
+            {
+                OwnerReference::from_kube(self.inner.controller_owner_ref(&()).unwrap())
+            }
+        }
+        }
+    };
+}
+
+pub use implement_custom_wrapper_type;
+
 pub trait ResourceWrapper<T>: Sized {
     fn from_kube(inner: T) -> Self;
 

--- a/src/kubernetes_api_objects/exec/resource.rs
+++ b/src/kubernetes_api_objects/exec/resource.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 use vstd::prelude::*;
 
-// This trait defines the methods that each wrapper of Kubernetes resource object should implement
 pub trait ResourceWrapper<T>: Sized {
     fn from_kube(inner: T) -> Self;
 
@@ -14,7 +13,7 @@ pub trait ResourceWrapper<T>: Sized {
 }
 
 #[macro_export]
-macro_rules! implement_resource_wrapper {
+macro_rules! implement_resource_wrapper_trait {
     ($t:ty, $it:ty) => {
         impl ResourceWrapper<$it> for $t {
             fn from_kube(inner: $it) -> $t {
@@ -36,4 +35,4 @@ macro_rules! implement_resource_wrapper {
     };
 }
 
-pub use implement_resource_wrapper;
+pub use implement_resource_wrapper_trait;

--- a/src/kubernetes_api_objects/exec/resource.rs
+++ b/src/kubernetes_api_objects/exec/resource.rs
@@ -1,6 +1,84 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
 use vstd::prelude::*;
+#[macro_export]
+macro_rules! implement_wrapper_type {
+    ($t:ident, $it:ty, $vt:ty) => {
+        verus! {
+        #[verifier(external_body)]
+        pub struct $t {
+            inner: $it,
+        }
+
+        impl View for $t {
+            type V = $vt;
+
+            spec fn view(&self) -> $vt;
+        }
+
+        impl $t {
+            #[verifier(external_body)]
+            pub fn default() -> (res: $t)
+                ensures res@ == $vt::default(),
+            {
+                Self { inner: $it::default() }
+            }
+
+            #[verifier(external_body)]
+            pub fn clone(&self) -> (res: Self)
+                ensures res@ == self@,
+            {
+                Self { inner: self.inner.clone() }
+            }
+
+            #[verifier(external_body)]
+            pub fn metadata(&self) -> (metadata: ObjectMeta)
+                ensures metadata@ == self@.metadata,
+            {
+                ObjectMeta::from_kube(self.inner.metadata.clone())
+            }
+
+            #[verifier(external_body)]
+            pub fn set_metadata(&mut self, metadata: ObjectMeta)
+                ensures self@ == old(self)@.with_metadata(metadata@),
+            {
+                self.inner.metadata = metadata.into_kube();
+            }
+
+            #[verifier(external_body)]
+            pub fn api_resource() -> (res: ApiResource)
+                ensures res@.kind == $vt::kind(),
+            {
+                ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<$it>(&()))
+            }
+
+            #[verifier(external_body)]
+            pub fn marshal(self) -> (obj: DynamicObject)
+                ensures obj@ == self@.marshal(),
+            {
+                DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
+            }
+
+            #[verifier(external_body)]
+            pub fn unmarshal(obj: DynamicObject) -> (res: Result<$t, UnmarshalError>)
+                ensures
+                    res.is_Ok() == $vt::unmarshal(obj@).is_Ok(),
+                    res.is_Ok() ==> res.get_Ok_0()@ == $vt::unmarshal(obj@).get_Ok_0(),
+            {
+                let parse_result = obj.into_kube().try_parse::<$it>();
+                if parse_result.is_ok() {
+                    let res = Self { inner: parse_result.unwrap() };
+                    Ok(res)
+                } else {
+                    Err(())
+                }
+            }
+        }
+        }
+    };
+}
+
+pub use implement_wrapper_type;
 
 pub trait ResourceWrapper<T>: Sized {
     fn from_kube(inner: T) -> Self;

--- a/src/kubernetes_api_objects/exec/resource.rs
+++ b/src/kubernetes_api_objects/exec/resource.rs
@@ -2,13 +2,38 @@
 // SPDX-License-Identifier: MIT
 use vstd::prelude::*;
 
-verus! {
-
 // This trait defines the methods that each wrapper of Kubernetes resource object should implement
 pub trait ResourceWrapper<T>: Sized {
     fn from_kube(inner: T) -> Self;
 
     fn into_kube(self) -> T;
+
+    fn as_kube_ref(&self) -> &T;
+
+    fn as_kube_mut_ref(&mut self) -> &mut T;
 }
 
+#[macro_export]
+macro_rules! implement_resource_wrapper {
+    ($t:ty, $it:ty) => {
+        impl ResourceWrapper<$it> for $t {
+            fn from_kube(inner: $it) -> $t {
+                Self { inner: inner }
+            }
+
+            fn into_kube(self) -> $it {
+                self.inner
+            }
+
+            fn as_kube_ref(&self) -> &$it {
+                &self.inner
+            }
+
+            fn as_kube_mut_ref(&mut self) -> &mut $it {
+                &mut self.inner
+            }
+        }
+    };
 }
+
+pub use implement_resource_wrapper;

--- a/src/kubernetes_api_objects/exec/resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/resource_requirements.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::resource_requirements::*;
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
@@ -43,12 +44,11 @@ impl ResourceRequirements {
     {
         self.inner.requests = Some(requests.into_rust_map().into_iter().map(|(k, v)| (k, deps_hack::k8s_openapi::apimachinery::pkg::api::resource::Quantity(v))).collect());
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ResourceRequirements) -> ResourceRequirements { ResourceRequirements { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ResourceRequirements { self.inner }
 }
 
 }
+
+implement_resource_wrapper!(
+    ResourceRequirements,
+    deps_hack::k8s_openapi::api::core::v1::ResourceRequirements
+);

--- a/src/kubernetes_api_objects/exec/resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/resource_requirements.rs
@@ -48,7 +48,7 @@ impl ResourceRequirements {
 
 }
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     ResourceRequirements,
     deps_hack::k8s_openapi::api::core::v1::ResourceRequirements
 );

--- a/src/kubernetes_api_objects/exec/role.rs
+++ b/src/kubernetes_api_objects/exec/role.rs
@@ -78,12 +78,6 @@ impl Role {
         Role { inner: self.inner.clone() }
     }
 
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::rbac::v1::Role { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::rbac::v1::Role) -> Role { Role { inner: inner } }
-
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures res@.kind == RoleView::kind(),
@@ -177,13 +171,11 @@ impl PolicyRule {
     {
         self.inner.verbs = verbs
     }
-
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::rbac::v1::PolicyRule { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::rbac::v1::PolicyRule) -> PolicyRule { PolicyRule { inner: inner } }
 }
 
 }
+
+implement_resource_wrapper!(
+    PolicyRule,
+    deps_hack::k8s_openapi::api::rbac::v1::PolicyRule
+);

--- a/src/kubernetes_api_objects/exec/role.rs
+++ b/src/kubernetes_api_objects/exec/role.rs
@@ -7,42 +7,17 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{resource::*, role::*};
 use vstd::prelude::*;
 
-verus! {
-
 // This definition is a wrapper of Role defined at
 // https://github.com/Arnavion/k8s-openapi/blob/v0.17.0/src/v1_26/api/rbac/v1/role.rs.
 // It is supposed to be used in exec controller code.
 //
 // More detailed information: https://kubernetes.io/docs/reference/access-authn-authz/rbac/.
 
-#[verifier(external_body)]
-pub struct Role {
-    inner: deps_hack::k8s_openapi::api::rbac::v1::Role,
-}
+implement_wrapper_type!(Role, deps_hack::k8s_openapi::api::rbac::v1::Role, RoleView);
 
-impl View for Role {
-    type V = RoleView;
-
-    spec fn view(&self) -> RoleView;
-}
+verus! {
 
 impl Role {
-    #[verifier(external_body)]
-    pub fn default() -> (role: Role)
-        ensures role@ == RoleView::default(),
-    {
-        Role {
-            inner: deps_hack::k8s_openapi::api::rbac::v1::Role::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn metadata(&self) -> (metadata: ObjectMeta)
-        ensures metadata@ == self@.metadata,
-    {
-        ObjectMeta::from_kube(self.inner.metadata.clone())
-    }
-
     #[verifier(external_body)]
     pub fn rules(&self) -> (policy_rules: Option<Vec<PolicyRule>>)
         ensures
@@ -56,55 +31,12 @@ impl Role {
     }
 
     #[verifier(external_body)]
-    pub fn set_metadata(&mut self, metadata: ObjectMeta)
-        ensures self@ == old(self)@.with_metadata(metadata@),
-    {
-        self.inner.metadata = metadata.into_kube();
-    }
-
-    #[verifier(external_body)]
     pub fn set_rules(&mut self, policy_rules: Vec<PolicyRule>)
         ensures self@ == old(self)@.with_rules(policy_rules@.map_values(|policy_rule: PolicyRule| policy_rule@)),
     {
         self.inner.rules = Some(
             policy_rules.into_iter().map(|p| p.into_kube()).collect()
         )
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (c: Self)
-        ensures c@ == self@,
-    {
-        Role { inner: self.inner.clone() }
-    }
-
-    #[verifier(external_body)]
-    pub fn api_resource() -> (res: ApiResource)
-        ensures res@.kind == RoleView::kind(),
-    {
-        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::rbac::v1::Role>(&()))
-    }
-
-    #[verifier(external_body)]
-    pub fn marshal(self) -> (obj: DynamicObject)
-        ensures obj@ == self@.marshal(),
-    {
-        DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
-    }
-
-    #[verifier(external_body)]
-    pub fn unmarshal(obj: DynamicObject) -> (res: Result<Role, UnmarshalError>)
-        ensures
-            res.is_Ok() == RoleView::unmarshal(obj@).is_Ok(),
-            res.is_Ok() ==> res.get_Ok_0()@ == RoleView::unmarshal(obj@).get_Ok_0(),
-    {
-        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::rbac::v1::Role>();
-        if parse_result.is_ok() {
-            let res = Role { inner: parse_result.unwrap() };
-            Ok(res)
-        } else {
-            Err(())
-        }
     }
 }
 
@@ -175,7 +107,7 @@ impl PolicyRule {
 
 }
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     PolicyRule,
     deps_hack::k8s_openapi::api::rbac::v1::PolicyRule
 );

--- a/src/kubernetes_api_objects/exec/role_binding.rs
+++ b/src/kubernetes_api_objects/exec/role_binding.rs
@@ -81,12 +81,6 @@ impl RoleBinding {
         RoleBinding { inner: self.inner.clone() }
     }
 
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::rbac::v1::RoleBinding { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::rbac::v1::RoleBinding) -> RoleBinding { RoleBinding { inner: inner } }
-
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures res@.kind == RoleBindingView::kind(),
@@ -160,7 +154,6 @@ impl RoleRef {
         self.inner.kind.clone()
     }
 
-
     #[verifier(external_body)]
     pub fn set_api_group(&mut self, api_group: String)
         ensures self@ == old(self)@.with_api_group(api_group@),
@@ -181,12 +174,6 @@ impl RoleRef {
     {
         self.inner.name = name;
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::rbac::v1::RoleRef { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::rbac::v1::RoleRef) -> RoleRef { RoleRef { inner: inner } }
 }
 
 #[verifier(external_body)]
@@ -226,12 +213,10 @@ impl Subject {
     {
         self.inner.namespace = Some(namespace);
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::rbac::v1::Subject { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::rbac::v1::Subject) -> Subject { Subject { inner: inner } }
 }
 
 }
+
+implement_resource_wrapper!(RoleRef, deps_hack::k8s_openapi::api::rbac::v1::RoleRef);
+
+implement_resource_wrapper!(Subject, deps_hack::k8s_openapi::api::rbac::v1::Subject);

--- a/src/kubernetes_api_objects/exec/role_binding.rs
+++ b/src/kubernetes_api_objects/exec/role_binding.rs
@@ -7,55 +7,26 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{resource::*, role_binding::*};
 use vstd::prelude::*;
 
-verus! {
-
-
 // This definition is a wrapper of RoleBinding defined at
 // https://github.com/Arnavion/k8s-openapi/blob/v0.17.0/src/v1_26/api/rbac/v1/role_binding.rs.
 // It is supposed to be used in exec controller code.
 //
 // More detailed information: https://kubernetes.io/docs/reference/access-authn-authz/rbac/.
 
-#[verifier(external_body)]
-pub struct RoleBinding {
-    inner: deps_hack::k8s_openapi::api::rbac::v1::RoleBinding,
-}
+implement_wrapper_type!(
+    RoleBinding,
+    deps_hack::k8s_openapi::api::rbac::v1::RoleBinding,
+    RoleBindingView
+);
 
-impl View for RoleBinding {
-    type V = RoleBindingView;
-
-    spec fn view(&self) -> RoleBindingView;
-}
+verus! {
 
 impl RoleBinding {
-    #[verifier(external_body)]
-    pub fn default() -> (role_binding: RoleBinding)
-        ensures role_binding@ == RoleBindingView::default(),
-    {
-        RoleBinding {
-            inner: deps_hack::k8s_openapi::api::rbac::v1::RoleBinding::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn metadata(&self) -> (metadata: ObjectMeta)
-        ensures metadata@ == self@.metadata,
-    {
-        ObjectMeta::from_kube(self.inner.metadata.clone())
-    }
-
     #[verifier(external_body)]
     pub fn role_ref(&self) -> (role_ref: RoleRef)
         ensures role_ref@ == self@.role_ref,
     {
         RoleRef::from_kube(self.inner.role_ref.clone())
-    }
-
-    #[verifier(external_body)]
-    pub fn set_metadata(&mut self, metadata: ObjectMeta)
-        ensures self@ == old(self)@.with_metadata(metadata@),
-    {
-        self.inner.metadata = metadata.into_kube();
     }
 
     #[verifier(external_body)]
@@ -72,42 +43,6 @@ impl RoleBinding {
         self.inner.subjects = Some(
             subjects.into_iter().map(|s: Subject| s.into_kube()).collect()
         );
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (c: Self)
-        ensures c@ == self@,
-    {
-        RoleBinding { inner: self.inner.clone() }
-    }
-
-    #[verifier(external_body)]
-    pub fn api_resource() -> (res: ApiResource)
-        ensures res@.kind == RoleBindingView::kind(),
-    {
-        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::rbac::v1::RoleBinding>(&()))
-    }
-
-    #[verifier(external_body)]
-    pub fn marshal(self) -> (obj: DynamicObject)
-        ensures obj@ == self@.marshal(),
-    {
-        DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
-    }
-
-    #[verifier(external_body)]
-    pub fn unmarshal(obj: DynamicObject) -> (res: Result<RoleBinding, UnmarshalError>)
-        ensures
-            res.is_Ok() == RoleBindingView::unmarshal(obj@).is_Ok(),
-            res.is_Ok() ==> res.get_Ok_0()@ == RoleBindingView::unmarshal(obj@).get_Ok_0(),
-    {
-        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::rbac::v1::RoleBinding>();
-        if parse_result.is_ok() {
-            let res = RoleBinding { inner: parse_result.unwrap() };
-            Ok(res)
-        } else {
-            Err(())
-        }
     }
 }
 
@@ -217,6 +152,6 @@ impl Subject {
 
 }
 
-implement_resource_wrapper!(RoleRef, deps_hack::k8s_openapi::api::rbac::v1::RoleRef);
+implement_resource_wrapper_trait!(RoleRef, deps_hack::k8s_openapi::api::rbac::v1::RoleRef);
 
-implement_resource_wrapper!(Subject, deps_hack::k8s_openapi::api::rbac::v1::Subject);
+implement_resource_wrapper_trait!(Subject, deps_hack::k8s_openapi::api::rbac::v1::Subject);

--- a/src/kubernetes_api_objects/exec/secret.rs
+++ b/src/kubernetes_api_objects/exec/secret.rs
@@ -95,12 +95,6 @@ impl Secret {
         Secret { inner: self.inner.clone() }
     }
 
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Secret) -> Secret { Secret { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Secret { self.inner }
-
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures res@.kind == SecretView::kind(),

--- a/src/kubernetes_api_objects/exec/secret.rs
+++ b/src/kubernetes_api_objects/exec/secret.rs
@@ -8,8 +8,6 @@ use crate::kubernetes_api_objects::spec::{resource::*, secret::*};
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
-verus! {
-
 // Secret is a type of API object used to store confidential data in key-value pairs.
 // A Secret object can be used to set environment variables or configuration files
 // in a Volume mounted to a Pod.
@@ -20,34 +18,15 @@ verus! {
 //
 // More detailed information: https://kubernetes.io/docs/concepts/configuration/secret/.
 
-#[verifier(external_body)]
-pub struct Secret {
-    inner: deps_hack::k8s_openapi::api::core::v1::Secret,
-}
+implement_wrapper_type!(
+    Secret,
+    deps_hack::k8s_openapi::api::core::v1::Secret,
+    SecretView
+);
 
-impl View for Secret {
-    type V = SecretView;
-
-    spec fn view(&self) -> SecretView;
-}
+verus! {
 
 impl Secret {
-    #[verifier(external_body)]
-    pub fn default() -> (secret: Secret)
-        ensures secret@ == SecretView::default(),
-    {
-        Secret {
-            inner: deps_hack::k8s_openapi::api::core::v1::Secret::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn metadata(&self) -> (metadata: ObjectMeta)
-        ensures metadata@ == self@.metadata,
-    {
-        ObjectMeta::from_kube(self.inner.metadata.clone())
-    }
-
     #[verifier(external_body)]
     pub fn data(&self) -> (data: Option<StringMap>)
         ensures
@@ -68,13 +47,6 @@ impl Secret {
         }
     }
 
-    #[verifier(external_body)]
-    pub fn set_metadata(&mut self, metadata: ObjectMeta)
-        ensures self@ == old(self)@.with_metadata(metadata@),
-    {
-        self.inner.metadata = metadata.into_kube();
-    }
-
     // TODO: data is a map of string to bytestring. May support it in the future.
     #[verifier(external_body)]
     pub fn set_data(&mut self, data: StringMap)
@@ -86,42 +58,6 @@ impl Secret {
             binary_map.insert(key, deps_hack::k8s_openapi::ByteString(value.into_bytes()));
         }
         self.inner.data = Some(binary_map)
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (c: Self)
-        ensures c@ == self@,
-    {
-        Secret { inner: self.inner.clone() }
-    }
-
-    #[verifier(external_body)]
-    pub fn api_resource() -> (res: ApiResource)
-        ensures res@.kind == SecretView::kind(),
-    {
-        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::Secret>(&()))
-    }
-
-    #[verifier(external_body)]
-    pub fn marshal(self) -> (obj: DynamicObject)
-        ensures obj@ == self@.marshal(),
-    {
-        DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
-    }
-
-    #[verifier(external_body)]
-    pub fn unmarshal(obj: DynamicObject) -> (res: Result<Secret, UnmarshalError>)
-        ensures
-            res.is_Ok() == SecretView::unmarshal(obj@).is_Ok(),
-            res.is_Ok() ==> res.get_Ok_0()@ == SecretView::unmarshal(obj@).get_Ok_0(),
-    {
-        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::Secret>();
-        if parse_result.is_ok() {
-            let res = Secret { inner: parse_result.unwrap() };
-            Ok(res)
-        } else {
-            Err(())
-        }
     }
 }
 

--- a/src/kubernetes_api_objects/exec/service.rs
+++ b/src/kubernetes_api_objects/exec/service.rs
@@ -81,12 +81,6 @@ impl Service {
         self.inner.spec = Some(spec.into_kube());
     }
 
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Service { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Service) -> Service { Service { inner: inner } }
-
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures res@.kind == ServiceView::kind(),
@@ -208,12 +202,6 @@ impl ServiceSpec {
     {
         self.inner.publish_not_ready_addresses = None;
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ServiceSpec) -> ServiceSpec { ServiceSpec { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ServiceSpec { self.inner }
 }
 
 #[verifier(external_body)]
@@ -270,12 +258,18 @@ impl ServicePort {
     {
         self.inner.protocol = Some(protocol);
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ServicePort) -> ServicePort { ServicePort { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ServicePort { self.inner }
 }
 
 }
+
+implement_resource_wrapper!(Service, deps_hack::k8s_openapi::api::core::v1::Service);
+
+implement_resource_wrapper!(
+    ServiceSpec,
+    deps_hack::k8s_openapi::api::core::v1::ServiceSpec
+);
+
+implement_resource_wrapper!(
+    ServicePort,
+    deps_hack::k8s_openapi::api::core::v1::ServicePort
+);

--- a/src/kubernetes_api_objects/exec/service_account.rs
+++ b/src/kubernetes_api_objects/exec/service_account.rs
@@ -61,12 +61,6 @@ impl ServiceAccount {
         ServiceAccount { inner: self.inner.clone() }
     }
 
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ServiceAccount) -> ServiceAccount { ServiceAccount { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ServiceAccount { self.inner }
-
     #[verifier(external_body)]
     pub fn api_resource() -> (res: ApiResource)
         ensures res@.kind == ServiceAccountView::kind(),

--- a/src/kubernetes_api_objects/exec/service_account.rs
+++ b/src/kubernetes_api_objects/exec/service_account.rs
@@ -7,8 +7,6 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{resource::*, service_account::*};
 use vstd::prelude::*;
 
-verus! {
-
 // A service account is a type of non-human account that, in Kubernetes, provides a distinct identity in a Kubernetes cluster.
 // Application Pods, system components, and entities inside and outside the cluster can use a specific ServiceAccount's credentials to identify as that ServiceAccount.
 // This identity is useful in various situations, including authenticating to the API server or implementing identity-based security policies.
@@ -19,76 +17,8 @@ verus! {
 //
 // More detailed information: https://kubernetes.io/docs/concepts/security/service-accounts/.
 
-#[verifier(external_body)]
-pub struct ServiceAccount {
-    inner: deps_hack::k8s_openapi::api::core::v1::ServiceAccount,
-}
-
-impl View for ServiceAccount {
-    type V = ServiceAccountView;
-
-    spec fn view(&self) -> ServiceAccountView;
-}
-
-impl ServiceAccount {
-    #[verifier(external_body)]
-    pub fn default() -> (service_account: ServiceAccount)
-        ensures service_account@ == ServiceAccountView::default(),
-    {
-        ServiceAccount {
-            inner: deps_hack::k8s_openapi::api::core::v1::ServiceAccount::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn metadata(&self) -> (metadata: ObjectMeta)
-        ensures metadata@ == self@.metadata,
-    {
-        ObjectMeta::from_kube(self.inner.metadata.clone())
-    }
-
-    #[verifier(external_body)]
-    pub fn set_metadata(&mut self, metadata: ObjectMeta)
-        ensures self@ == old(self)@.with_metadata(metadata@),
-    {
-        self.inner.metadata = metadata.into_kube();
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (c: Self)
-        ensures c@ == self@,
-    {
-        ServiceAccount { inner: self.inner.clone() }
-    }
-
-    #[verifier(external_body)]
-    pub fn api_resource() -> (res: ApiResource)
-        ensures res@.kind == ServiceAccountView::kind(),
-    {
-        ApiResource::from_kube(deps_hack::kube::api::ApiResource::erase::<deps_hack::k8s_openapi::api::core::v1::ServiceAccount>(&()))
-    }
-
-    #[verifier(external_body)]
-    pub fn marshal(self) -> (obj: DynamicObject)
-        ensures obj@ == self@.marshal(),
-    {
-        DynamicObject::from_kube(deps_hack::k8s_openapi::serde_json::from_str(&deps_hack::k8s_openapi::serde_json::to_string(&self.inner).unwrap()).unwrap())
-    }
-
-    #[verifier(external_body)]
-    pub fn unmarshal(obj: DynamicObject) -> (res: Result<ServiceAccount, UnmarshalError>)
-        ensures
-            res.is_Ok() == ServiceAccountView::unmarshal(obj@).is_Ok(),
-            res.is_Ok() ==> res.get_Ok_0()@ == ServiceAccountView::unmarshal(obj@).get_Ok_0(),
-    {
-        let parse_result = obj.into_kube().try_parse::<deps_hack::k8s_openapi::api::core::v1::ServiceAccount>();
-        if parse_result.is_ok() {
-            let res = ServiceAccount { inner: parse_result.unwrap() };
-            Ok(res)
-        } else {
-            Err(())
-        }
-    }
-}
-
-}
+implement_wrapper_type!(
+    ServiceAccount,
+    deps_hack::k8s_openapi::api::core::v1::ServiceAccount,
+    ServiceAccountView
+);

--- a/src/kubernetes_api_objects/exec/stateful_set.rs
+++ b/src/kubernetes_api_objects/exec/stateful_set.rs
@@ -129,17 +129,6 @@ impl StatefulSet {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSet> for StatefulSet {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSet) -> StatefulSet {
-        StatefulSet { inner: inner }
-    }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSet {
-        self.inner
-    }
-}
-
 #[verifier(external_body)]
 pub struct StatefulSetSpec {
     inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec,
@@ -284,17 +273,6 @@ impl StatefulSetSpec {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec> for StatefulSetSpec {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec) -> StatefulSetSpec {
-        StatefulSetSpec { inner: inner }
-    }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec {
-        self.inner
-    }
-}
-
 #[verifier(external_body)]
 pub struct StatefulSetPersistentVolumeClaimRetentionPolicy {
     inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy,
@@ -332,13 +310,6 @@ impl StatefulSetPersistentVolumeClaimRetentionPolicy {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy> for StatefulSetPersistentVolumeClaimRetentionPolicy {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy) -> StatefulSetPersistentVolumeClaimRetentionPolicy { StatefulSetPersistentVolumeClaimRetentionPolicy { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy { self.inner }
-}
-
 #[verifier(external_body)]
 pub struct StatefulSetStatus {
     inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetStatus,
@@ -357,11 +328,24 @@ impl StatefulSetStatus {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSetStatus> for StatefulSetStatus {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetStatus) -> StatefulSetStatus { StatefulSetStatus { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetStatus { self.inner }
 }
 
-}
+implement_resource_wrapper!(
+    StatefulSet,
+    deps_hack::k8s_openapi::api::apps::v1::StatefulSet
+);
+
+implement_resource_wrapper!(
+    StatefulSetSpec,
+    deps_hack::k8s_openapi::api::apps::v1::StatefulSetSpec
+);
+
+implement_resource_wrapper!(
+    StatefulSetStatus,
+    deps_hack::k8s_openapi::api::apps::v1::StatefulSetStatus
+);
+
+implement_resource_wrapper!(
+    StatefulSetPersistentVolumeClaimRetentionPolicy,
+    deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy
+);

--- a/src/kubernetes_api_objects/exec/toleration.rs
+++ b/src/kubernetes_api_objects/exec/toleration.rs
@@ -25,7 +25,7 @@ impl Toleration {
 
 }
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     Toleration,
     deps_hack::k8s_openapi::api::core::v1::Toleration
 );

--- a/src/kubernetes_api_objects/exec/toleration.rs
+++ b/src/kubernetes_api_objects/exec/toleration.rs
@@ -23,11 +23,9 @@ impl Toleration {
     pub spec fn view(&self) -> TolerationView;
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::core::v1::Toleration> for Toleration {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Toleration) -> Toleration { Toleration { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Toleration { self.inner }
 }
 
-}
+implement_resource_wrapper!(
+    Toleration,
+    deps_hack::k8s_openapi::api::core::v1::Toleration
+);

--- a/src/kubernetes_api_objects/exec/volume.rs
+++ b/src/kubernetes_api_objects/exec/volume.rs
@@ -471,61 +471,61 @@ impl ObjectFieldSelector {
 
 }
 
-implement_resource_wrapper!(Volume, deps_hack::k8s_openapi::api::core::v1::Volume);
+implement_resource_wrapper_trait!(Volume, deps_hack::k8s_openapi::api::core::v1::Volume);
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     EmptyDirVolumeSource,
     deps_hack::k8s_openapi::api::core::v1::EmptyDirVolumeSource
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     HostPathVolumeSource,
     deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     ConfigMapVolumeSource,
     deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     SecretVolumeSource,
     deps_hack::k8s_openapi::api::core::v1::SecretVolumeSource
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     ProjectedVolumeSource,
     deps_hack::k8s_openapi::api::core::v1::ProjectedVolumeSource
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     VolumeProjection,
     deps_hack::k8s_openapi::api::core::v1::VolumeProjection
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     ConfigMapProjection,
     deps_hack::k8s_openapi::api::core::v1::ConfigMapProjection
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     SecretProjection,
     deps_hack::k8s_openapi::api::core::v1::SecretProjection
 );
 
-implement_resource_wrapper!(KeyToPath, deps_hack::k8s_openapi::api::core::v1::KeyToPath);
+implement_resource_wrapper_trait!(KeyToPath, deps_hack::k8s_openapi::api::core::v1::KeyToPath);
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     DownwardAPIVolumeSource,
     deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeSource
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     DownwardAPIVolumeFile,
     deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeFile
 );
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     ObjectFieldSelector,
     deps_hack::k8s_openapi::api::core::v1::ObjectFieldSelector
 );

--- a/src/kubernetes_api_objects/exec/volume.rs
+++ b/src/kubernetes_api_objects/exec/volume.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::volume::*;
 use vstd::prelude::*;
 
@@ -71,12 +72,6 @@ impl Volume {
         self.inner.downward_api = Some(downward_api.into_kube());
     }
 
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::Volume { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::Volume) -> Volume { Volume { inner } }
-
     // Methods for the fields that Anvil currently does not reason about
 
     #[verifier(external_body)]
@@ -110,12 +105,6 @@ impl EmptyDirVolumeSource {
     {
         EmptyDirVolumeSource { inner: self.inner.clone() }
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::EmptyDirVolumeSource { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::EmptyDirVolumeSource) -> EmptyDirVolumeSource { EmptyDirVolumeSource { inner } }
 }
 
 #[verifier(external_body)]
@@ -146,12 +135,6 @@ impl HostPathVolumeSource {
     {
         self.inner.path = path;
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource) -> HostPathVolumeSource { HostPathVolumeSource { inner } }
 }
 
 #[verifier(external_body)]
@@ -182,12 +165,6 @@ impl ConfigMapVolumeSource {
     {
         self.inner.name = Some(name);
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource) -> ConfigMapVolumeSource { ConfigMapVolumeSource { inner } }
 }
 
 #[verifier(external_body)]
@@ -220,12 +197,6 @@ impl SecretVolumeSource {
     {
         self.inner.secret_name = Some(secret_name);
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::SecretVolumeSource { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::SecretVolumeSource) -> SecretVolumeSource { SecretVolumeSource { inner } }
 }
 
 #[verifier(external_body)]
@@ -256,12 +227,6 @@ impl ProjectedVolumeSource {
     {
         self.inner.sources = Some(sources.into_iter().map(|v: VolumeProjection| v.into_kube()).collect());
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ProjectedVolumeSource { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ProjectedVolumeSource) -> ProjectedVolumeSource { ProjectedVolumeSource { inner } }
 }
 
 #[verifier(external_body)]
@@ -292,12 +257,6 @@ impl VolumeProjection {
     {
         self.inner.secret = Some(secret.into_kube());
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::VolumeProjection { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::VolumeProjection) -> VolumeProjection { VolumeProjection { inner } }
 }
 
 #[verifier(external_body)]
@@ -335,12 +294,6 @@ impl ConfigMapProjection {
     {
         self.inner.items = Some(items.into_iter().map(|v: KeyToPath| v.into_kube()).collect());
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ConfigMapProjection { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapProjection) -> ConfigMapProjection { ConfigMapProjection { inner } }
 }
 
 #[verifier(external_body)]
@@ -378,12 +331,6 @@ impl SecretProjection {
     {
         self.inner.items = Some(items.into_iter().map(|v: KeyToPath| v.into_kube()).collect());
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::SecretProjection { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::SecretProjection) -> SecretProjection { SecretProjection { inner } }
 }
 
 #[verifier(external_body)]
@@ -414,12 +361,6 @@ impl KeyToPath {
     {
         self.inner.path = path;
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::KeyToPath { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::KeyToPath) -> KeyToPath { KeyToPath { inner } }
 }
 
 #[verifier(external_body)]
@@ -450,12 +391,6 @@ impl DownwardAPIVolumeSource {
     {
         self.inner.items = Some(items.into_iter().map(|v: DownwardAPIVolumeFile| v.into_kube()).collect());
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeSource { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeSource) -> DownwardAPIVolumeSource { DownwardAPIVolumeSource { inner } }
 }
 
 #[verifier(external_body)]
@@ -486,12 +421,6 @@ impl DownwardAPIVolumeFile {
     {
         self.inner.path = path;
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeFile { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeFile) -> DownwardAPIVolumeFile { DownwardAPIVolumeFile { inner } }
 }
 
 #[verifier(external_body)]
@@ -538,12 +467,65 @@ impl ObjectFieldSelector {
     {
         self.inner.api_version = Some(api_version);
     }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::ObjectFieldSelector { self.inner }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::ObjectFieldSelector) -> (object_field_selector: ObjectFieldSelector) { ObjectFieldSelector { inner } }
 }
 
 }
+
+implement_resource_wrapper!(Volume, deps_hack::k8s_openapi::api::core::v1::Volume);
+
+implement_resource_wrapper!(
+    EmptyDirVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::EmptyDirVolumeSource
+);
+
+implement_resource_wrapper!(
+    HostPathVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource
+);
+
+implement_resource_wrapper!(
+    ConfigMapVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource
+);
+
+implement_resource_wrapper!(
+    SecretVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::SecretVolumeSource
+);
+
+implement_resource_wrapper!(
+    ProjectedVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::ProjectedVolumeSource
+);
+
+implement_resource_wrapper!(
+    VolumeProjection,
+    deps_hack::k8s_openapi::api::core::v1::VolumeProjection
+);
+
+implement_resource_wrapper!(
+    ConfigMapProjection,
+    deps_hack::k8s_openapi::api::core::v1::ConfigMapProjection
+);
+
+implement_resource_wrapper!(
+    SecretProjection,
+    deps_hack::k8s_openapi::api::core::v1::SecretProjection
+);
+
+implement_resource_wrapper!(KeyToPath, deps_hack::k8s_openapi::api::core::v1::KeyToPath);
+
+implement_resource_wrapper!(
+    DownwardAPIVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeSource
+);
+
+implement_resource_wrapper!(
+    DownwardAPIVolumeFile,
+    deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeFile
+);
+
+implement_resource_wrapper!(
+    ObjectFieldSelector,
+    deps_hack::k8s_openapi::api::core::v1::ObjectFieldSelector
+);

--- a/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
@@ -48,7 +48,7 @@ impl VolumeResourceRequirements {
 
 }
 
-implement_resource_wrapper!(
+implement_resource_wrapper_trait!(
     VolumeResourceRequirements,
     deps_hack::k8s_openapi::api::core::v1::VolumeResourceRequirements
 );

--- a/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
+use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::volume_resource_requirements::*;
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
@@ -43,12 +44,11 @@ impl VolumeResourceRequirements {
     {
         self.inner.requests = Some(requests.into_rust_map().into_iter().map(|(k, v)| (k, deps_hack::k8s_openapi::apimachinery::pkg::api::resource::Quantity(v))).collect());
     }
-
-    #[verifier(external)]
-    pub fn from_kube(inner: deps_hack::k8s_openapi::api::core::v1::VolumeResourceRequirements) -> VolumeResourceRequirements { VolumeResourceRequirements { inner: inner } }
-
-    #[verifier(external)]
-    pub fn into_kube(self) -> deps_hack::k8s_openapi::api::core::v1::VolumeResourceRequirements { self.inner }
 }
 
 }
+
+implement_resource_wrapper!(
+    VolumeResourceRequirements,
+    deps_hack::k8s_openapi::api::core::v1::VolumeResourceRequirements
+);

--- a/src/kubernetes_api_objects/spec/api_method.rs
+++ b/src/kubernetes_api_objects/spec/api_method.rs
@@ -34,6 +34,12 @@ pub struct GetRequest {
     pub key: ObjectRef,
 }
 
+impl GetRequest {
+    pub open spec fn key(self) -> ObjectRef {
+        self.key
+    }
+}
+
 // ListRequest lists all the objects of kind in namespace.
 
 pub struct ListRequest {

--- a/src/kubernetes_api_objects/spec/api_method.rs
+++ b/src/kubernetes_api_objects/spec/api_method.rs
@@ -65,6 +65,12 @@ pub struct DeleteRequest {
     pub preconditions: Option<PreconditionsView>,
 }
 
+impl DeleteRequest {
+    pub open spec fn key(self) -> ObjectRef {
+        self.key
+    }
+}
+
 // UpdateRequest replaces the existing obj with a new one.
 
 pub struct UpdateRequest {

--- a/src/v2/controllers/vdeployment_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/vdeployment_controller/trusted/exec_types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::error::UnmarshalError;
 use crate::kubernetes_api_objects::exec::{
-    api_resource::*, label_selector::*, pod_template_spec::*, prelude::*,
+    api_resource::*, label_selector::*, pod_template_spec::*, prelude::*, resource::*,
 };
 use crate::kubernetes_api_objects::spec::resource::*;
 use crate::vdeployment_controller::trusted::{spec_types, step::*};
@@ -78,12 +78,6 @@ impl VDeployment {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::VDeployment> for VDeployment {
-    fn from_kube(inner: deps_hack::VDeployment) -> VDeployment { VDeployment { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::VDeployment { self.inner }
-}
 
 #[verifier(external_body)]
 pub struct VDeploymentSpec {
@@ -123,3 +117,5 @@ impl VDeploymentSpec {
 }
 
 }
+
+implement_resource_wrapper_trait!(VDeployment, deps_hack::VDeployment);

--- a/src/v2/controllers/vreplicaset_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/exec_types.rs
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::error::UnmarshalError;
 use crate::kubernetes_api_objects::exec::{
-    api_resource::*, label_selector::*, pod_template_spec::*, prelude::*,
+    api_resource::*, label_selector::*, pod_template_spec::*, prelude::*, resource::*,
 };
 use crate::kubernetes_api_objects::spec::resource::*;
 use crate::vreplicaset_controller::trusted::spec_types;
 use crate::vstd_ext::string_map::StringMap;
 use deps_hack::kube::Resource;
 use vstd::prelude::*;
+
 verus! {
 
 #[verifier(external_body)]
@@ -76,11 +77,11 @@ impl VReplicaSet {
         }
     }
 
-    pub fn state_validation(&self) -> (res: bool) 
+    pub fn state_validation(&self) -> (res: bool)
         ensures
             res == self@.state_validation()
     {
-        
+
         // replicas exists and non-negative
         if let Some(replicas) = self.spec().replicas() {
             if replicas < 0 {
@@ -102,7 +103,7 @@ impl VReplicaSet {
             if template.metadata().is_none() || template.spec().is_none() {
                 return false;
             }
-            
+
             // Map::empty() did not compile
             if !self.spec().selector().matches(template.metadata().unwrap().labels().unwrap_or(StringMap::empty())) {
                 return false;
@@ -111,16 +112,9 @@ impl VReplicaSet {
         } else {
             return false;
         }
-    
+
         true
     }
-}
-
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::VReplicaSet> for VReplicaSet {
-    fn from_kube(inner: deps_hack::VReplicaSet) -> VReplicaSet { VReplicaSet { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::VReplicaSet { self.inner }
 }
 
 #[verifier(external_body)]
@@ -161,3 +155,5 @@ impl VReplicaSetSpec {
 }
 
 }
+
+implement_resource_wrapper!(VReplicaSet, deps_hack::VReplicaSet);

--- a/src/v2/controllers/vreplicaset_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/exec_types.rs
@@ -156,4 +156,4 @@ impl VReplicaSetSpec {
 
 }
 
-implement_resource_wrapper!(VReplicaSet, deps_hack::VReplicaSet);
+implement_resource_wrapper_trait!(VReplicaSet, deps_hack::VReplicaSet);

--- a/src/v2/controllers/vstatefulset_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/vstatefulset_controller/trusted/exec_types.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: MIT
 use crate::kubernetes_api_objects::error::UnmarshalError;
 use crate::kubernetes_api_objects::exec::{
-    api_resource::*, label_selector::*, pod_template_spec::*, prelude::*, persistent_volume_claim::*
+    api_resource::*, label_selector::*, persistent_volume_claim::*, pod_template_spec::*,
+    prelude::*, resource::*,
 };
-use crate::kubernetes_api_objects::spec::{resource::*, persistent_volume_claim::*, volume_resource_requirements::*};
+use crate::kubernetes_api_objects::spec::{
+    persistent_volume_claim::*, resource::*, volume_resource_requirements::*,
+};
 use crate::vstatefulset_controller::trusted::spec_types;
 use crate::vstd_ext::string_map::*;
 use deps_hack::kube::Resource;
@@ -226,13 +229,6 @@ impl VStatefulSet {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::VStatefulSet> for VStatefulSet {
-    fn from_kube(inner: deps_hack::VStatefulSet) -> VStatefulSet { VStatefulSet { inner: inner } }
-
-    fn into_kube(self) -> deps_hack::VStatefulSet { self.inner }
-}
-
 #[verifier(external_body)]
 pub struct VStatefulSetSpec {
     inner: deps_hack::VStatefulSetSpec,
@@ -339,6 +335,8 @@ impl VStatefulSetSpec {
     }
 }
 
+// TODO: merge the definitions below into kubernetes_api_objects
+
 #[verifier(external_body)]
 pub struct StatefulSetUpdateStrategy {
     inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetUpdateStrategy,
@@ -396,17 +394,6 @@ impl StatefulSetUpdateStrategy {
         ensures self@ == old(self)@.with_rolling_update(rolling_update@),
     {
         self.inner.rolling_update = Some(rolling_update.into_kube());
-    }
-}
-
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSetUpdateStrategy> for StatefulSetUpdateStrategy {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetUpdateStrategy) -> StatefulSetUpdateStrategy {
-        StatefulSetUpdateStrategy { inner: inner }
-    }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetUpdateStrategy {
-        self.inner
     }
 }
 
@@ -477,16 +464,6 @@ impl RollingUpdateStatefulSetStrategy {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::RollingUpdateStatefulSetStrategy> for RollingUpdateStatefulSetStrategy {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::RollingUpdateStatefulSetStrategy) -> RollingUpdateStatefulSetStrategy {
-        RollingUpdateStatefulSetStrategy { inner: inner }
-    }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::RollingUpdateStatefulSetStrategy {
-        self.inner
-    }
-}
 
 #[verifier(external_body)]
 pub struct StatefulSetPersistentVolumeClaimRetentionPolicy {
@@ -545,17 +522,6 @@ impl StatefulSetPersistentVolumeClaimRetentionPolicy {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy> for StatefulSetPersistentVolumeClaimRetentionPolicy {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy) -> StatefulSetPersistentVolumeClaimRetentionPolicy {
-        StatefulSetPersistentVolumeClaimRetentionPolicy { inner: inner }
-    }
-
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy {
-        self.inner
-    }
-}
-
 #[verifier(external_body)]
 pub struct StatefulSetOrdinals {
     inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetOrdinals,
@@ -600,14 +566,26 @@ impl StatefulSetOrdinals {
     }
 }
 
-#[verifier(external)]
-impl ResourceWrapper<deps_hack::k8s_openapi::api::apps::v1::StatefulSetOrdinals> for StatefulSetOrdinals {
-    fn from_kube(inner: deps_hack::k8s_openapi::api::apps::v1::StatefulSetOrdinals) -> StatefulSetOrdinals {
-        StatefulSetOrdinals { inner: inner }
-    }
+}
 
-    fn into_kube(self) -> deps_hack::k8s_openapi::api::apps::v1::StatefulSetOrdinals {
-        self.inner
-    }
-}
-}
+implement_resource_wrapper_trait!(VStatefulSet, deps_hack::VStatefulSet);
+
+implement_resource_wrapper_trait!(
+    StatefulSetUpdateStrategy,
+    deps_hack::k8s_openapi::api::apps::v1::StatefulSetUpdateStrategy
+);
+
+implement_resource_wrapper_trait!(
+    RollingUpdateStatefulSetStrategy,
+    deps_hack::k8s_openapi::api::apps::v1::RollingUpdateStatefulSetStrategy
+);
+
+implement_resource_wrapper_trait!(
+    StatefulSetOrdinals,
+    deps_hack::k8s_openapi::api::apps::v1::StatefulSetOrdinals
+);
+
+implement_resource_wrapper_trait!(
+    StatefulSetPersistentVolumeClaimRetentionPolicy,
+    deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy
+);

--- a/src/v2/kubernetes_cluster/spec/message.rs
+++ b/src/v2/kubernetes_cluster/spec/message.rs
@@ -68,64 +68,11 @@ pub enum MessageContent {
 
 // Some handy methods for pattern matching and retrieving information from MessageContent
 impl MessageContent {
-    // pub open spec fn is_get_request(self) -> bool {
-    //     &&& self.is_APIRequest()
-    //     &&& self.get_APIRequest_0().is_GetRequest()
-    // }
-
-    // pub open spec fn get_get_request(self) -> GetRequest
-    //     recommends
-    //         self.is_get_request()
-    // {
-    //     self.get_APIRequest_0().get_GetRequest_0()
-    // }
-
-    // pub open spec fn is_list_request(self) -> bool {
-    //     &&& self.is_APIRequest()
-    //     &&& self.get_APIRequest_0().is_ListRequest()
-    // }
-
-    // pub open spec fn get_list_request(self) -> ListRequest
-    //     recommends
-    //         self.is_list_request()
-    // {
-    //     self.get_APIRequest_0().get_ListRequest_0()
-    // }
-
-    // pub open spec fn is_create_request(self) -> bool {
-    //     &&& self.is_APIRequest()
-    //     &&& self.get_APIRequest_0().is_CreateRequest()
-    // }
-
-    // pub open spec fn get_create_request(self) -> CreateRequest
-    //     recommends
-    //         self.is_create_request()
-    // {
-    //     self.get_APIRequest_0().get_CreateRequest_0()
-    // }
-
-    // pub open spec fn is_delete_request(self) -> bool {
-    //     &&& self.is_APIRequest()
-    //     &&& self.get_APIRequest_0().is_DeleteRequest()
-    // }
-
     pub open spec fn is_delete_request_with_key(self, key: ObjectRef) -> bool {
         &&& self.is_APIRequest()
         &&& self.get_APIRequest_0().is_DeleteRequest()
         &&& self.get_APIRequest_0().get_DeleteRequest_0().key == key
     }
-
-    // pub open spec fn get_delete_request(self) -> DeleteRequest
-    //     recommends
-    //         self.is_delete_request()
-    // {
-    //     self.get_APIRequest_0().get_DeleteRequest_0()
-    // }
-
-    // pub open spec fn is_update_request(self) -> bool {
-    //     &&& self.is_APIRequest()
-    //     &&& self.get_APIRequest_0().is_UpdateRequest()
-    // }
 
     pub open spec fn is_update_request_with_key(self, key: ObjectRef) -> bool {
         &&& self.is_APIRequest()
@@ -133,30 +80,11 @@ impl MessageContent {
         &&& self.get_APIRequest_0().get_UpdateRequest_0().key() == key
     }
 
-    // pub open spec fn get_update_request(self) -> UpdateRequest
-    //     recommends
-    //         self.is_update_request()
-    // {
-    //     self.get_APIRequest_0().get_UpdateRequest_0()
-    // }
-
-    // pub open spec fn is_update_status_request(self) -> bool {
-    //     &&& self.is_APIRequest()
-    //     &&& self.get_APIRequest_0().is_UpdateStatusRequest()
-    // }
-
     pub open spec fn is_update_status_request_with_key(self, key: ObjectRef) -> bool {
         &&& self.is_APIRequest()
         &&& self.get_APIRequest_0().is_UpdateStatusRequest()
         &&& self.get_APIRequest_0().get_UpdateStatusRequest_0().key() == key
     }
-
-    // pub open spec fn get_update_status_request(self) -> UpdateStatusRequest
-    //     recommends
-    //         self.is_update_status_request()
-    // {
-    //     self.get_APIRequest_0().get_UpdateStatusRequest_0()
-    // }
 }
 
 
@@ -468,7 +396,7 @@ macro_rules! declare_message_content_req_helper_methods {
         impl MessageContent {
             pub open spec fn $is_fun(self) -> bool {
                 &&& self is APIRequest
-                &&& self->APIRequest_0 is $req_type
+                &&& self.get_APIRequest_0() is $req_type
             }
 
             pub open spec fn $get_fun(self) -> $req_type {
@@ -485,7 +413,7 @@ macro_rules! declare_message_content_resp_helper_methods {
         impl MessageContent {
             pub open spec fn $is_fun(self) -> bool {
                 &&& self is APIResponse
-                &&& self->APIResponse_0 is $resp_type
+                &&& self.get_APIResponse_0() is $resp_type
             }
 
             pub open spec fn $get_fun(self) -> $resp_type {

--- a/src/v2/kubernetes_cluster/spec/message.rs
+++ b/src/v2/kubernetes_cluster/spec/message.rs
@@ -68,46 +68,46 @@ pub enum MessageContent {
 
 // Some handy methods for pattern matching and retrieving information from MessageContent
 impl MessageContent {
-    pub open spec fn is_get_request(self) -> bool {
-        &&& self.is_APIRequest()
-        &&& self.get_APIRequest_0().is_GetRequest()
-    }
+    // pub open spec fn is_get_request(self) -> bool {
+    //     &&& self.is_APIRequest()
+    //     &&& self.get_APIRequest_0().is_GetRequest()
+    // }
 
-    pub open spec fn get_get_request(self) -> GetRequest
-        recommends
-            self.is_get_request()
-    {
-        self.get_APIRequest_0().get_GetRequest_0()
-    }
+    // pub open spec fn get_get_request(self) -> GetRequest
+    //     recommends
+    //         self.is_get_request()
+    // {
+    //     self.get_APIRequest_0().get_GetRequest_0()
+    // }
 
-    pub open spec fn is_list_request(self) -> bool {
-        &&& self.is_APIRequest()
-        &&& self.get_APIRequest_0().is_ListRequest()
-    }
+    // pub open spec fn is_list_request(self) -> bool {
+    //     &&& self.is_APIRequest()
+    //     &&& self.get_APIRequest_0().is_ListRequest()
+    // }
 
-    pub open spec fn get_list_request(self) -> ListRequest
-        recommends
-            self.is_list_request()
-    {
-        self.get_APIRequest_0().get_ListRequest_0()
-    }
+    // pub open spec fn get_list_request(self) -> ListRequest
+    //     recommends
+    //         self.is_list_request()
+    // {
+    //     self.get_APIRequest_0().get_ListRequest_0()
+    // }
 
-    pub open spec fn is_create_request(self) -> bool {
-        &&& self.is_APIRequest()
-        &&& self.get_APIRequest_0().is_CreateRequest()
-    }
+    // pub open spec fn is_create_request(self) -> bool {
+    //     &&& self.is_APIRequest()
+    //     &&& self.get_APIRequest_0().is_CreateRequest()
+    // }
 
-    pub open spec fn get_create_request(self) -> CreateRequest
-        recommends
-            self.is_create_request()
-    {
-        self.get_APIRequest_0().get_CreateRequest_0()
-    }
+    // pub open spec fn get_create_request(self) -> CreateRequest
+    //     recommends
+    //         self.is_create_request()
+    // {
+    //     self.get_APIRequest_0().get_CreateRequest_0()
+    // }
 
-    pub open spec fn is_delete_request(self) -> bool {
-        &&& self.is_APIRequest()
-        &&& self.get_APIRequest_0().is_DeleteRequest()
-    }
+    // pub open spec fn is_delete_request(self) -> bool {
+    //     &&& self.is_APIRequest()
+    //     &&& self.get_APIRequest_0().is_DeleteRequest()
+    // }
 
     pub open spec fn is_delete_request_with_key(self, key: ObjectRef) -> bool {
         &&& self.is_APIRequest()
@@ -115,17 +115,17 @@ impl MessageContent {
         &&& self.get_APIRequest_0().get_DeleteRequest_0().key == key
     }
 
-    pub open spec fn get_delete_request(self) -> DeleteRequest
-        recommends
-            self.is_delete_request()
-    {
-        self.get_APIRequest_0().get_DeleteRequest_0()
-    }
+    // pub open spec fn get_delete_request(self) -> DeleteRequest
+    //     recommends
+    //         self.is_delete_request()
+    // {
+    //     self.get_APIRequest_0().get_DeleteRequest_0()
+    // }
 
-    pub open spec fn is_update_request(self) -> bool {
-        &&& self.is_APIRequest()
-        &&& self.get_APIRequest_0().is_UpdateRequest()
-    }
+    // pub open spec fn is_update_request(self) -> bool {
+    //     &&& self.is_APIRequest()
+    //     &&& self.get_APIRequest_0().is_UpdateRequest()
+    // }
 
     pub open spec fn is_update_request_with_key(self, key: ObjectRef) -> bool {
         &&& self.is_APIRequest()
@@ -133,17 +133,17 @@ impl MessageContent {
         &&& self.get_APIRequest_0().get_UpdateRequest_0().key() == key
     }
 
-    pub open spec fn get_update_request(self) -> UpdateRequest
-        recommends
-            self.is_update_request()
-    {
-        self.get_APIRequest_0().get_UpdateRequest_0()
-    }
+    // pub open spec fn get_update_request(self) -> UpdateRequest
+    //     recommends
+    //         self.is_update_request()
+    // {
+    //     self.get_APIRequest_0().get_UpdateRequest_0()
+    // }
 
-    pub open spec fn is_update_status_request(self) -> bool {
-        &&& self.is_APIRequest()
-        &&& self.get_APIRequest_0().is_UpdateStatusRequest()
-    }
+    // pub open spec fn is_update_status_request(self) -> bool {
+    //     &&& self.is_APIRequest()
+    //     &&& self.get_APIRequest_0().is_UpdateStatusRequest()
+    // }
 
     pub open spec fn is_update_status_request_with_key(self, key: ObjectRef) -> bool {
         &&& self.is_APIRequest()
@@ -151,73 +151,14 @@ impl MessageContent {
         &&& self.get_APIRequest_0().get_UpdateStatusRequest_0().key() == key
     }
 
-    pub open spec fn get_update_status_request(self) -> UpdateStatusRequest
-        recommends
-            self.is_update_status_request()
-    {
-        self.get_APIRequest_0().get_UpdateStatusRequest_0()
-    }
-
-    pub open spec fn is_get_response(self) -> bool {
-        &&& self.is_APIResponse()
-        &&& self.get_APIResponse_0().is_GetResponse()
-    }
-
-    pub open spec fn get_get_response(self) -> GetResponse
-        recommends
-            self.is_get_response()
-    {
-        self.get_APIResponse_0().get_GetResponse_0()
-    }
-
-    pub open spec fn is_create_response(self) -> bool {
-        &&& self.is_APIResponse()
-        &&& self.get_APIResponse_0().is_CreateResponse()
-    }
-
-    pub open spec fn get_create_response(self) -> CreateResponse
-        recommends
-            self.is_create_response()
-    {
-        self.get_APIResponse_0().get_CreateResponse_0()
-    }
-
-    pub open spec fn is_update_response(self) -> bool {
-        &&& self.is_APIResponse()
-        &&& self.get_APIResponse_0().is_UpdateResponse()
-    }
-
-    pub open spec fn get_update_response(self) -> UpdateResponse
-        recommends
-            self.is_update_response()
-    {
-        self.get_APIResponse_0().get_UpdateResponse_0()
-    }
-
-    pub open spec fn is_delete_response(self) -> bool {
-        &&& self.is_APIResponse()
-        &&& self.get_APIResponse_0().is_DeleteResponse()
-    }
-
-    pub open spec fn get_delete_response(self) -> DeleteResponse
-        recommends
-            self.is_delete_response()
-    {
-        self.get_APIResponse_0().get_DeleteResponse_0()
-    }
-
-    pub open spec fn is_list_response(self) -> bool {
-        &&& self.is_APIResponse()
-        &&& self.get_APIResponse_0().is_ListResponse()
-    }
-
-    pub open spec fn get_list_response(self) -> ListResponse
-        recommends
-            self.is_list_response()
-    {
-        self.get_APIResponse_0().get_ListResponse_0()
-    }
+    // pub open spec fn get_update_status_request(self) -> UpdateStatusRequest
+    //     recommends
+    //         self.is_update_status_request()
+    // {
+    //     self.get_APIRequest_0().get_UpdateStatusRequest_0()
+    // }
 }
+
 
 pub open spec fn is_ok_resp(resp: APIResponse) -> bool {
     match resp {
@@ -520,3 +461,121 @@ pub open spec fn is_ok_create_response_msg_and_matches_key(key: ObjectRef) -> sp
 }
 
 }
+
+macro_rules! declare_message_content_req_helper_methods {
+    ($req_type:ty, $is_fun:ident, $get_fun:ident, $project:ident) => {
+        verus! {
+        impl MessageContent {
+            pub open spec fn $is_fun(self) -> bool {
+                &&& self is APIRequest
+                &&& self->APIRequest_0 is $req_type
+            }
+
+            pub open spec fn $get_fun(self) -> $req_type {
+                self.get_APIRequest_0().$project()
+            }
+        }
+        }
+    };
+}
+
+macro_rules! declare_message_content_resp_helper_methods {
+    ($resp_type:ty, $is_fun:ident, $get_fun:ident, $project:ident) => {
+        verus! {
+        impl MessageContent {
+            pub open spec fn $is_fun(self) -> bool {
+                &&& self is APIResponse
+                &&& self->APIResponse_0 is $resp_type
+            }
+
+            pub open spec fn $get_fun(self) -> $resp_type {
+                self.get_APIResponse_0().$project()
+            }
+        }
+        }
+    };
+}
+
+declare_message_content_req_helper_methods!(
+    GetRequest,
+    is_get_request,
+    get_get_request,
+    get_GetRequest_0
+);
+
+declare_message_content_req_helper_methods!(
+    ListRequest,
+    is_list_request,
+    get_list_request,
+    get_ListRequest_0
+);
+
+declare_message_content_req_helper_methods!(
+    CreateRequest,
+    is_create_request,
+    get_create_request,
+    get_CreateRequest_0
+);
+
+declare_message_content_req_helper_methods!(
+    DeleteRequest,
+    is_delete_request,
+    get_delete_request,
+    get_DeleteRequest_0
+);
+
+declare_message_content_req_helper_methods!(
+    UpdateRequest,
+    is_update_request,
+    get_update_request,
+    get_UpdateRequest_0
+);
+
+declare_message_content_req_helper_methods!(
+    UpdateStatusRequest,
+    is_update_status_request,
+    get_update_status_request,
+    get_UpdateStatusRequest_0
+);
+
+declare_message_content_resp_helper_methods!(
+    GetResponse,
+    is_get_response,
+    get_get_response,
+    get_GetResponse_0
+);
+
+declare_message_content_resp_helper_methods!(
+    ListResponse,
+    is_list_response,
+    get_list_response,
+    get_ListResponse_0
+);
+
+declare_message_content_resp_helper_methods!(
+    CreateResponse,
+    is_create_response,
+    get_create_response,
+    get_CreateResponse_0
+);
+
+declare_message_content_resp_helper_methods!(
+    DeleteResponse,
+    is_delete_response,
+    get_delete_response,
+    get_DeleteResponse_0
+);
+
+declare_message_content_resp_helper_methods!(
+    UpdateResponse,
+    is_update_response,
+    get_update_response,
+    get_UpdateResponse_0
+);
+
+declare_message_content_resp_helper_methods!(
+    UpdateStatusResponse,
+    is_update_status_response,
+    get_update_status_response,
+    get_UpdateStatusResponse_0
+);

--- a/src/v2/kubernetes_cluster/spec/message.rs
+++ b/src/v2/kubernetes_cluster/spec/message.rs
@@ -261,48 +261,7 @@ pub open spec fn resource_delete_request_msg(key: ObjectRef) -> spec_fn(Message)
         && msg.content.get_delete_request().key == key
 }
 
-pub open spec fn is_ok_get_response_msg() -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.src.is_APIServer()
-        && msg.content.is_get_response()
-        && msg.content.get_get_response().res.is_Ok()
 }
-
-pub open spec fn is_ok_get_response_msg_and_matches_key(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        is_ok_get_response_msg()(msg)
-        && msg.content.get_get_response().res.get_Ok_0().object_ref() == key
-}
-
-pub open spec fn is_ok_update_response_msg() -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.src.is_APIServer()
-        && msg.content.is_update_response()
-        && msg.content.get_update_response().res.is_Ok()
-}
-
-pub open spec fn is_ok_update_response_msg_and_matches_key(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        is_ok_update_response_msg()(msg)
-        && msg.content.get_update_response().res.get_Ok_0().object_ref() == key
-}
-
-pub open spec fn is_ok_create_response_msg() -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.src.is_APIServer()
-        && msg.content.is_create_response()
-        && msg.content.get_create_response().res.is_Ok()
-}
-
-pub open spec fn is_ok_create_response_msg_and_matches_key(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        is_ok_create_response_msg()(msg)
-        && msg.content.get_create_response().res.get_Ok_0().object_ref() == key
-}
-
-}
-
-// Some handy (but repeated) functions generated using macro
 
 macro_rules! declare_message_content_req_helper_methods {
     ($req_type:ty, $is_fun:ident, $get_fun:ident, $project:ident) => {
@@ -475,3 +434,40 @@ declare_form_resp_msg_functions!(DeleteResponse, form_delete_resp_msg);
 declare_form_resp_msg_functions!(UpdateResponse, form_update_resp_msg);
 
 declare_form_resp_msg_functions!(UpdateStatusResponse, form_update_status_resp_msg);
+
+macro_rules! declare_is_ok_resp_msg_functions {
+    ($is_ok_fun:ident, $is_ok_for_fun:ident, $is:ident, $get:ident) => {
+        verus! {
+        pub open spec fn $is_ok_fun() -> spec_fn(Message) -> bool {
+            |msg: Message|
+                msg.src.is_APIServer() && msg.content.$is() && msg.content.$get().res.is_Ok()
+        }
+
+        pub open spec fn $is_ok_for_fun(key: ObjectRef) -> spec_fn(Message) -> bool {
+            |msg: Message|
+                $is_ok_fun()(msg) && msg.content.$get().res.get_Ok_0().object_ref() == key
+        }
+        }
+    };
+}
+
+declare_is_ok_resp_msg_functions!(
+    is_ok_get_response_msg,
+    is_ok_get_response_msg_and_matches_key,
+    is_get_response,
+    get_get_response
+);
+
+declare_is_ok_resp_msg_functions!(
+    is_ok_create_response_msg,
+    is_ok_create_response_msg_and_matches_key,
+    is_create_response,
+    get_create_response
+);
+
+declare_is_ok_resp_msg_functions!(
+    is_ok_update_response_msg,
+    is_ok_update_response_msg_and_matches_key,
+    is_update_response,
+    get_update_response
+);

--- a/src/v2/kubernetes_cluster/spec/message.rs
+++ b/src/v2/kubernetes_cluster/spec/message.rs
@@ -197,14 +197,6 @@ pub open spec fn api_request_msg_before(rpc_id: RPCId) -> spec_fn(Message) -> bo
     }
 }
 
-pub open spec fn update_status_msg_from_bc_for(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.src.is_BuiltinController()
-        && msg.content.is_update_status_request()
-        && msg.content.get_update_status_request().key() == key
-}
-
 pub open spec fn received_msg_destined_for(recv: Option<Message>, host_id: HostId) -> bool {
     if recv.is_Some() {
         recv.get_Some_0().dst == host_id
@@ -213,58 +205,10 @@ pub open spec fn received_msg_destined_for(recv: Option<Message>, host_id: HostI
     }
 }
 
-pub open spec fn resource_get_request_msg(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_get_request()
-        && msg.content.get_get_request().key == key
-}
-
-pub open spec fn resource_create_request_msg(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_create_request()
-        && msg.content.get_create_request().namespace == key.namespace
-        && msg.content.get_create_request().obj.metadata.name == Some(key.name)
-        && msg.content.get_create_request().obj.kind == key.kind
-}
-
-// This is mainly used for reasoning about create requests with generate name
-pub open spec fn resource_create_request_msg_without_name(kind: Kind, namespace: StringView) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_create_request()
-        && msg.content.get_create_request().namespace == namespace
-        && msg.content.get_create_request().obj.metadata.name.is_None()
-        && msg.content.get_create_request().obj.metadata.generate_name.is_Some()
-        && msg.content.get_create_request().obj.kind == kind
-}
-
-pub open spec fn resource_update_status_request_msg(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_update_status_request()
-        && msg.content.get_update_status_request().key() == key
-}
-
-pub open spec fn resource_update_request_msg(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_update_request()
-        && msg.content.get_update_request().key() == key
-}
-
-pub open spec fn resource_delete_request_msg(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_delete_request()
-        && msg.content.get_delete_request().key == key
-}
-
 }
 
 macro_rules! declare_message_content_req_helper_methods {
-    ($req_type:ty, $is_fun:ident, $get_fun:ident, $project:ident) => {
+    ($is_fun:ident, $get_fun:ident, $req_type:ty, $project:ident) => {
         verus! {
         impl MessageContent {
             pub open spec fn $is_fun(self) -> bool {
@@ -281,7 +225,7 @@ macro_rules! declare_message_content_req_helper_methods {
 }
 
 macro_rules! declare_message_content_req_helper_methods_with_key {
-    ($req_type:ty, $is_fun:ident, $project:ident) => {
+    ($is_fun:ident, $req_type:ty, $project:ident) => {
         verus! {
         impl MessageContent {
             pub open spec fn $is_fun(self, key: ObjectRef) -> bool {
@@ -295,7 +239,7 @@ macro_rules! declare_message_content_req_helper_methods_with_key {
 }
 
 macro_rules! declare_message_content_resp_helper_methods {
-    ($resp_type:ty, $is_fun:ident, $get_fun:ident, $project:ident) => {
+    ($is_fun:ident, $get_fun:ident, $resp_type:ty, $project:ident) => {
         verus! {
         impl MessageContent {
             pub open spec fn $is_fun(self) -> bool {
@@ -312,109 +256,109 @@ macro_rules! declare_message_content_resp_helper_methods {
 }
 
 declare_message_content_req_helper_methods!(
-    GetRequest,
     is_get_request,
     get_get_request,
+    GetRequest,
     get_GetRequest_0
 );
 
 declare_message_content_req_helper_methods!(
-    ListRequest,
     is_list_request,
     get_list_request,
+    ListRequest,
     get_ListRequest_0
 );
 
 declare_message_content_req_helper_methods!(
-    CreateRequest,
     is_create_request,
     get_create_request,
+    CreateRequest,
     get_CreateRequest_0
 );
 
 declare_message_content_req_helper_methods!(
-    DeleteRequest,
     is_delete_request,
     get_delete_request,
+    DeleteRequest,
     get_DeleteRequest_0
 );
 
 declare_message_content_req_helper_methods!(
-    UpdateRequest,
     is_update_request,
     get_update_request,
+    UpdateRequest,
     get_UpdateRequest_0
 );
 
 declare_message_content_req_helper_methods!(
-    UpdateStatusRequest,
     is_update_status_request,
     get_update_status_request,
+    UpdateStatusRequest,
     get_UpdateStatusRequest_0
 );
 
 declare_message_content_req_helper_methods_with_key!(
-    DeleteRequest,
     is_delete_request_with_key,
+    DeleteRequest,
     get_DeleteRequest_0
 );
 
 declare_message_content_req_helper_methods_with_key!(
-    UpdateRequest,
     is_update_request_with_key,
+    UpdateRequest,
     get_UpdateRequest_0
 );
 
 declare_message_content_req_helper_methods_with_key!(
-    UpdateStatusRequest,
     is_update_status_request_with_key,
+    UpdateStatusRequest,
     get_UpdateStatusRequest_0
 );
 
 declare_message_content_resp_helper_methods!(
-    GetResponse,
     is_get_response,
     get_get_response,
+    GetResponse,
     get_GetResponse_0
 );
 
 declare_message_content_resp_helper_methods!(
-    ListResponse,
     is_list_response,
     get_list_response,
+    ListResponse,
     get_ListResponse_0
 );
 
 declare_message_content_resp_helper_methods!(
-    CreateResponse,
     is_create_response,
     get_create_response,
+    CreateResponse,
     get_CreateResponse_0
 );
 
 declare_message_content_resp_helper_methods!(
-    DeleteResponse,
     is_delete_response,
     get_delete_response,
+    DeleteResponse,
     get_DeleteResponse_0
 );
 
 declare_message_content_resp_helper_methods!(
-    UpdateResponse,
     is_update_response,
     get_update_response,
+    UpdateResponse,
     get_UpdateResponse_0
 );
 
 declare_message_content_resp_helper_methods!(
-    UpdateStatusResponse,
     is_update_status_response,
     get_update_status_response,
+    UpdateStatusResponse,
     get_UpdateStatusResponse_0
 );
 
 macro_rules! declare_form_resp_msg_functions {
-    ($resp_type:ty, $fun:ident) => {
+    ($fun:ident, $resp_type:ty) => {
         verus! {
         pub open spec fn $fun(req_msg: Message, resp: $resp_type) -> Message {
             form_msg(req_msg.dst, req_msg.src, req_msg.rpc_id, MessageContent::APIResponse(APIResponse::$resp_type(resp)))
@@ -423,29 +367,87 @@ macro_rules! declare_form_resp_msg_functions {
     };
 }
 
-declare_form_resp_msg_functions!(GetResponse, form_get_resp_msg);
+declare_form_resp_msg_functions!(form_get_resp_msg, GetResponse);
 
-declare_form_resp_msg_functions!(ListResponse, form_list_resp_msg);
+declare_form_resp_msg_functions!(form_list_resp_msg, ListResponse);
 
-declare_form_resp_msg_functions!(CreateResponse, form_create_resp_msg);
+declare_form_resp_msg_functions!(form_create_resp_msg, CreateResponse);
 
-declare_form_resp_msg_functions!(DeleteResponse, form_delete_resp_msg);
+declare_form_resp_msg_functions!(form_delete_resp_msg, DeleteResponse);
 
-declare_form_resp_msg_functions!(UpdateResponse, form_update_resp_msg);
+declare_form_resp_msg_functions!(form_update_resp_msg, UpdateResponse);
 
-declare_form_resp_msg_functions!(UpdateStatusResponse, form_update_status_resp_msg);
+declare_form_resp_msg_functions!(form_update_status_resp_msg, UpdateStatusResponse);
+
+macro_rules! declare_is_req_msg_functions {
+    ($is_fun:ident, $is_req:ident, $get_req:ident) => {
+        verus! {
+        pub open spec fn $is_fun(key: ObjectRef) -> spec_fn(Message) -> bool {
+            |msg: Message| msg.dst.is_APIServer() && msg.content.$is_req() && msg.content.$get_req().key() == key
+        }
+        }
+    };
+}
+
+declare_is_req_msg_functions!(resource_get_request_msg, is_get_request, get_get_request);
+
+declare_is_req_msg_functions!(
+    resource_update_request_msg,
+    is_update_request,
+    get_update_request
+);
+
+declare_is_req_msg_functions!(
+    resource_update_status_request_msg,
+    is_update_status_request,
+    get_update_status_request
+);
+
+declare_is_req_msg_functions!(
+    resource_delete_request_msg,
+    is_delete_request,
+    get_delete_request
+);
+
+verus! {
+
+pub open spec fn update_status_msg_from_bc_for(key: ObjectRef) -> spec_fn(Message) -> bool {
+    |msg: Message|
+        resource_update_status_request_msg(key)(msg) && msg.src.is_BuiltinController()
+}
+
+pub open spec fn resource_create_request_msg(key: ObjectRef) -> spec_fn(Message) -> bool {
+    |msg: Message|
+        msg.dst.is_APIServer()
+        && msg.content.is_create_request()
+        && msg.content.get_create_request().obj.metadata.name.is_Some()
+        && msg.content.get_create_request().key() == key
+}
+
+// This is mainly used for reasoning about create requests with generate name
+pub open spec fn resource_create_request_msg_without_name(kind: Kind, namespace: StringView) -> spec_fn(Message) -> bool {
+    |msg: Message|
+        msg.dst.is_APIServer()
+        && msg.content.is_create_request()
+        && msg.content.get_create_request().namespace == namespace
+        && msg.content.get_create_request().obj.metadata.name.is_None()
+        && msg.content.get_create_request().obj.metadata.generate_name.is_Some()
+        && msg.content.get_create_request().obj.kind == kind
+}
+
+}
 
 macro_rules! declare_is_ok_resp_msg_functions {
-    ($is_ok_fun:ident, $is_ok_for_fun:ident, $is:ident, $get:ident) => {
+    ($is_ok_fun:ident, $is_ok_for_fun:ident, $is_resp:ident, $get_resp:ident) => {
         verus! {
         pub open spec fn $is_ok_fun() -> spec_fn(Message) -> bool {
             |msg: Message|
-                msg.src.is_APIServer() && msg.content.$is() && msg.content.$get().res.is_Ok()
+                msg.src.is_APIServer() && msg.content.$is_resp() && msg.content.$get_resp().res.is_Ok()
         }
 
         pub open spec fn $is_ok_for_fun(key: ObjectRef) -> spec_fn(Message) -> bool {
             |msg: Message|
-                $is_ok_fun()(msg) && msg.content.$get().res.get_Ok_0().object_ref() == key
+                $is_ok_fun()(msg) && msg.content.$get_resp().res.get_Ok_0().object_ref() == key
         }
         }
     };

--- a/src/v2/kubernetes_cluster/spec/message.rs
+++ b/src/v2/kubernetes_cluster/spec/message.rs
@@ -197,37 +197,6 @@ pub open spec fn api_request_msg_before(rpc_id: RPCId) -> spec_fn(Message) -> bo
     }
 }
 
-pub open spec fn create_msg_for(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_create_request()
-        && msg.content.get_create_request().namespace == key.namespace
-        && msg.content.get_create_request().obj.kind == key.kind
-        && msg.content.get_create_request().obj.metadata.name.is_Some()
-        && msg.content.get_create_request().obj.metadata.name.get_Some_0() == key.name
-}
-
-pub open spec fn update_msg_for(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_update_request()
-        && msg.content.get_update_request().key() == key
-}
-
-pub open spec fn update_status_msg_for(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_update_status_request()
-        && msg.content.get_update_status_request().key() == key
-}
-
-pub open spec fn delete_msg_for(key: ObjectRef) -> spec_fn(Message) -> bool {
-    |msg: Message|
-        msg.dst.is_APIServer()
-        && msg.content.is_delete_request()
-        && msg.content.get_delete_request().key == key
-}
-
 pub open spec fn update_status_msg_from_bc_for(key: ObjectRef) -> spec_fn(Message) -> bool {
     |msg: Message|
         msg.dst.is_APIServer()


### PR DESCRIPTION
This PR introduces several macros to generate boilerplate code, including:
- convenient methods for different message and API request/response types
- wrapper types for external Kubernetes objects