### PR TITLE
Mitigate the impact of flaky proofs

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/proof.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/proof.rs
@@ -829,6 +829,7 @@ pub proof fn lemma_eventually_always_every_create_matching_pod_request_implies_a
 
 // TODO: investigate flaky proof.
 #[verifier(rlimit(100))]
+#[verifier(spinoff_prover)]
 pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_at_after_delete_pod_step(
     spec: TempPred<ClusterState>, vrs: VReplicaSetView, cluster: Cluster, controller_id: int,
 )
@@ -1086,7 +1087,9 @@ pub proof fn lemma_eventually_always_every_delete_matching_pod_request_implies_a
     );
 }
 
+// TODO: investigate flaky proof.
 #[verifier(rlimit(100))]
+#[verifier(spinoff_prover)]
 pub proof fn lemma_always_each_vrs_in_reconcile_implies_filtered_pods_owned_by_vrs(
     spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
 )

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -234,8 +234,7 @@ pub open spec fn cr_objects_in_etcd_satisfy_state_validation<T: CustomResourceVi
     }
 }
 
-// TODO: investigate flaky proof. (higher priority, I think).
-#[verifier(rlimit(400))]
+// TODO: investigate flaky proof.
 #[verifier(spinoff_prover)]
 pub proof fn lemma_always_cr_objects_in_etcd_satisfy_state_validation<T: CustomResourceView>(
     self, spec: TempPred<ClusterState>,


### PR DESCRIPTION
Here I reduce the total verification time of `./build.sh v2_vreplicaset_controller.rs` from 6 minutes to 3 minutes on my machine. The flakiness of these proofs is still something we need to address, but it's less urgent.