### PR TITLE
Change ESR definition; fix most proofs

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/proof.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/proof.rs
@@ -827,6 +827,8 @@ pub proof fn lemma_eventually_always_every_create_matching_pod_request_implies_a
     );
 }
 
+// TODO: investigate flaky proof.
+#[verifier(rlimit(100))]
 pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_at_after_delete_pod_step(
     spec: TempPred<ClusterState>, vrs: VReplicaSetView, cluster: Cluster, controller_id: int,
 )

--- a/src/v2/controllers/vreplicaset_controller/proof/helper_lemmas.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_lemmas.rs
@@ -142,15 +142,14 @@ pub proof fn lemma_filtered_pods_set_equals_matching_pods(
         Cluster::each_object_in_etcd_is_weakly_well_formed()(s),
         Cluster::etcd_is_finite()(s),
         resp_msg_is_the_in_flight_list_resp_at_after_list_pods_step(vrs, controller_id, resp_msg)(s),
-        forall |obj: DynamicObjectView| #[trigger] matching_pod_entries(vrs, s.resources()).values().contains(obj) ==> PodView::unmarshal(obj).is_Ok(),
+        forall |obj: DynamicObjectView| #[trigger] matching_pods(vrs, s.resources()).contains(obj) ==> PodView::unmarshal(obj).is_Ok(),
     ensures
         ({
             let resp_objs = resp_msg.content.get_list_response().res.unwrap();
             let filtered_pods = filter_pods(objects_to_pods(resp_objs).unwrap(), vrs);
             &&& filtered_pods.no_duplicates()
-            &&& filtered_pods.len() == matching_pod_entries(vrs, s.resources()).len() == matching_pod_keys(vrs, s.resources()).len()
-            // .mk_map(PodView::unmarshal).values() == .map_values(|p: PodView| p.marshal())
-            &&& filtered_pods.to_set() == matching_pod_entries(vrs, s.resources()).values().mk_map(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).values()
+            &&& filtered_pods.len() == matching_pods(vrs, s.resources()).len()
+            &&& filtered_pods.to_set() == matching_pods(vrs, s.resources()).mk_map(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).values()
         }),
 {
     let resp_objs = resp_msg.content.get_list_response().res.unwrap();
@@ -171,9 +170,9 @@ pub proof fn lemma_filtered_pods_set_equals_matching_pods(
     // now we only need to prove
     // resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)) == 
     // filter_pods(objects_to_pods(resp_objs).unwrap(), vrs).map_values(|p: PodView| p.marshal())
-    assert(matching_pod_entries(vrs, s.resources()).values() == filtered_objs.to_set());
+    assert(matching_pods(vrs, s.resources()) == filtered_objs.to_set());
     map_values_to_set_eq_to_set_mk_map_values(filtered_objs, |obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0());
-    assert(matching_pod_entries(vrs, s.resources()).values().mk_map(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).values() == filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).to_set());
+    assert(matching_pods(vrs, s.resources()).mk_map(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).values() == filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).to_set());
     assert(filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()) == filtered_pods) by {
         // get rid of objects_to_pods
         true_pred_on_all_element_equal_to_pred_on_all_index(resp_objs, |obj: DynamicObjectView| PodView::unmarshal(obj).is_Ok());
@@ -215,21 +214,16 @@ pub proof fn lemma_filtered_pods_set_equals_matching_pods(
             assert_seqs_equal!(filtered_pods, filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()));
         }
     }
-    assert(filtered_pods.len() == matching_pod_entries(vrs, s.resources()).len() == matching_pod_keys(vrs, s.resources()).len()) by {
-        assert(matching_pod_entries(vrs, s.resources()).values() == filtered_objs.to_set());
+    assert(filtered_pods.len() == matching_pods(vrs, s.resources()).len()) by {
+        assert(matching_pods(vrs, s.resources()) == filtered_objs.to_set());
         assert(resp_objs.no_duplicates());
         seq_filter_preserves_no_duplicates(resp_objs, |obj| owned_selector_match_is(vrs, obj));
         assert(filtered_objs.no_duplicates());
         filtered_objs.unique_seq_to_set();
-        assert_by(matching_pod_entries(vrs, s.resources()).len() == matching_pod_entries(vrs, s.resources()).values().len(), {
-            a_submap_of_a_finite_map_is_finite(matching_pod_entries(vrs, s.resources()), s.resources());
-            injective_finite_map_implies_dom_len_is_equal_to_values_len(matching_pod_entries(vrs, s.resources()));
-        });
-        assert(matching_pod_entries(vrs, s.resources()).values().len() == filtered_objs.len());
+        assert(matching_pods(vrs, s.resources()).len() == filtered_objs.len());
         assert(filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()) == filtered_pods);
         assert(filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).len() == filtered_pods.len());
         assert(filtered_pods.len() == filtered_pods.len());
-        assert(matching_pod_entries(vrs, s.resources()).len() == matching_pod_keys(vrs, s.resources()).len());
     }
 }
 

--- a/src/v2/controllers/vreplicaset_controller/proof/helper_lemmas.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_lemmas.rs
@@ -148,7 +148,7 @@ pub proof fn lemma_filtered_pods_set_equals_matching_pods(
             let resp_objs = resp_msg.content.get_list_response().res.unwrap();
             let filtered_pods = filter_pods(objects_to_pods(resp_objs).unwrap(), vrs);
             &&& filtered_pods.no_duplicates()
-            &&& filtered_pods.len() == matching_pod_entries(vrs, s.resources()).len() == matching_pods(vrs, s.resources()).len()
+            &&& filtered_pods.len() == matching_pod_entries(vrs, s.resources()).len() == matching_pod_keys(vrs, s.resources()).len()
             // .mk_map(PodView::unmarshal).values() == .map_values(|p: PodView| p.marshal())
             &&& filtered_pods.to_set() == matching_pod_entries(vrs, s.resources()).values().mk_map(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).values()
         }),
@@ -215,7 +215,7 @@ pub proof fn lemma_filtered_pods_set_equals_matching_pods(
             assert_seqs_equal!(filtered_pods, filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()));
         }
     }
-    assert(filtered_pods.len() == matching_pod_entries(vrs, s.resources()).len() == matching_pods(vrs, s.resources()).len()) by {
+    assert(filtered_pods.len() == matching_pod_entries(vrs, s.resources()).len() == matching_pod_keys(vrs, s.resources()).len()) by {
         assert(matching_pod_entries(vrs, s.resources()).values() == filtered_objs.to_set());
         assert(resp_objs.no_duplicates());
         seq_filter_preserves_no_duplicates(resp_objs, |obj| owned_selector_match_is(vrs, obj));
@@ -229,7 +229,7 @@ pub proof fn lemma_filtered_pods_set_equals_matching_pods(
         assert(filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()) == filtered_pods);
         assert(filtered_objs.map_values(|obj: DynamicObjectView| PodView::unmarshal(obj).get_Ok_0()).len() == filtered_pods.len());
         assert(filtered_pods.len() == filtered_pods.len());
-        assert(matching_pod_entries(vrs, s.resources()).len() == matching_pods(vrs, s.resources()).len());
+        assert(matching_pod_entries(vrs, s.resources()).len() == matching_pod_keys(vrs, s.resources()).len());
     }
 }
 

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
@@ -87,10 +87,7 @@ pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_
     };
 }
 
-<<<<<<< HEAD
-=======
 // TODO: broken by changed ESR spec, needs new set-based (rather than map-based) argument.
->>>>>>> 74d2694b (fix almost all broken proofs)
 #[verifier(external_body)]
 pub proof fn lemma_api_request_not_made_by_vrs_maintains_matching_pods(
     s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int,

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
@@ -18,11 +18,11 @@ use vstd::{map::*, map_lib::*, prelude::*};
 
 verus! {
 
-// TODO: get rid of diff parameter.
+// TODO: broken by changed ESR spec, needs new set-based (rather than map-based) argument.
 #[verifier(external_body)]
 pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_pods(
-    s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int,
-    diff: int, msg: Message,
+    s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
+    msg: Message,
 )
     requires
         cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
@@ -43,7 +43,7 @@ pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_
         forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)
             ==> #[trigger] vrs_rely(other_id)(s)
     ensures
-        matching_pod_entries(vrs, s.resources()) == matching_pod_entries(vrs, s_prime.resources()),
+        matching_pods(vrs, s.resources()) == matching_pods(vrs, s_prime.resources()),
 {
     if msg.src.is_Controller() {
         let id = msg.src.get_Controller_0();
@@ -87,6 +87,10 @@ pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_
     };
 }
 
+<<<<<<< HEAD
+=======
+// TODO: broken by changed ESR spec, needs new set-based (rather than map-based) argument.
+>>>>>>> 74d2694b (fix almost all broken proofs)
 #[verifier(external_body)]
 pub proof fn lemma_api_request_not_made_by_vrs_maintains_matching_pods(
     s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int,
@@ -112,7 +116,7 @@ pub proof fn lemma_api_request_not_made_by_vrs_maintains_matching_pods(
         forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)
             ==> #[trigger] vrs_rely(other_id)(s)
     ensures
-        matching_pod_entries(vrs, s.resources()) == matching_pod_entries(vrs, s_prime.resources()),
+        matching_pods(vrs, s.resources()) == matching_pods(vrs, s_prime.resources()),
 {
     if msg.src.is_Controller() {
         let id = msg.src.get_Controller_0();

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/proof.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/proof.rs
@@ -153,6 +153,8 @@ proof fn spec_before_phase_n_entails_true_leads_to_current_state_matches(i: nat,
     leads_to_trans(spec.and(spec_before_phase_n(i, vrs, cluster, controller_id)), true_pred(), invariants_since_phase_n(i, vrs, cluster, controller_id), always(lift_state(current_state_matches(vrs))));
 }
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 proof fn lemma_true_leads_to_always_current_state_matches(provided_spec: TempPred<ClusterState>, vrs: VReplicaSetView, cluster: Cluster, controller_id: int) 
     requires
         // The cluster always takes an action, and the relevant actions satisfy weak fairness.
@@ -234,7 +236,7 @@ proof fn lemma_true_leads_to_always_current_state_matches(provided_spec: TempPre
         assert forall |ex: Execution<ClusterState>|
         true_pred::<ClusterState>().satisfied_by(ex) implies #[trigger] exists_num_diff_pods_is.satisfied_by(ex) by {
             let s = ex.head();
-            let pods = matching_pods(vrs, s.resources());
+            let pods = matching_pod_keys(vrs, s.resources());
             let diff = pods.len() - vrs.spec.replicas.unwrap_or(0);
 
             // Instantiate exists statement.

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/proof.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/proof.rs
@@ -153,8 +153,6 @@ proof fn spec_before_phase_n_entails_true_leads_to_current_state_matches(i: nat,
     leads_to_trans(spec.and(spec_before_phase_n(i, vrs, cluster, controller_id)), true_pred(), invariants_since_phase_n(i, vrs, cluster, controller_id), always(lift_state(current_state_matches(vrs))));
 }
 
-// TODO: broken by changed ESR spec.
-#[verifier(external_body)]
 proof fn lemma_true_leads_to_always_current_state_matches(provided_spec: TempPred<ClusterState>, vrs: VReplicaSetView, cluster: Cluster, controller_id: int) 
     requires
         // The cluster always takes an action, and the relevant actions satisfy weak fairness.
@@ -236,7 +234,7 @@ proof fn lemma_true_leads_to_always_current_state_matches(provided_spec: TempPre
         assert forall |ex: Execution<ClusterState>|
         true_pred::<ClusterState>().satisfied_by(ex) implies #[trigger] exists_num_diff_pods_is.satisfied_by(ex) by {
             let s = ex.head();
-            let pods = matching_pod_keys(vrs, s.resources());
+            let pods = matching_pods(vrs, s.resources());
             let diff = pods.len() - vrs.spec.replicas.unwrap_or(0);
 
             // Instantiate exists statement.

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
@@ -1030,6 +1030,8 @@ pub proof fn lemma_from_after_receive_delete_pod_resp_to_receive_delete_pod_resp
 
 // List lemmas
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_init_step_to_send_list_pods_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, diff: int
 )
@@ -1160,7 +1162,9 @@ pub proof fn lemma_from_init_step_to_send_list_pods_req(
     );
 }
 
-#[verifier(spinoff_prover)]
+//#[verifier(spinoff_prover)]
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_send_list_pods_req_to_receive_list_pods_resp(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     req_msg: Message, diff: int
@@ -1604,6 +1608,8 @@ pub proof fn lemma_from_after_send_list_pods_req_to_receive_list_pods_resp(
     );
 }
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_list_pods_resp_to_done(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message
@@ -1764,6 +1770,8 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_done(
 
 // Create lemmas
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_list_pods_resp_to_send_create_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int
@@ -1908,9 +1916,11 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_create_pod_req(
     );
 }
 
-// TODO: Investigate flaky proof.
-#[verifier(spinoff_prover)]
-#[verifier(rlimit(100))]
+// // TODO: Investigate flaky proof.
+// #[verifier(spinoff_prover)]
+// #[verifier(rlimit(4000))]
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     req_msg: Message, diff: int
@@ -2137,6 +2147,8 @@ pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
     );
 }
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_ok_resp_to_send_create_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int
@@ -2282,6 +2294,8 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_create_pod_req(
     );
 }
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_ok_resp_at_after_create_pod_step_to_done(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message,
@@ -2457,6 +2471,8 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_create_pod_step_to_done(
 
 // Delete lemmas
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_list_pods_resp_to_send_delete_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int
@@ -2612,6 +2628,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_delete_pod_req(
     );
 }
 
+// TODO: broken by changed ESR spec.
 #[verifier(external_body)]
 pub proof fn lemma_from_after_send_delete_pod_req_to_receive_ok_resp(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
@@ -2779,6 +2796,8 @@ pub proof fn lemma_from_after_send_delete_pod_req_to_receive_ok_resp(
     );
 }
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_ok_resp_to_send_delete_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int
@@ -2935,6 +2954,8 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_delete_pod_req(
     );
 }
 
+// TODO: broken by changed ESR spec.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_ok_resp_at_after_delete_pod_step_to_done(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message,
@@ -3108,7 +3129,8 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_delete_pod_step_to_done(
     );
 }
 
-// #[verifier(spinoff_prover)]
+//#[verifier(spinoff_prover)]
+// TODO: broken by changed ESR spec.
 #[verifier(external_body)]
 pub proof fn lemma_current_state_matches_is_stable(
     spec: TempPred<ClusterState>,

--- a/src/v2/controllers/vreplicaset_controller/proof/predicate.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/predicate.rs
@@ -170,7 +170,7 @@ pub open spec fn exists_resp_in_flight_at_after_list_pods_step(
             &&& resp_msg.content.get_list_response().res.is_Ok()
             &&& {
                 let resp_objs = resp_msg.content.get_list_response().res.unwrap();
-                &&& matching_pod_entries(vrs, s.resources()).values() == resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set()
+                &&& matching_pods(vrs, s.resources()) == resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set()
                 //&&& resp_objs.no_duplicates()
                 &&& objects_to_pods(resp_objs).is_Some()
                 &&& objects_to_pods(resp_objs).unwrap().no_duplicates()
@@ -205,7 +205,7 @@ pub open spec fn resp_msg_is_the_in_flight_list_resp_at_after_list_pods_step(
         &&& resp_msg.content.get_list_response().res.is_Ok()
         &&& {
             let resp_objs = resp_msg.content.get_list_response().res.unwrap();
-            &&& matching_pod_entries(vrs, s.resources()).values() == resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set()
+            &&& matching_pods(vrs, s.resources()) == resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set()
             //&&& resp_objs.no_duplicates()
             &&& objects_to_pods(resp_objs).is_Some()
             &&& objects_to_pods(resp_objs).unwrap().no_duplicates()
@@ -314,7 +314,9 @@ pub open spec fn delete_constraint(
     vrs: VReplicaSetView, req: DeleteRequest
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        matching_pod_entries(vrs, s.resources()).contains_key(req.key)
+        let obj = s.resources()[req.key];
+        &&& s.resources().contains_key(req.key)
+        &&& matching_pods(vrs, s.resources()).contains(obj)
     }
 }
 

--- a/src/v2/controllers/vreplicaset_controller/proof/predicate.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/predicate.rs
@@ -73,7 +73,7 @@ pub open spec fn no_pending_req_at_vrs_step_with_vrs(vrs: VReplicaSetView, contr
 }
 
 // Predicates for reasoning about pods
-pub open spec fn matching_pods(vrs: VReplicaSetView, resources: StoredState) -> Set<ObjectRef> {
+pub open spec fn matching_pod_keys(vrs: VReplicaSetView, resources: StoredState) -> Set<ObjectRef> {
     Set::new(|key: ObjectRef| {
         let obj = resources[key];
         &&& resources.contains_key(key)

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -234,6 +234,9 @@ pub open spec fn cr_objects_in_etcd_satisfy_state_validation<T: CustomResourceVi
     }
 }
 
+// TODO: investigate flaky proof. (higher priority, I think).
+#[verifier(rlimit(400))]
+#[verifier(spinoff_prover)]
 pub proof fn lemma_always_cr_objects_in_etcd_satisfy_state_validation<T: CustomResourceView>(
     self, spec: TempPred<ClusterState>,
 )

--- a/src/v2/kubernetes_cluster/proof/req_resp.rs
+++ b/src/v2/kubernetes_cluster/proof/req_resp.rs
@@ -23,7 +23,7 @@ pub open spec fn object_in_ok_get_response_has_smaller_rv_than_etcd() -> StatePr
     }
 }
 
-// TODO: Investigate flaky proof.
+// TODO: investigate flaky proof.
 #[verifier(rlimit(100))]
 pub proof fn lemma_always_object_in_ok_get_response_has_smaller_rv_than_etcd(self, spec: TempPred<ClusterState>)
     requires


### PR DESCRIPTION
Here, I change the ESR definition for `VReplicaSet` as well as some associated definitions. I fix most of the proofs that are broken by these changes, except for ones that would require a different kind of argument (such arguments relied heavily on maps from `ObjectRef` to `DynamicObjectView`, but `matching_pods` is redefined in terms of filtered sets of objects).

I'd like to call attention to a flaky proof `lemma_always_cr_objects_in_etcd_satisfy_state_validation` which increases the total verification time for VRS from ~2m real time on my machine to ~6m.