### PR TITLE
Flatten spec of API server's list handler

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/trusted/liveness_theorem.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/liveness_theorem.rs
@@ -14,6 +14,7 @@ pub open spec fn vrs_eventually_stable_reconciliation_per_cr(vrs: VReplicaSetVie
     Cluster::eventually_stable_reconciliation_per_cr(vrs, |vrs| current_state_matches(vrs))
 }
 
+// TODO: rewrite it to s.resources().values().filter(selector).to_seq().filter(...).len() == ...
 pub open spec fn current_state_matches(vrs: VReplicaSetView) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let pods: Set<ObjectRef> = Set::new(|key: ObjectRef| {

--- a/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -207,14 +207,13 @@ pub open spec fn handle_get_request(req: GetRequest, s: APIServerState) -> GetRe
 
 #[verifier(inline)]
 pub open spec fn handle_list_request(req: ListRequest, s: APIServerState) -> ListResponse {
-    let selector = |o: DynamicObjectView| {
+    // s.resources.values() returns the set of objects in s.resources
+    // This will not make list return fewer number of objects because
+    // each object is unique in terms of {name, namespace, kind}
+    ListResponse{res: Ok(s.resources.values().filter(|o: DynamicObjectView| {
         &&& o.object_ref().namespace == req.namespace
         &&& o.object_ref().kind == req.kind
-    };
-    // s.resources.values() returns the set of objects in s.resources
-    // this will not make list return fewer number of objects because
-    // each object is unique in terms of {name, namespace, kind}
-    ListResponse{res: Ok(s.resources.values().filter(selector).to_seq())}
+    }).to_seq())}
 }
 
 pub open spec fn create_request_admission_check(installed_types: InstalledTypes, req: CreateRequest, s: APIServerState) -> Option<APIError> {

--- a/src/vstd_ext/map_lib.rs
+++ b/src/vstd_ext/map_lib.rs
@@ -5,13 +5,8 @@ use vstd::{map_lib::*, prelude::*, seq_lib::*, set::*, set_lib::*};
 
 verus! {
 
-// Return all the values in m, which satisfy f, as a seq
-pub open spec fn map_to_seq<K, V>(m: Map<K, V>, f: spec_fn(V) -> bool) -> Seq<V> {
-    m.values().filter(f).to_seq()
-}
-
 pub proof fn a_submap_of_a_finite_map_is_finite<K, V>(m1: Map<K, V>, m2: Map<K, V>)
-    requires 
+    requires
         m1.submap_of(m2),
         m2.dom().finite(),
     ensures


### PR DESCRIPTION
This PR simply inlines `map_to_seq` in the spec of API server's list handler and removes the definition of `map_to_seq`.