### PR TITLE
Make the HostId for Controller Messages Carry the Current Reconcile Key

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/proof/guarantee.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/guarantee.rs
@@ -51,7 +51,7 @@ spec fn stronger_vrs_guarantee(other_id: int) -> StatePred<ClusterState> {
         forall |msg| {
             &&& #[trigger] s.in_flight().contains(msg)
             &&& msg.content.is_APIRequest()
-            &&& msg.src == HostId::Controller(other_id)
+            &&& msg.src.is_controller_id(other_id)
         } ==> match msg.content.get_APIRequest_0() {
             APIRequest::ListRequest(_) => true,
             APIRequest::CreateRequest(req) => vrs_guarantee_create_req(req)(s),
@@ -116,7 +116,7 @@ pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cl
                     &&& stronger_next(s, s_prime)
                     &&& #[trigger] s_prime.in_flight().contains(msg)
                     &&& msg.content.is_APIRequest()
-                    &&& msg.src == HostId::Controller(controller_id)
+                    &&& msg.src.is_controller_id(controller_id)
                 } implies match msg.content.get_APIRequest_0() {
                     APIRequest::ListRequest(_) => true,
                     APIRequest::CreateRequest(req) => vrs_guarantee_create_req(req)(s_prime),
@@ -133,7 +133,7 @@ pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cl
                     &&& stronger_next(s, s_prime)
                     &&& #[trigger] s_prime.in_flight().contains(msg)
                     &&& msg.content.is_APIRequest()
-                    &&& msg.src == HostId::Controller(controller_id)
+                    &&& msg.src.is_controller_id(controller_id)
                 } implies match msg.content.get_APIRequest_0() {
                     APIRequest::ListRequest(_) => true,
                     APIRequest::CreateRequest(req) => vrs_guarantee_create_req(req)(s_prime),
@@ -242,7 +242,7 @@ pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cl
                     &&& stronger_next(s, s_prime)
                     &&& #[trigger] s_prime.in_flight().contains(msg)
                     &&& msg.content.is_APIRequest()
-                    &&& msg.src == HostId::Controller(controller_id)
+                    &&& msg.src.is_controller_id(controller_id)
                 } implies match msg.content.get_APIRequest_0() {
                     APIRequest::ListRequest(_) => true,
                     APIRequest::CreateRequest(req) => vrs_guarantee_create_req(req)(s_prime),

--- a/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/proof.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/proof.rs
@@ -198,7 +198,7 @@ pub proof fn lemma_eventually_always_no_pending_interfering_update_request(
             match msg.content.get_APIRequest_0() {
                 APIRequest::UpdateRequest(req) =>
                     msg.src.is_Controller()
-                    && msg.src != HostId::Controller(controller_id)
+                    && !msg.src.is_controller_id(controller_id)
                     && vrs_rely_update_req(req)(s),
                 _ => true,
             }
@@ -318,7 +318,7 @@ pub proof fn lemma_eventually_always_no_pending_interfering_update_status_reques
             match msg.content.get_APIRequest_0() {
                 APIRequest::UpdateStatusRequest(req) =>
                     msg.src.is_Controller()
-                    && msg.src != HostId::Controller(controller_id)
+                    && !msg.src.is_controller_id(controller_id)
                     && vrs_rely_update_status_req(req)(s),
                 _ => true,
             }
@@ -2907,7 +2907,7 @@ ensures
         assert forall |msg: Message|
             inv(s)
             && s_prime.in_flight().contains(msg)
-            && #[trigger] msg.src == HostId::Controller(controller_id)
+            && #[trigger] msg.src.is_controller_id(controller_id)
             implies msg.dst != HostId::External(controller_id) by {
             if new_msgs.contains(msg) {
                 // Empty if statement required to trigger quantifiers.

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/proof.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/proof.rs
@@ -327,6 +327,8 @@ proof fn lemma_from_reconcile_idle_to_scheduled(spec: TempPred<ClusterState>, vr
     temp_pred_equality(lift_state(pre).or(lift_state(post)), lift_state(|s: ClusterState| {!s.ongoing_reconciles(controller_id).contains_key(vrs.object_ref())}));
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 proof fn lemma_from_scheduled_to_init_step(spec: TempPred<ClusterState>, vrs: VReplicaSetView, cluster: Cluster, controller_id: int)
     requires
         spec.entails(always(lift_action(cluster.next()))),

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
@@ -1030,6 +1030,8 @@ pub proof fn lemma_from_after_receive_delete_pod_resp_to_receive_delete_pod_resp
 
 // List lemmas
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_init_step_to_send_list_pods_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, diff: int
 )
@@ -1611,6 +1613,8 @@ pub proof fn lemma_from_after_send_list_pods_req_to_receive_list_pods_resp(
     );
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_list_pods_resp_to_done(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message
@@ -1771,6 +1775,8 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_done(
 
 // Create lemmas
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_list_pods_resp_to_send_create_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int
@@ -2146,6 +2152,8 @@ pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
     );
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_ok_resp_to_send_create_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int
@@ -2291,6 +2299,8 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_create_pod_req(
     );
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_ok_resp_at_after_create_pod_step_to_done(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message,
@@ -2436,6 +2446,8 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_create_pod_step_to_done(
 
 // Delete lemmas
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_list_pods_resp_to_send_delete_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int
@@ -2759,6 +2771,8 @@ pub proof fn lemma_from_after_send_delete_pod_req_to_receive_ok_resp(
     );
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_ok_resp_to_send_delete_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int
@@ -2915,6 +2929,8 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_delete_pod_req(
     );
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_ok_resp_at_after_delete_pod_step_to_done(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message,

--- a/src/v2/controllers/vreplicaset_controller/proof/predicate.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/predicate.rs
@@ -115,7 +115,7 @@ pub open spec fn pending_req_in_flight_at_after_list_pods_step(
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg)
         &&& s.in_flight().contains(msg)
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_ListRequest()
@@ -136,7 +136,7 @@ pub open spec fn req_msg_is_the_in_flight_list_req_at_after_list_pods_step(
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg)
         &&& s.in_flight().contains(msg)
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_ListRequest()
@@ -156,7 +156,7 @@ pub open spec fn exists_resp_in_flight_at_after_list_pods_step(
         let request = msg.content.get_APIRequest_0();
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg)
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_ListRequest()
@@ -192,7 +192,7 @@ pub open spec fn resp_msg_is_the_in_flight_list_resp_at_after_list_pods_step(
         let request = msg.content.get_APIRequest_0();
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg)
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_ListRequest()
@@ -228,7 +228,7 @@ pub open spec fn pending_req_in_flight_at_after_create_pod_step(
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg)
         &&& s.in_flight().contains(msg)
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_CreateRequest()
@@ -248,7 +248,7 @@ pub open spec fn req_msg_is_the_in_flight_create_request_at_after_create_pod_ste
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), req_msg)
         &&& s.in_flight().contains(req_msg)
-        &&& req_msg.src == HostId::Controller(controller_id)
+        &&& req_msg.src.is_controller_id(controller_id)
         &&& req_msg.dst == HostId::APIServer
         &&& req_msg.content.is_APIRequest()
         &&& request.is_CreateRequest()
@@ -268,7 +268,7 @@ pub open spec fn exists_ok_resp_in_flight_at_after_create_pod_step(
         let request = msg.content.get_APIRequest_0();
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::has_pending_k8s_api_req_msg(controller_id, s, vrs.object_ref())
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_CreateRequest()
@@ -293,7 +293,7 @@ pub open spec fn resp_msg_is_the_in_flight_ok_resp_at_after_create_pod_step(
         let request = msg.content.get_APIRequest_0();
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::has_pending_k8s_api_req_msg(controller_id, s, vrs.object_ref())
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_CreateRequest()
@@ -332,7 +332,7 @@ pub open spec fn pending_req_in_flight_at_after_delete_pod_step(
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg)
         &&& s.in_flight().contains(msg)
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_DeleteRequest()
@@ -361,7 +361,7 @@ pub open spec fn req_msg_is_the_in_flight_delete_request_at_after_delete_pod_ste
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), req_msg)
         &&& s.in_flight().contains(req_msg)
-        &&& req_msg.src == HostId::Controller(controller_id)
+        &&& req_msg.src.is_controller_id(controller_id)
         &&& req_msg.dst == HostId::APIServer
         &&& req_msg.content.is_APIRequest()
         &&& request.is_DeleteRequest()
@@ -388,7 +388,7 @@ pub open spec fn exists_ok_resp_in_flight_at_after_delete_pod_step(
         let request = msg.content.get_APIRequest_0();
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::has_pending_k8s_api_req_msg(controller_id, s, vrs.object_ref())
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_DeleteRequest()
@@ -409,7 +409,7 @@ pub open spec fn resp_msg_is_the_in_flight_ok_resp_at_after_delete_pod_step(
         let request = msg.content.get_APIRequest_0();
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::has_pending_k8s_api_req_msg(controller_id, s, vrs.object_ref())
-        &&& msg.src == HostId::Controller(controller_id)
+        &&& msg.src.is_controller_id(controller_id)
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
         &&& request.is_DeleteRequest()

--- a/src/v2/controllers/vreplicaset_controller/trusted/rely_guarantee.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/rely_guarantee.rs
@@ -95,7 +95,7 @@ pub open spec fn vrs_rely(other_id: int) -> StatePred<ClusterState> {
         forall |msg| {
             &&& #[trigger] s.in_flight().contains(msg)
             &&& msg.content.is_APIRequest()
-            &&& msg.src == HostId::Controller(other_id)
+            &&& msg.src.is_controller_id(other_id)
         } ==> match msg.content.get_APIRequest_0() {
             APIRequest::CreateRequest(req) => vrs_rely_create_req(req)(s),
             APIRequest::UpdateRequest(req) => vrs_rely_update_req(req)(s),
@@ -150,7 +150,7 @@ pub open spec fn vrs_guarantee(controller_id: int) -> StatePred<ClusterState> {
         forall |msg| {
             &&& #[trigger] s.in_flight().contains(msg)
             &&& msg.content.is_APIRequest()
-            &&& msg.src == HostId::Controller(controller_id)
+            &&& msg.src.is_controller_id(controller_id)
         } ==> match msg.content.get_APIRequest_0() {
             APIRequest::ListRequest(_) => true,
             APIRequest::CreateRequest(req) => vrs_guarantee_create_req(req)(s),

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -40,7 +40,7 @@ pub open spec fn at_reconcile_state(controller_id: int, key: ObjectRef, current_
 }
 
 pub open spec fn request_sent_by_controller(controller_id: int, msg: Message) -> bool {
-    &&& msg.src == HostId::Controller(controller_id)
+    &&& msg.src.is_controller_id(controller_id)
     &&& {
         ||| {
             &&& msg.dst == HostId::APIServer
@@ -147,6 +147,8 @@ pub open spec fn reconcile_idle(controller_id: int, key: ObjectRef) -> StatePred
     |s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(key)
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_reconcile_done_leads_to_reconcile_idle(self, spec: TempPred<ClusterState>, controller_id: int, cr_key: ObjectRef)
     requires
         self.controller_models.contains_key(controller_id),
@@ -170,6 +172,8 @@ pub proof fn lemma_reconcile_done_leads_to_reconcile_idle(self, spec: TempPred<C
     self.lemma_pre_leads_to_post_by_controller(spec, controller_id, input, stronger_next, ControllerStep::EndReconcile, pre, post);
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_reconcile_error_leads_to_reconcile_idle(self, spec: TempPred<ClusterState>, controller_id: int, cr_key: ObjectRef)
     requires
         self.controller_models.contains_key(controller_id),
@@ -193,6 +197,8 @@ pub proof fn lemma_reconcile_error_leads_to_reconcile_idle(self, spec: TempPred<
     self.lemma_pre_leads_to_post_by_controller(spec, controller_id, input, stronger_next, ControllerStep::EndReconcile, pre, post);
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_reconcile_idle_and_scheduled_leads_to_reconcile_init(self, spec: TempPred<ClusterState>, controller_id: int, cr_key: ObjectRef)
     requires
         self.controller_models.contains_key(controller_id),
@@ -317,6 +323,8 @@ pub proof fn lemma_from_some_state_to_arbitrary_next_state(self, spec: TempPred<
     );
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_init_state_to_next_state_to_reconcile_idle(self, spec: TempPred<ClusterState>, controller_id: int, cr: DynamicObjectView, init_state: spec_fn(ReconcileLocalState) -> bool, next_state: spec_fn(ReconcileLocalState) -> bool)
     requires
         self.controller_models.contains_key(controller_id),
@@ -388,6 +396,8 @@ pub proof fn lemma_from_pending_req_in_flight_at_some_state_to_next_state(self, 
     );
 }
 
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_from_in_flight_resp_matches_pending_req_at_some_state_to_next_state(self, spec: TempPred<ClusterState>, controller_id: int, cr: DynamicObjectView, current_state: spec_fn(ReconcileLocalState) -> bool, next_state: spec_fn(ReconcileLocalState) -> bool)
     requires
         self.controller_models.contains_key(controller_id),
@@ -461,7 +471,7 @@ pub open spec fn there_is_no_request_msg_to_external_from_controller(controller_
     |s: ClusterState| {
         forall |msg: Message|
             s.in_flight().contains(msg)
-            && #[trigger] msg.src == HostId::Controller(controller_id)
+            && #[trigger] msg.src.is_controller_id(controller_id)
             ==> msg.dst != HostId::External(controller_id)
     }
 }
@@ -643,6 +653,8 @@ pub open spec fn the_object_in_reconcile_has_spec_and_uid_as<T: CustomResourceVi
 
 // This lemma says that under the spec where []desired_state_is(cr), it will eventually reach a state where any object
 // in reconcile for cr.object_ref() has the same spec as cr.spec.
+// TODO: broken by adding cr_key to HostId.
+#[verifier(external_body)]
 pub proof fn lemma_true_leads_to_always_the_object_in_reconcile_has_spec_and_uid_as<T: CustomResourceView>(self, spec: TempPred<ClusterState>, controller_id: int, cr: T)
     requires
         self.controller_models.contains_key(controller_id),

--- a/src/v2/kubernetes_cluster/spec/cluster.rs
+++ b/src/v2/kubernetes_cluster/spec/cluster.rs
@@ -278,7 +278,8 @@ impl Cluster {
         Action {
             precondition: |input: (Option<Message>, Option<ObjectRef>), s: ClusterState| {
                 &&& self.controller_models.contains_key(controller_id)
-                &&& received_msg_destined_for(input.0, HostId::Controller(controller_id))
+                &&& input.1.is_Some()
+                &&& received_msg_destined_for(input.0, HostId::Controller(controller_id, input.1.get_Some_0()))
                 &&& result(input, s).0.is_Enabled()
                 &&& result(input, s).1.is_Enabled()
             },
@@ -679,7 +680,8 @@ impl Cluster {
             let network_result = network().next_result(msg_ops, s.network);
 
             &&& self.controller_models.contains_key(input.0)
-            &&& received_msg_destined_for(input.1, HostId::Controller(controller_id))
+            &&& input.1.is_Some()
+            &&& received_msg_destined_for(input.1, HostId::Controller(controller_id, input.2.get_Some_0()))
             &&& host_result.is_Enabled()
             &&& network_result.is_Enabled()
         }

--- a/src/v2/kubernetes_cluster/spec/controller/state_machine.rs
+++ b/src/v2/kubernetes_cluster/spec/controller/state_machine.rs
@@ -76,10 +76,10 @@ pub open spec fn continue_reconcile(model: ReconcileModel, controller_id: int) -
             let (pending_req_msg, send, rpc_id_allocator_prime) = if req_o.is_Some() {
                 let pending_req_msg = match req_o.get_Some_0() {
                     RequestContent::KubernetesRequest(req) => {
-                        Some(controller_req_msg(controller_id, input.rpc_id_allocator.allocate().1, req))
+                        Some(controller_req_msg(controller_id, cr_key, input.rpc_id_allocator.allocate().1, req))
                     },
                     RequestContent::ExternalRequest(req) => {
-                        Some(controller_external_req_msg(controller_id, input.rpc_id_allocator.allocate().1, req))
+                        Some(controller_external_req_msg(controller_id, cr_key, input.rpc_id_allocator.allocate().1, req))
                     }
                 };
                 (pending_req_msg, Multiset::singleton(pending_req_msg.get_Some_0()), input.rpc_id_allocator.allocate().0)

--- a/src/v2/kubernetes_cluster/spec/message.rs
+++ b/src/v2/kubernetes_cluster/spec/message.rs
@@ -27,7 +27,7 @@ pub struct Message {
 pub enum HostId {
     APIServer,
     BuiltinController,
-    Controller(int),
+    Controller(int, ObjectRef),
     External(int),
     PodMonkey,
 }
@@ -80,12 +80,12 @@ pub open spec fn is_ok_resp(resp: APIResponse) -> bool {
     }
 }
 
-pub open spec fn controller_req_msg(controller_id: int, req_id: RPCId, req: APIRequest) -> Message {
-    form_msg(HostId::Controller(controller_id), HostId::APIServer, req_id, MessageContent::APIRequest(req))
+pub open spec fn controller_req_msg(controller_id: int, cr_key: ObjectRef, req_id: RPCId, req: APIRequest) -> Message {
+    form_msg(HostId::Controller(controller_id, cr_key), HostId::APIServer, req_id, MessageContent::APIRequest(req))
 }
 
-pub open spec fn controller_external_req_msg(controller_id: int, req_id: RPCId, req: ExternalRequest) -> Message {
-    form_msg(HostId::Controller(controller_id), HostId::External(controller_id), req_id, MessageContent::ExternalRequest(req))
+pub open spec fn controller_external_req_msg(controller_id: int, cr_key: ObjectRef, req_id: RPCId, req: ExternalRequest) -> Message {
+    form_msg(HostId::Controller(controller_id, cr_key), HostId::External(controller_id), req_id, MessageContent::ExternalRequest(req))
 }
 
 pub open spec fn built_in_controller_req_msg(rpc_id: RPCId, msg_content: MessageContent) -> Message {
@@ -225,6 +225,15 @@ pub open spec fn received_msg_destined_for(recv: Option<Message>, host_id: HostI
         recv.get_Some_0().dst == host_id
     } else {
         true
+    }
+}
+
+impl HostId {
+    pub open spec fn is_controller_id(self, controller_id: int) -> bool {
+        match self {
+            HostId::Controller(id, _) => id == controller_id,
+            _ => false,
+        }
     }
 }
 


### PR DESCRIPTION
I modify the `HostId` enum so that the `Controller` variant also carries an `ObjectRef`, indicating which reconcile key is associated with that message. I additionally modify the cluster state machine to handle this additional information, update definitions, and mark broken proofs for repair.

This new addition allows us to specify an invariant not only preventing reconciles from other installed controllers in the cluster from interfering with our reconcile, but also preventing other reconciles _from the controller we are reasoning about_ from interfering with our reconcile.