### PR TITLE
Update Verus Version to 3b6b805ac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   merge_group:
   workflow_dispatch:
 env:
-  verus_commit: 6b278074651d520825ea62fe2079ed1e3959cb69
+  verus_commit: 3b6b805ac
   kind_version: 0.23.0
   go_version: "^1.20"
   home_dir: /home/runner

--- a/.github/workflows/verus-build.yml
+++ b/.github/workflows/verus-build.yml
@@ -17,9 +17,9 @@ jobs:
       - name: Build Verus image
         run: |
           cd docker/verus
-          docker build -t ghcr.io/${{ env.IMAGE_NAME }}/verus:latest --build-arg VERUS_VER=6b278074651d520825ea62fe2079ed1e3959cb69 .
-          docker tag ghcr.io/${{ env.IMAGE_NAME }}/verus:latest ghcr.io/${{ env.IMAGE_NAME }}/verus:6b278074651d520825ea62fe2079ed1e3959cb69
+          docker build -t ghcr.io/${{ env.IMAGE_NAME }}/verus:latest --build-arg VERUS_VER=3b6b805ac .
+          docker tag ghcr.io/${{ env.IMAGE_NAME }}/verus:latest ghcr.io/${{ env.IMAGE_NAME }}/verus:3b6b805ac
       - name: Push Verus image
         run: |
           docker push ghcr.io/${{ env.IMAGE_NAME }}/verus:latest
-          docker push ghcr.io/${{ env.IMAGE_NAME }}/verus:6b278074651d520825ea62fe2079ed1e3959cb69
+          docker push ghcr.io/${{ env.IMAGE_NAME }}/verus:3b6b805ac

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Anvil is a framework for building and formally verifying Kubernetes controllers.
 
 So far, we have built and verified three Kubernetes controllers (for managing ZooKeeper, RabbitMQ and FluentBit) using Anvil. We used the [Pravega ZooKeeper operator](https://github.com/pravega/zookeeper-operator), [official RabbitMQ operator](https://github.com/rabbitmq/cluster-operator) and [official Fluent operator](https://github.com/fluent/fluent-operator) as references when building our controllers. We are now using Anvil to build (and verify) more controllers, including Kubernetes built-in controllers.
 
-For now, the best way to use Anvil is to download the source code and import its components into your controller projects, like what we did for our controller [examples](src/v2/controllers/). To use Anvil, you will need to install [Verus](https://github.com/verus-lang/verus) (See the [installation instructions](https://github.com/verus-lang/verus/blob/main/INSTALL.md)). Currently Anvil uses Verus version `6b278074651d520825ea62fe2079ed1e3959cb69`.
+For now, the best way to use Anvil is to download the source code and import its components into your controller projects, like what we did for our controller [examples](src/v2/controllers/). To use Anvil, you will need to install [Verus](https://github.com/verus-lang/verus) (See the [installation instructions](https://github.com/verus-lang/verus/blob/main/INSTALL.md)). Currently Anvil uses Verus version `3b6b805ac`.
 
 If you want to reproduce the results in the OSDI'24 paper "Anvil: Verifying Liveness of Cluster Management Controllers", please refer to the [osdi24](https://github.com/anvil-verifier/anvil/tree/osdi24) branch.
 

--- a/build.md
+++ b/build.md
@@ -26,7 +26,7 @@ Controller source should be put in `src/`, with e2e test in `e2e/src` and test w
 ### Dependencies
 
 ```
-verus_commit: 6b278074651d520825ea62fe2079ed1e3959cb69
+verus_commit: 3b6b805ac
 kind_version: 0.23.0
 go_version: "^1.20"
 ```

--- a/build.sh
+++ b/build.sh
@@ -17,4 +17,5 @@ cd ..
 "$rv" -L dependency=deps_hack/target/debug/deps \
   --extern=deps_hack="deps_hack/target/debug/libdeps_hack.rlib" \
   --compile \
+  --no-lifetime \
   "$@"

--- a/discussion/exec-as-spec/specexec.rs
+++ b/discussion/exec-as-spec/specexec.rs
@@ -33,7 +33,7 @@ impl Concrete {
         Self { a: self.a + 1 }
     }
 
-    spec fn spec_add1_b(self) -> Self; // {
+    uninterp spec fn spec_add1_b(self) -> Self; // {
     //     self@.add1_b()
     // }
     // Cannot write this body, because we need to return `Self` not `Self::V`

--- a/src/executable_model/common.rs
+++ b/src/executable_model/common.rs
@@ -589,13 +589,13 @@ impl ResourceView for SimpleCRView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: SimpleCRSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: SimpleCRSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<SimpleCRSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<SimpleCRSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<SimpleCRStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<SimpleCRStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<SimpleCRStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<SimpleCRStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}
@@ -626,7 +626,7 @@ pub struct SimpleCR {}
 impl View for SimpleCR {
     type V = SimpleCRView;
 
-    spec fn view(&self) -> SimpleCRView;
+    uninterp spec fn view(&self) -> SimpleCRView;
 }
 
 impl CustomResource for SimpleCR {

--- a/src/executable_model/object_map.rs
+++ b/src/executable_model/object_map.rs
@@ -17,7 +17,7 @@ pub struct ObjectMap {
 }
 
 impl ObjectMap {
-    pub spec fn view(&self) -> StoredState;
+    pub uninterp spec fn view(&self) -> StoredState;
 
     #[verifier(external_body)]
     pub fn new() -> (m: Self)

--- a/src/executable_model/object_ref_set.rs
+++ b/src/executable_model/object_ref_set.rs
@@ -14,7 +14,7 @@ pub struct ObjectRefSet {
 }
 
 impl ObjectRefSet {
-    pub spec fn view(&self) -> Set::<ObjectRef>;
+    pub uninterp spec fn view(&self) -> Set::<ObjectRef>;
 
     #[verifier(external_body)]
     pub fn new() -> (m: Self)

--- a/src/executable_model/string_set.rs
+++ b/src/executable_model/string_set.rs
@@ -13,7 +13,7 @@ pub struct StringSet {
 }
 
 impl StringSet {
-    pub spec fn view(&self) -> Set::<StringView>;
+    pub uninterp spec fn view(&self) -> Set::<StringView>;
 
     #[verifier(external_body)]
     pub fn new() -> (m: Self)

--- a/src/kubernetes_api_objects/exec/affinity.rs
+++ b/src/kubernetes_api_objects/exec/affinity.rs
@@ -20,7 +20,7 @@ pub struct Affinity {
 }
 
 impl Affinity {
-    pub spec fn view(&self) -> AffinityView;
+    pub uninterp spec fn view(&self) -> AffinityView;
 }
 
 }

--- a/src/kubernetes_api_objects/exec/api_resource.rs
+++ b/src/kubernetes_api_objects/exec/api_resource.rs
@@ -18,7 +18,7 @@ pub struct ApiResource {
 }
 
 impl ApiResource {
-    pub spec fn view(&self) -> ApiResourceView;
+    pub uninterp spec fn view(&self) -> ApiResourceView;
 }
 
 }

--- a/src/kubernetes_api_objects/exec/container.rs
+++ b/src/kubernetes_api_objects/exec/container.rs
@@ -13,7 +13,7 @@ pub struct Container {
 }
 
 impl Container {
-    pub spec fn view(&self) -> ContainerView;
+    pub uninterp spec fn view(&self) -> ContainerView;
 
     #[verifier(external_body)]
     pub fn default() -> (container: Container)
@@ -131,7 +131,7 @@ pub struct ContainerPort {
 }
 
 impl ContainerPort {
-    pub spec fn view(&self) -> ContainerPortView;
+    pub uninterp spec fn view(&self) -> ContainerPortView;
 
     #[verifier(external_body)]
     pub fn default() -> (container_port: ContainerPort)
@@ -192,7 +192,7 @@ pub struct VolumeMount {
 }
 
 impl VolumeMount {
-    pub spec fn view(&self) -> VolumeMountView;
+    pub uninterp spec fn view(&self) -> VolumeMountView;
 
     #[verifier(external_body)]
     pub fn default() -> (volume_mount: VolumeMount)
@@ -253,7 +253,7 @@ pub struct Probe {
 }
 
 impl Probe {
-    pub spec fn view(&self) -> ProbeView;
+    pub uninterp spec fn view(&self) -> ProbeView;
 
     #[verifier(external_body)]
     pub fn default() -> (probe: Probe)
@@ -325,7 +325,7 @@ pub struct ExecAction {
 }
 
 impl ExecAction {
-    pub spec fn view(&self) -> ExecActionView;
+    pub uninterp spec fn view(&self) -> ExecActionView;
 
     #[verifier(external_body)]
     pub fn default() -> (exec_action: ExecAction)
@@ -355,7 +355,7 @@ pub struct TCPSocketAction {
 }
 
 impl TCPSocketAction {
-    pub spec fn view(&self) -> TCPSocketActionView;
+    pub uninterp spec fn view(&self) -> TCPSocketActionView;
 
     #[verifier(external_body)]
     pub fn default() -> (tcp_socket_action: TCPSocketAction)
@@ -392,7 +392,7 @@ pub struct Lifecycle {
 }
 
 impl Lifecycle {
-    pub spec fn view(&self) -> LifecycleView;
+    pub uninterp spec fn view(&self) -> LifecycleView;
 
     #[verifier(external_body)]
     pub fn default() -> (lifecycle: Lifecycle)
@@ -422,7 +422,7 @@ pub struct LifecycleHandler {
 }
 
 impl LifecycleHandler {
-    pub spec fn view(&self) -> LifecycleHandlerView;
+    pub uninterp spec fn view(&self) -> LifecycleHandlerView;
 
     #[verifier(external_body)]
     pub fn default() -> (lifecycle_handler: LifecycleHandler)
@@ -452,7 +452,7 @@ pub struct EnvVar {
 }
 
 impl EnvVar {
-    pub spec fn view(&self) -> EnvVarView;
+    pub uninterp spec fn view(&self) -> EnvVarView;
 
     #[verifier(external_body)]
     pub fn default() -> (env_var: EnvVar)
@@ -519,7 +519,7 @@ pub struct EnvVarSource {
 }
 
 impl EnvVarSource {
-    pub spec fn view(&self) -> EnvVarSourceView;
+    pub uninterp spec fn view(&self) -> EnvVarSourceView;
 
     #[verifier(external_body)]
     pub fn default() -> (env_var_source: EnvVarSource)
@@ -553,7 +553,7 @@ pub struct SecurityContext {
 }
 
 impl SecurityContext {
-    pub spec fn view(&self) -> SecurityContextView;
+    pub uninterp spec fn view(&self) -> SecurityContextView;
 }
 
 }

--- a/src/kubernetes_api_objects/exec/daemon_set.rs
+++ b/src/kubernetes_api_objects/exec/daemon_set.rs
@@ -52,7 +52,7 @@ pub struct DaemonSetSpec {
 }
 
 impl DaemonSetSpec {
-    pub spec fn view(&self) -> DaemonSetSpecView;
+    pub uninterp spec fn view(&self) -> DaemonSetSpecView;
 
     #[verifier(external_body)]
     pub fn default() -> (daemon_set_spec: DaemonSetSpec)
@@ -103,7 +103,7 @@ pub struct DaemonSetStatus {
 }
 
 impl DaemonSetStatus {
-    pub spec fn view(&self) -> DaemonSetStatusView;
+    pub uninterp spec fn view(&self) -> DaemonSetStatusView;
 
     #[verifier(external_body)]
     pub fn number_ready(&self) -> (number_ready: i32)

--- a/src/kubernetes_api_objects/exec/dynamic.rs
+++ b/src/kubernetes_api_objects/exec/dynamic.rs
@@ -18,7 +18,7 @@ pub struct DynamicObject {
 impl View for DynamicObject {
     type V = DynamicObjectView;
 
-    spec fn view(&self) -> DynamicObjectView;
+    uninterp spec fn view(&self) -> DynamicObjectView;
 }
 
 impl DynamicObject {

--- a/src/kubernetes_api_objects/exec/label_selector.rs
+++ b/src/kubernetes_api_objects/exec/label_selector.rs
@@ -23,7 +23,7 @@ pub struct LabelSelector {
 
 impl LabelSelector {
 
-    pub spec fn view(&self) -> LabelSelectorView;
+    pub uninterp spec fn view(&self) -> LabelSelectorView;
 
     #[verifier(external_body)]
     pub fn eq(&self, other: &Self) -> (b: bool)

--- a/src/kubernetes_api_objects/exec/object_meta.rs
+++ b/src/kubernetes_api_objects/exec/object_meta.rs
@@ -22,7 +22,7 @@ pub struct ObjectMeta {
 }
 
 impl ObjectMeta {
-    pub spec fn view(&self) -> ObjectMetaView;
+    pub uninterp spec fn view(&self) -> ObjectMetaView;
 
     #[verifier(external_body)]
     pub fn default() -> (object_meta: ObjectMeta)

--- a/src/kubernetes_api_objects/exec/owner_reference.rs
+++ b/src/kubernetes_api_objects/exec/owner_reference.rs
@@ -21,7 +21,7 @@ pub struct OwnerReference {
 }
 
 impl OwnerReference {
-    pub spec fn view(&self) -> OwnerReferenceView;
+    pub uninterp spec fn view(&self) -> OwnerReferenceView;
 
     #[verifier(external_body)]
     pub fn clone(&self) -> (s: Self)

--- a/src/kubernetes_api_objects/exec/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/exec/persistent_volume_claim.rs
@@ -58,7 +58,7 @@ pub struct PersistentVolumeClaimSpec {
 }
 
 impl PersistentVolumeClaimSpec {
-    pub spec fn view(&self) -> PersistentVolumeClaimSpecView;
+    pub uninterp spec fn view(&self) -> PersistentVolumeClaimSpecView;
 
     #[verifier(external_body)]
     pub fn default() -> (pvc_spec: PersistentVolumeClaimSpec)

--- a/src/kubernetes_api_objects/exec/pod.rs
+++ b/src/kubernetes_api_objects/exec/pod.rs
@@ -165,7 +165,7 @@ pub struct PodSecurityContext {
 impl View for PodSecurityContext {
     type V = PodSecurityContextView;
 
-    spec fn view(&self) -> PodSecurityContextView;
+    uninterp spec fn view(&self) -> PodSecurityContextView;
 }
 
 #[verifier(external_body)]
@@ -176,7 +176,7 @@ pub struct LocalObjectReference {
 impl View for LocalObjectReference {
     type V = LocalObjectReferenceView;
 
-    spec fn view(&self) -> LocalObjectReferenceView;
+    uninterp spec fn view(&self) -> LocalObjectReferenceView;
 }
 
 }

--- a/src/kubernetes_api_objects/exec/pod_template_spec.rs
+++ b/src/kubernetes_api_objects/exec/pod_template_spec.rs
@@ -12,7 +12,7 @@ pub struct PodTemplateSpec {
 }
 
 impl PodTemplateSpec {
-    pub spec fn view(&self) -> PodTemplateSpecView;
+    pub uninterp spec fn view(&self) -> PodTemplateSpecView;
 
     #[verifier(external_body)]
     pub fn eq(&self, other: &Self) -> (b: bool)

--- a/src/kubernetes_api_objects/exec/preconditions.rs
+++ b/src/kubernetes_api_objects/exec/preconditions.rs
@@ -14,7 +14,7 @@ pub struct Preconditions {
 impl View for Preconditions {
     type V = PreconditionsView;
 
-    spec fn view(&self) -> PreconditionsView;
+    uninterp spec fn view(&self) -> PreconditionsView;
 }
 
 implement_deep_view_trait!(Preconditions, PreconditionsView);

--- a/src/kubernetes_api_objects/exec/resource.rs
+++ b/src/kubernetes_api_objects/exec/resource.rs
@@ -111,7 +111,7 @@ macro_rules! implement_view_trait {
         impl View for $t {
             type V = $vt;
 
-            spec fn view(&self) -> $vt;
+            uninterp spec fn view(&self) -> $vt;
         }
 
         }

--- a/src/kubernetes_api_objects/exec/resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/resource_requirements.rs
@@ -13,7 +13,7 @@ pub struct ResourceRequirements {
 }
 
 impl ResourceRequirements {
-    pub spec fn view(&self) -> ResourceRequirementsView;
+    pub uninterp spec fn view(&self) -> ResourceRequirementsView;
 
     #[verifier(external_body)]
     pub fn default() -> (resource_requirements: ResourceRequirements)

--- a/src/kubernetes_api_objects/exec/role.rs
+++ b/src/kubernetes_api_objects/exec/role.rs
@@ -46,7 +46,7 @@ pub struct PolicyRule {
 }
 
 impl PolicyRule {
-    pub spec fn view(&self) -> PolicyRuleView;
+    pub uninterp spec fn view(&self) -> PolicyRuleView;
 
     #[verifier(external_body)]
     pub fn default() -> (policy_rule: PolicyRule)

--- a/src/kubernetes_api_objects/exec/role_binding.rs
+++ b/src/kubernetes_api_objects/exec/role_binding.rs
@@ -52,7 +52,7 @@ pub struct RoleRef {
 }
 
 impl RoleRef {
-    pub spec fn view(&self) -> RoleRefView;
+    pub uninterp spec fn view(&self) -> RoleRefView;
 
     #[verifier(external_body)]
     pub fn default() -> (role_ref: RoleRef)
@@ -117,7 +117,7 @@ pub struct Subject {
 }
 
 impl Subject {
-    pub spec fn view(&self) -> SubjectView;
+    pub uninterp spec fn view(&self) -> SubjectView;
 
     #[verifier(external_body)]
     pub fn default() -> (subject: Subject)

--- a/src/kubernetes_api_objects/exec/service.rs
+++ b/src/kubernetes_api_objects/exec/service.rs
@@ -53,7 +53,7 @@ pub struct ServiceSpec {
 }
 
 impl ServiceSpec {
-    pub spec fn view(&self) -> ServiceSpecView;
+    pub uninterp spec fn view(&self) -> ServiceSpecView;
 
     #[verifier(external_body)]
     pub fn default() -> (service_spec: ServiceSpec)
@@ -146,7 +146,7 @@ pub struct ServicePort {
 }
 
 impl ServicePort {
-    pub spec fn view(&self) -> ServicePortView;
+    pub uninterp spec fn view(&self) -> ServicePortView;
 
     #[verifier(external_body)]
     pub fn default() -> (service_port: ServicePort)

--- a/src/kubernetes_api_objects/exec/stateful_set.rs
+++ b/src/kubernetes_api_objects/exec/stateful_set.rs
@@ -69,7 +69,7 @@ pub struct StatefulSetSpec {
 }
 
 impl StatefulSetSpec {
-    pub spec fn view(&self) -> StatefulSetSpecView;
+    pub uninterp spec fn view(&self) -> StatefulSetSpecView;
 
     #[verifier(external_body)]
     pub fn default() -> (stateful_set_spec: StatefulSetSpec)
@@ -213,7 +213,7 @@ pub struct StatefulSetPersistentVolumeClaimRetentionPolicy {
 }
 
 impl StatefulSetPersistentVolumeClaimRetentionPolicy {
-    pub spec fn view(&self) -> StatefulSetPersistentVolumeClaimRetentionPolicyView;
+    pub uninterp spec fn view(&self) -> StatefulSetPersistentVolumeClaimRetentionPolicyView;
 
     #[verifier(external_body)]
     pub fn default() -> (pvc_retention_policy: StatefulSetPersistentVolumeClaimRetentionPolicy)
@@ -250,7 +250,7 @@ pub struct StatefulSetStatus {
 }
 
 impl StatefulSetStatus {
-    pub spec fn view(&self) -> StatefulSetStatusView;
+    pub uninterp spec fn view(&self) -> StatefulSetStatusView;
 
     #[verifier(external_body)]
     pub fn ready_replicas(&self) -> (ready_replicas: Option<i32>)

--- a/src/kubernetes_api_objects/exec/toleration.rs
+++ b/src/kubernetes_api_objects/exec/toleration.rs
@@ -20,7 +20,7 @@ pub struct Toleration {
 }
 
 impl Toleration {
-    pub spec fn view(&self) -> TolerationView;
+    pub uninterp spec fn view(&self) -> TolerationView;
 }
 
 }

--- a/src/kubernetes_api_objects/exec/volume.rs
+++ b/src/kubernetes_api_objects/exec/volume.rs
@@ -12,7 +12,7 @@ pub struct Volume {
 }
 
 impl Volume {
-    pub spec fn view(&self) -> VolumeView;
+    pub uninterp spec fn view(&self) -> VolumeView;
 
     #[verifier(external_body)]
     pub fn default() -> (volume: Volume)
@@ -88,7 +88,7 @@ pub struct EmptyDirVolumeSource {
 }
 
 impl EmptyDirVolumeSource {
-    pub spec fn view(&self) -> EmptyDirVolumeSourceView;
+    pub uninterp spec fn view(&self) -> EmptyDirVolumeSourceView;
 
     #[verifier(external_body)]
     pub fn default() -> (empty_dir_volum_source: EmptyDirVolumeSource)
@@ -113,7 +113,7 @@ pub struct HostPathVolumeSource {
 }
 
 impl HostPathVolumeSource {
-    pub spec fn view(&self) -> HostPathVolumeSourceView;
+    pub uninterp spec fn view(&self) -> HostPathVolumeSourceView;
 
     #[verifier(external_body)]
     pub fn default() -> (host_path_volume_source: HostPathVolumeSource)
@@ -143,7 +143,7 @@ pub struct ConfigMapVolumeSource {
 }
 
 impl ConfigMapVolumeSource {
-    pub spec fn view(&self) -> ConfigMapVolumeSourceView;
+    pub uninterp spec fn view(&self) -> ConfigMapVolumeSourceView;
 
     #[verifier(external_body)]
     pub fn default() -> (config_map_volume_source: ConfigMapVolumeSource)
@@ -173,7 +173,7 @@ pub struct SecretVolumeSource {
 }
 
 impl SecretVolumeSource {
-    pub spec fn view(&self) -> SecretVolumeSourceView;
+    pub uninterp spec fn view(&self) -> SecretVolumeSourceView;
 
     #[verifier(external_body)]
     pub fn default() -> (secret_volume_source: SecretVolumeSource)
@@ -205,7 +205,7 @@ pub struct ProjectedVolumeSource {
 }
 
 impl ProjectedVolumeSource {
-    pub spec fn view(&self) -> ProjectedVolumeSourceView;
+    pub uninterp spec fn view(&self) -> ProjectedVolumeSourceView;
 
     #[verifier(external_body)]
     pub fn default() -> (projected_volume_source: ProjectedVolumeSource)
@@ -235,7 +235,7 @@ pub struct VolumeProjection {
 }
 
 impl VolumeProjection {
-    pub spec fn view(&self) -> VolumeProjectionView;
+    pub uninterp spec fn view(&self) -> VolumeProjectionView;
 
     #[verifier(external_body)]
     pub fn default() -> (volume_projection: VolumeProjection)
@@ -265,7 +265,7 @@ pub struct ConfigMapProjection {
 }
 
 impl ConfigMapProjection {
-    pub spec fn view(&self) -> ConfigMapProjectionView;
+    pub uninterp spec fn view(&self) -> ConfigMapProjectionView;
 
     #[verifier(external_body)]
     pub fn default() -> (config_map_projection: ConfigMapProjection)
@@ -302,7 +302,7 @@ pub struct SecretProjection {
 }
 
 impl SecretProjection {
-    pub spec fn view(&self) -> SecretProjectionView;
+    pub uninterp spec fn view(&self) -> SecretProjectionView;
 
     #[verifier(external_body)]
     pub fn default() -> (secret_projection: SecretProjection)
@@ -339,7 +339,7 @@ pub struct KeyToPath {
 }
 
 impl KeyToPath {
-    pub spec fn view(&self) -> KeyToPathView;
+    pub uninterp spec fn view(&self) -> KeyToPathView;
 
     #[verifier(external_body)]
     pub fn default() -> (key_to_path: KeyToPath)
@@ -369,7 +369,7 @@ pub struct DownwardAPIVolumeSource {
 }
 
 impl DownwardAPIVolumeSource {
-    pub spec fn view(&self) -> DownwardAPIVolumeSourceView;
+    pub uninterp spec fn view(&self) -> DownwardAPIVolumeSourceView;
 
     #[verifier(external_body)]
     pub fn default() -> (downward_api_volume_source: DownwardAPIVolumeSource)
@@ -399,7 +399,7 @@ pub struct DownwardAPIVolumeFile {
 }
 
 impl DownwardAPIVolumeFile {
-    pub spec fn view(&self) -> DownwardAPIVolumeFileView;
+    pub uninterp spec fn view(&self) -> DownwardAPIVolumeFileView;
 
     #[verifier(external_body)]
     pub fn default() -> (downward_api_volume_file: DownwardAPIVolumeFile)
@@ -429,7 +429,7 @@ pub struct ObjectFieldSelector {
 }
 
 impl ObjectFieldSelector {
-    pub spec fn view(&self) -> ObjectFieldSelectorView;
+    pub uninterp spec fn view(&self) -> ObjectFieldSelectorView;
 
     #[verifier(external_body)]
     pub fn default() -> (object_field_selector: ObjectFieldSelector)

--- a/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
@@ -13,7 +13,7 @@ pub struct VolumeResourceRequirements {
 }
 
 impl VolumeResourceRequirements {
-    pub spec fn view(&self) -> VolumeResourceRequirementsView;
+    pub uninterp spec fn view(&self) -> VolumeResourceRequirementsView;
 
     #[verifier(external_body)]
     pub fn default() -> (resource_requirements: VolumeResourceRequirements)

--- a/src/kubernetes_api_objects/spec/config_map.rs
+++ b/src/kubernetes_api_objects/spec/config_map.rs
@@ -111,13 +111,13 @@ impl ResourceView for ConfigMapView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: ConfigMapSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: ConfigMapSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<ConfigMapSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<ConfigMapSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: EmptyStatusView) -> Value;
+    uninterp spec fn marshal_status(s: EmptyStatusView) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/kubernetes_api_objects/spec/daemon_set.rs
+++ b/src/kubernetes_api_objects/spec/daemon_set.rs
@@ -105,13 +105,13 @@ impl ResourceView for DaemonSetView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: Option<DaemonSetSpecView>) -> Value;
+    uninterp spec fn marshal_spec(s: Option<DaemonSetSpecView>) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<Option<DaemonSetSpecView>, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<Option<DaemonSetSpecView>, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<DaemonSetStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<DaemonSetStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<DaemonSetStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<DaemonSetStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/kubernetes_api_objects/spec/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/spec/persistent_volume_claim.rs
@@ -108,13 +108,13 @@ impl ResourceView for PersistentVolumeClaimView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: Option<PersistentVolumeClaimSpecView>) -> Value;
+    uninterp spec fn marshal_spec(s: Option<PersistentVolumeClaimSpecView>) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<Option<PersistentVolumeClaimSpecView>, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<Option<PersistentVolumeClaimSpecView>, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<PersistentVolumeClaimStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<PersistentVolumeClaimStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<PersistentVolumeClaimStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<PersistentVolumeClaimStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/kubernetes_api_objects/spec/pod.rs
+++ b/src/kubernetes_api_objects/spec/pod.rs
@@ -109,13 +109,13 @@ impl ResourceView for PodView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: Option<PodSpecView>) -> Value;
+    uninterp spec fn marshal_spec(s: Option<PodSpecView>) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<Option<PodSpecView>, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<Option<PodSpecView>, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<PodStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<PodStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<PodStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<PodStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity(){}

--- a/src/kubernetes_api_objects/spec/role.rs
+++ b/src/kubernetes_api_objects/spec/role.rs
@@ -103,13 +103,13 @@ impl ResourceView for RoleView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: RoleSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: RoleSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<RoleSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<RoleSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: EmptyStatusView) -> Value;
+    uninterp spec fn marshal_status(s: EmptyStatusView) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/kubernetes_api_objects/spec/role_binding.rs
+++ b/src/kubernetes_api_objects/spec/role_binding.rs
@@ -113,13 +113,13 @@ impl ResourceView for RoleBindingView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: RoleBindingSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: RoleBindingSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<RoleBindingSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<RoleBindingSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: EmptyStatusView) -> Value;
+    uninterp spec fn marshal_status(s: EmptyStatusView) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/kubernetes_api_objects/spec/secret.rs
+++ b/src/kubernetes_api_objects/spec/secret.rs
@@ -100,13 +100,13 @@ impl ResourceView for SecretView {
 
     proof fn marshal_preserves_kind() {}
 
-    open spec fn marshal_spec(s: SecretSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: SecretSpecView) -> Value;
 
-    open spec fn unmarshal_spec(v: Value) -> Result<SecretSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<SecretSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: EmptyStatusView) -> Value;
+    uninterp spec fn marshal_status(s: EmptyStatusView) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/kubernetes_api_objects/spec/service.rs
+++ b/src/kubernetes_api_objects/spec/service.rs
@@ -106,13 +106,13 @@ impl ResourceView for ServiceView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: Option<ServiceSpecView>) -> Value;
+    uninterp spec fn marshal_spec(s: Option<ServiceSpecView>) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<Option<ServiceSpecView>, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<Option<ServiceSpecView>, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<ServiceStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<ServiceStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<ServiceStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<ServiceStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/kubernetes_api_objects/spec/service_account.rs
+++ b/src/kubernetes_api_objects/spec/service_account.rs
@@ -95,13 +95,13 @@ impl ResourceView for ServiceAccountView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: ServiceAccountSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: ServiceAccountSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<ServiceAccountSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<ServiceAccountSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: EmptyStatusView) -> Value;
+    uninterp spec fn marshal_status(s: EmptyStatusView) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<EmptyStatusView, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/kubernetes_api_objects/spec/stateful_set.rs
+++ b/src/kubernetes_api_objects/spec/stateful_set.rs
@@ -107,13 +107,13 @@ impl ResourceView for StatefulSetView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: Option<StatefulSetSpecView>) -> Value;
+    uninterp spec fn marshal_spec(s: Option<StatefulSetSpecView>) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<Option<StatefulSetSpecView>, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<Option<StatefulSetSpecView>, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<StatefulSetStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<StatefulSetStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<StatefulSetStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<StatefulSetStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/v2/controllers/fluent_controller/fluentbit/trusted/exec_types.rs
+++ b/src/v2/controllers/fluent_controller/fluentbit/trusted/exec_types.rs
@@ -43,7 +43,7 @@ pub struct FluentBit {
 impl View for FluentBit {
     type V = FluentBitView;
 
-    spec fn view(&self) -> FluentBitView;
+    uninterp spec fn view(&self) -> FluentBitView;
 }
 
 impl FluentBit {
@@ -116,7 +116,7 @@ pub struct FluentBitSpec {
 }
 
 impl FluentBitSpec {
-    pub spec fn view(&self) -> spec_types::FluentBitSpecView;
+    pub uninterp spec fn view(&self) -> spec_types::FluentBitSpecView;
 
     #[verifier(external_body)]
     pub fn fluentbit_config_name(&self) -> (fluentbit_config_name: String)

--- a/src/v2/controllers/fluent_controller/fluentbit/trusted/maker.rs
+++ b/src/v2/controllers/fluent_controller/fluentbit/trusted/maker.rs
@@ -10,17 +10,17 @@ use vstd::prelude::*;
 verus! {
 
 pub trait Maker {
-    spec fn make_service_account_key(fb: FluentBitView) -> ObjectRef;
-    spec fn make_role_key(fb: FluentBitView) -> ObjectRef;
-    spec fn make_role_binding_key(fb: FluentBitView) -> ObjectRef;
-    spec fn make_service_key(fb: FluentBitView) -> ObjectRef;
-    spec fn make_daemon_set_key(fb: FluentBitView) -> ObjectRef;
+    uninterp spec fn make_service_account_key(fb: FluentBitView) -> ObjectRef;
+    uninterp spec fn make_role_key(fb: FluentBitView) -> ObjectRef;
+    uninterp spec fn make_role_binding_key(fb: FluentBitView) -> ObjectRef;
+    uninterp spec fn make_service_key(fb: FluentBitView) -> ObjectRef;
+    uninterp spec fn make_daemon_set_key(fb: FluentBitView) -> ObjectRef;
 
-    spec fn make_service_account(fb: FluentBitView) -> ServiceAccountView;
-    spec fn make_role(fb: FluentBitView) -> RoleView;
-    spec fn make_role_binding(fb: FluentBitView) -> RoleBindingView;
-    spec fn make_service(fb: FluentBitView) -> ServiceView;
-    spec fn make_daemon_set(fb: FluentBitView) -> DaemonSetView;
+    uninterp spec fn make_service_account(fb: FluentBitView) -> ServiceAccountView;
+    uninterp spec fn make_role(fb: FluentBitView) -> RoleView;
+    uninterp spec fn make_role_binding(fb: FluentBitView) -> RoleBindingView;
+    uninterp spec fn make_service(fb: FluentBitView) -> ServiceView;
+    uninterp spec fn make_daemon_set(fb: FluentBitView) -> DaemonSetView;
 }
 
 }

--- a/src/v2/controllers/fluent_controller/fluentbit/trusted/spec_types.rs
+++ b/src/v2/controllers/fluent_controller/fluentbit/trusted/spec_types.rs
@@ -116,13 +116,13 @@ impl ResourceView for FluentBitView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: FluentBitSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: FluentBitSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<FluentBitSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<FluentBitSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<FluentBitStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<FluentBitStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<FluentBitStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<FluentBitStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/v2/controllers/fluent_controller/fluentbit_config/trusted/exec_types.rs
+++ b/src/v2/controllers/fluent_controller/fluentbit_config/trusted/exec_types.rs
@@ -47,7 +47,7 @@ pub struct FluentBitConfig {
 impl View for FluentBitConfig {
     type V = spec_types::FluentBitConfigView;
 
-    spec fn view(&self) -> spec_types::FluentBitConfigView;
+    uninterp spec fn view(&self) -> spec_types::FluentBitConfigView;
 }
 
 impl FluentBitConfig {
@@ -120,7 +120,7 @@ pub struct FluentBitConfigSpec {
 }
 
 impl FluentBitConfigSpec {
-    pub spec fn view(&self) -> spec_types::FluentBitConfigSpecView;
+    pub uninterp spec fn view(&self) -> spec_types::FluentBitConfigSpecView;
 
     #[verifier(external_body)]
     pub fn fluentbit_config(&self) -> (fluentbit_config: String)

--- a/src/v2/controllers/fluent_controller/fluentbit_config/trusted/maker.rs
+++ b/src/v2/controllers/fluent_controller/fluentbit_config/trusted/maker.rs
@@ -10,9 +10,9 @@ use vstd::prelude::*;
 verus! {
 
 pub trait Maker {
-    spec fn make_secret_key(fbc: FluentBitConfigView) -> ObjectRef;
+    uninterp spec fn make_secret_key(fbc: FluentBitConfigView) -> ObjectRef;
 
-    spec fn make_secret(fbc: FluentBitConfigView) -> SecretView;
+    uninterp spec fn make_secret(fbc: FluentBitConfigView) -> SecretView;
 }
 
 }

--- a/src/v2/controllers/fluent_controller/fluentbit_config/trusted/spec_types.rs
+++ b/src/v2/controllers/fluent_controller/fluentbit_config/trusted/spec_types.rs
@@ -115,13 +115,13 @@ impl ResourceView for FluentBitConfigView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: FluentBitConfigSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: FluentBitConfigSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<FluentBitConfigSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<FluentBitConfigSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<FluentBitConfigStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<FluentBitConfigStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<FluentBitConfigStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<FluentBitConfigStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/v2/controllers/rabbitmq_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/rabbitmq_controller/trusted/exec_types.rs
@@ -61,7 +61,7 @@ pub struct RabbitmqCluster {
 impl View for RabbitmqCluster {
     type V = spec_types::RabbitmqClusterView;
 
-    spec fn view(&self) -> spec_types::RabbitmqClusterView;
+    uninterp spec fn view(&self) -> spec_types::RabbitmqClusterView;
 }
 
 impl RabbitmqCluster {
@@ -132,7 +132,7 @@ pub struct RabbitmqClusterSpec {
 }
 
 impl RabbitmqClusterSpec {
-    pub spec fn view(&self) -> spec_types::RabbitmqClusterSpecView;
+    pub uninterp spec fn view(&self) -> spec_types::RabbitmqClusterSpecView;
 
     #[verifier(external_body)]
     pub fn replicas(&self) -> (replicas: i32)
@@ -243,7 +243,7 @@ pub struct RabbitmqConfig {
 }
 
 impl RabbitmqConfig {
-    pub spec fn view(&self) -> spec_types::RabbitmqConfigView;
+    pub uninterp spec fn view(&self) -> spec_types::RabbitmqConfigView;
 
     #[verifier(external_body)]
     pub fn additional_config(&self) -> (additional_config: Option<String>)
@@ -279,7 +279,7 @@ pub struct RabbitmqClusterPersistenceSpec {
 }
 
 impl RabbitmqClusterPersistenceSpec {
-    pub spec fn view(&self) -> spec_types::RabbitmqClusterPersistenceSpecView;
+    pub uninterp spec fn view(&self) -> spec_types::RabbitmqClusterPersistenceSpecView;
 
     #[verifier(external_body)]
     pub fn storage(&self) -> (storage: String)

--- a/src/v2/controllers/rabbitmq_controller/trusted/maker.rs
+++ b/src/v2/controllers/rabbitmq_controller/trusted/maker.rs
@@ -10,27 +10,27 @@ use vstd::prelude::*;
 verus! {
 
 pub trait Maker {
-    spec fn make_headless_service_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_main_service_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_erlang_secret_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_default_user_secret_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_plugins_config_map_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_server_config_map_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_service_account_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_role_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_role_binding_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
-    spec fn make_stateful_set_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_headless_service_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_main_service_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_erlang_secret_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_default_user_secret_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_plugins_config_map_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_server_config_map_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_service_account_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_role_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_role_binding_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
+    uninterp spec fn make_stateful_set_key(rabbitmq: RabbitmqClusterView) -> ObjectRef;
 
-    spec fn make_headless_service(rabbitmq: RabbitmqClusterView) -> ServiceView;
-    spec fn make_main_service(rabbitmq: RabbitmqClusterView) -> ServiceView;
-    spec fn make_erlang_secret(rabbitmq: RabbitmqClusterView) -> SecretView;
-    spec fn make_default_user_secret(rabbitmq: RabbitmqClusterView) -> SecretView;
-    spec fn make_plugins_config_map(rabbitmq: RabbitmqClusterView) -> ConfigMapView;
-    spec fn make_server_config_map(rabbitmq: RabbitmqClusterView) -> ConfigMapView;
-    spec fn make_service_account(rabbitmq: RabbitmqClusterView) -> ServiceAccountView;
-    spec fn make_role(rabbitmq: RabbitmqClusterView) -> RoleView;
-    spec fn make_role_binding(rabbitmq: RabbitmqClusterView) -> RoleBindingView;
-    spec fn make_stateful_set(rabbitmq: RabbitmqClusterView, config_map_rv: StringView) -> StatefulSetView;
+    uninterp spec fn make_headless_service(rabbitmq: RabbitmqClusterView) -> ServiceView;
+    uninterp spec fn make_main_service(rabbitmq: RabbitmqClusterView) -> ServiceView;
+    uninterp spec fn make_erlang_secret(rabbitmq: RabbitmqClusterView) -> SecretView;
+    uninterp spec fn make_default_user_secret(rabbitmq: RabbitmqClusterView) -> SecretView;
+    uninterp spec fn make_plugins_config_map(rabbitmq: RabbitmqClusterView) -> ConfigMapView;
+    uninterp spec fn make_server_config_map(rabbitmq: RabbitmqClusterView) -> ConfigMapView;
+    uninterp spec fn make_service_account(rabbitmq: RabbitmqClusterView) -> ServiceAccountView;
+    uninterp spec fn make_role(rabbitmq: RabbitmqClusterView) -> RoleView;
+    uninterp spec fn make_role_binding(rabbitmq: RabbitmqClusterView) -> RoleBindingView;
+    uninterp spec fn make_stateful_set(rabbitmq: RabbitmqClusterView, config_map_rv: StringView) -> StatefulSetView;
 }
 
 }

--- a/src/v2/controllers/rabbitmq_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/rabbitmq_controller/trusted/spec_types.rs
@@ -116,13 +116,13 @@ impl ResourceView for RabbitmqClusterView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: RabbitmqClusterSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: RabbitmqClusterSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<RabbitmqClusterSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<RabbitmqClusterSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<RabbitmqClusterStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<RabbitmqClusterStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<RabbitmqClusterStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<RabbitmqClusterStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}
@@ -187,6 +187,6 @@ pub struct RabbitmqClusterPersistenceSpecView {
     pub storage: StringView,
 }
 
-pub closed spec fn random_encoded_string(length: usize) -> StringView;
+pub uninterp spec fn random_encoded_string(length: usize) -> StringView;
 
 }

--- a/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
@@ -354,6 +354,8 @@ ensures
                     vrs_list@.map_values(|vrs: VReplicaSet| vrs@) == model_result.unwrap().take(idx as int))
             &&& forall|i: int| 0 <= i < idx ==> VReplicaSetView::unmarshal(#[trigger] objs@[i]@).is_ok()
         }),
+    decreases
+        objs.len() - idx,
     {
         match VReplicaSet::unmarshal(objs[idx].clone()) {
             Ok(vrs) => {
@@ -433,6 +435,8 @@ ensures
         filtered_vrs_list@.map_values(|vrs: VReplicaSet| vrs@)
             == model_util::filter_vrs_list(vrs_list@.map_values(|vrs: VReplicaSet| vrs@).take(idx as int), vd@),
         forall |i: int| 0 <= i < filtered_vrs_list.len() ==> #[trigger] filtered_vrs_list[i]@.well_formed(),
+    decreases
+        vrs_list.len() - idx,
     {
         let vrs = &vrs_list[idx];
         if vrs.metadata().owner_references_contains(&vd.controller_owner_ref())
@@ -506,6 +510,8 @@ ensures
         old_vrs_list@.map_values(|vrs: VReplicaSet| vrs@) == model_reconciler::filter_old_and_new_vrs(vrs_list@.map_values(|vrs: VReplicaSet| vrs@).take(idx as int), vd@).1,
         forall |i: int| 0 <= i < new_vrs_list.len() ==> (#[trigger] new_vrs_list[i])@.well_formed(),
         forall |i: int| 0 <= i < old_vrs_list.len() ==> (#[trigger] old_vrs_list[i])@.well_formed(),
+    decreases
+        vrs_list.len() - idx,
     {
         let vrs = &vrs_list[idx];
         assert(vrs@.well_formed());

--- a/src/v2/controllers/vdeployment_controller/model/install.rs
+++ b/src/v2/controllers/vdeployment_controller/model/install.rs
@@ -10,9 +10,9 @@ use vstd::prelude::*;
 verus! {
 
 impl Marshallable for VDeploymentReconcileState {
-    spec fn marshal(self) -> Value;
+    uninterp spec fn marshal(self) -> Value;
 
-    spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
+    uninterp spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity()

--- a/src/v2/controllers/vdeployment_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/vdeployment_controller/trusted/spec_types.rs
@@ -106,13 +106,13 @@ impl ResourceView for VDeploymentView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: VDeploymentSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: VDeploymentSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<VDeploymentSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<VDeploymentSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<VDeploymentStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<VDeploymentStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<VDeploymentStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<VDeploymentStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/v2/controllers/vreplicaset_controller/exec/reconciler.rs
+++ b/src/v2/controllers/vreplicaset_controller/exec/reconciler.rs
@@ -304,6 +304,8 @@ fn objects_to_pods(objs: Vec<DynamicObject>) -> (pods_or_none: Option<Vec<Pod>>)
                         pods@.map_values(|p: Pod| p@) == model_result.unwrap().take(idx as int))
                 &&& forall|i: int| 0 <= i < idx ==> PodView::unmarshal(#[trigger] objs@[i]@).is_ok()
             }),
+        decreases
+            objs.len() - idx,
     {
         let pod_or_error = Pod::unmarshal(objs[idx].clone());
         if pod_or_error.is_ok() {
@@ -381,6 +383,8 @@ fn filter_pods(pods: Vec<Pod>, v_replica_set: &VReplicaSet) -> (filtered_pods: V
             idx <= pods.len(),
             filtered_pods@.map_values(|p: Pod| p@)
                 == model_reconciler::filter_pods(pods@.map_values(|p: Pod| p@).take(idx as int), v_replica_set@),
+        decreases
+            pods.len() - idx,
     {
         let pod = &pods[idx];
 

--- a/src/v2/controllers/vreplicaset_controller/model/install.rs
+++ b/src/v2/controllers/vreplicaset_controller/model/install.rs
@@ -10,9 +10,9 @@ use vstd::prelude::*;
 verus! {
 
 impl Marshallable for VReplicaSetReconcileState {
-    spec fn marshal(self) -> Value;
+    uninterp spec fn marshal(self) -> Value;
 
-    spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
+    uninterp spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity()

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/terminate.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/terminate.rs
@@ -1025,6 +1025,6 @@ pub proof fn lemma_from_pending_req_in_flight_or_resp_in_flight_at_all_delete_to
 }
 
 // Havoc function for VReplicaSetView.
-spec fn make_vrs() -> VReplicaSetView;
+uninterp spec fn make_vrs() -> VReplicaSetView;
 
 }

--- a/src/v2/controllers/vreplicaset_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/exec_types.rs
@@ -19,7 +19,7 @@ pub struct VReplicaSet {
 impl View for VReplicaSet {
     type V = spec_types::VReplicaSetView;
 
-    spec fn view(&self) -> spec_types::VReplicaSetView;
+    uninterp spec fn view(&self) -> spec_types::VReplicaSetView;
 }
 
 implement_deep_view_trait!(VReplicaSet, spec_types::VReplicaSetView);
@@ -169,7 +169,7 @@ pub struct VReplicaSetSpec {
 }
 
 impl VReplicaSetSpec {
-    pub spec fn view(&self) -> spec_types::VReplicaSetSpecView;
+    pub uninterp spec fn view(&self) -> spec_types::VReplicaSetSpecView;
 
     #[verifier(external_body)]
     pub fn default() -> (vreplicaset_spec: VReplicaSetSpec)

--- a/src/v2/controllers/vreplicaset_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/vreplicaset_controller/trusted/spec_types.rs
@@ -110,13 +110,13 @@ impl ResourceView for VReplicaSetView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: VReplicaSetSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: VReplicaSetSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<VReplicaSetSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<VReplicaSetSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<VReplicaSetStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<VReplicaSetStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<VReplicaSetStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<VReplicaSetStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/v2/controllers/vstatefulset_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/vstatefulset_controller/trusted/exec_types.rs
@@ -43,7 +43,7 @@ pub struct VStatefulSet {
 impl View for VStatefulSet {
     type V = spec_types::VStatefulSetView;
 
-    spec fn view(&self) -> spec_types::VStatefulSetView;
+    uninterp spec fn view(&self) -> spec_types::VStatefulSetView;
 }
 
 impl VStatefulSet {
@@ -235,7 +235,7 @@ pub struct VStatefulSetSpec {
 }
 
 impl VStatefulSetSpec {
-    pub spec fn view(&self) -> spec_types::VStatefulSetSpecView;
+    pub uninterp spec fn view(&self) -> spec_types::VStatefulSetSpecView;
 
     #[verifier(external_body)]
     pub fn service_name(&self) -> (service_name: String)
@@ -343,7 +343,7 @@ pub struct StatefulSetUpdateStrategy {
 }
 
 impl StatefulSetUpdateStrategy {
-    pub spec fn view(&self) -> spec_types::StatefulSetUpdateStrategyView;
+    pub uninterp spec fn view(&self) -> spec_types::StatefulSetUpdateStrategyView;
 
     #[verifier(external_body)]
     pub fn default() -> (strategy: StatefulSetUpdateStrategy)
@@ -403,7 +403,7 @@ pub struct RollingUpdateStatefulSetStrategy {
 }
 
 impl RollingUpdateStatefulSetStrategy {
-    pub spec fn view(&self) -> spec_types::RollingUpdateStatefulSetStrategyView;
+    pub uninterp spec fn view(&self) -> spec_types::RollingUpdateStatefulSetStrategyView;
 
     #[verifier(external_body)]
     pub fn default() -> (rolling_update: RollingUpdateStatefulSetStrategy)
@@ -471,7 +471,7 @@ pub struct StatefulSetPersistentVolumeClaimRetentionPolicy {
 }
 
 impl StatefulSetPersistentVolumeClaimRetentionPolicy {
-    pub spec fn view(&self) -> spec_types::StatefulSetPersistentVolumeClaimRetentionPolicyView;
+    pub uninterp spec fn view(&self) -> spec_types::StatefulSetPersistentVolumeClaimRetentionPolicyView;
 
     #[verifier(external_body)]
     pub fn default() -> (policy: StatefulSetPersistentVolumeClaimRetentionPolicy)
@@ -528,7 +528,7 @@ pub struct StatefulSetOrdinals {
 }
 
 impl StatefulSetOrdinals {
-    pub spec fn view(&self) -> spec_types::StatefulSetOrdinalsView;
+    pub uninterp spec fn view(&self) -> spec_types::StatefulSetOrdinalsView;
 
     #[verifier(external_body)]
     pub fn default() -> (ordinals: StatefulSetOrdinals)

--- a/src/v2/controllers/vstatefulset_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/vstatefulset_controller/trusted/spec_types.rs
@@ -96,13 +96,13 @@ impl ResourceView for VStatefulSetView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: VStatefulSetSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: VStatefulSetSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<VStatefulSetSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<VStatefulSetSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<VStatefulSetStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<VStatefulSetStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<VStatefulSetStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<VStatefulSetStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/v2/controllers/zookeeper_controller/trusted/exec_types.rs
+++ b/src/v2/controllers/zookeeper_controller/trusted/exec_types.rs
@@ -60,7 +60,7 @@ pub struct ZookeeperCluster {
 impl View for ZookeeperCluster {
     type V = spec_types::ZookeeperClusterView;
 
-    spec fn view(&self) -> spec_types::ZookeeperClusterView;
+    uninterp spec fn view(&self) -> spec_types::ZookeeperClusterView;
 }
 
 impl ZookeeperCluster {
@@ -147,7 +147,7 @@ pub struct ZookeeperClusterSpec {
 }
 
 impl ZookeeperClusterSpec {
-    pub spec fn view(&self) -> spec_types::ZookeeperClusterSpecView;
+    pub uninterp spec fn view(&self) -> spec_types::ZookeeperClusterSpecView;
 
     #[verifier(external_body)]
     pub fn replicas(&self) -> (replicas: i32)
@@ -248,7 +248,7 @@ pub struct ZookeeperPorts {
 }
 
 impl ZookeeperPorts {
-    pub spec fn view(&self) -> spec_types::ZookeeperPortsView;
+    pub uninterp spec fn view(&self) -> spec_types::ZookeeperPortsView;
 
     #[verifier(external_body)]
     pub fn client(&self) -> (client: i32)
@@ -292,7 +292,7 @@ pub struct ZookeeperConfig {
 }
 
 impl ZookeeperConfig {
-    pub spec fn view(&self) -> spec_types::ZookeeperConfigView;
+    pub uninterp spec fn view(&self) -> spec_types::ZookeeperConfigView;
 
     #[verifier(external_body)]
     pub fn init_limit(&self) -> (init_limit: i32)
@@ -406,7 +406,7 @@ pub struct ZookeeperPersistence {
 }
 
 impl ZookeeperPersistence {
-    pub spec fn view(&self) -> spec_types::ZookeeperPersistenceView;
+    pub uninterp spec fn view(&self) -> spec_types::ZookeeperPersistenceView;
 
     #[verifier(external_body)]
     pub fn enabled(&self) -> (enabled: bool)
@@ -436,7 +436,7 @@ pub struct ZookeeperClusterStatus {
 }
 
 impl ZookeeperClusterStatus {
-    pub spec fn view(&self) -> spec_types::ZookeeperClusterStatusView;
+    pub uninterp spec fn view(&self) -> spec_types::ZookeeperClusterStatusView;
 
     #[verifier(external_body)]
     pub fn default() -> (status: ZookeeperClusterStatus)

--- a/src/v2/controllers/zookeeper_controller/trusted/maker.rs
+++ b/src/v2/controllers/zookeeper_controller/trusted/maker.rs
@@ -9,17 +9,17 @@ use vstd::prelude::*;
 verus! {
 
 pub trait Maker {
-    spec fn make_headless_service_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
-    spec fn make_client_service_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
-    spec fn make_admin_server_service_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
-    spec fn make_config_map_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
-    spec fn make_stateful_set_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
+    uninterp spec fn make_headless_service_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
+    uninterp spec fn make_client_service_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
+    uninterp spec fn make_admin_server_service_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
+    uninterp spec fn make_config_map_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
+    uninterp spec fn make_stateful_set_key(zookeeper: ZookeeperClusterView) -> ObjectRef;
 
-    spec fn make_headless_service(zookeeper: ZookeeperClusterView) -> ServiceView;
-    spec fn make_client_service(zookeeper: ZookeeperClusterView) -> ServiceView;
-    spec fn make_admin_server_service(zookeeper: ZookeeperClusterView) -> ServiceView;
-    spec fn make_config_map(zookeeper: ZookeeperClusterView) -> ConfigMapView;
-    spec fn make_stateful_set(zookeeper: ZookeeperClusterView, config_map_rv: StringView) -> StatefulSetView;
+    uninterp spec fn make_headless_service(zookeeper: ZookeeperClusterView) -> ServiceView;
+    uninterp spec fn make_client_service(zookeeper: ZookeeperClusterView) -> ServiceView;
+    uninterp spec fn make_admin_server_service(zookeeper: ZookeeperClusterView) -> ServiceView;
+    uninterp spec fn make_config_map(zookeeper: ZookeeperClusterView) -> ConfigMapView;
+    uninterp spec fn make_stateful_set(zookeeper: ZookeeperClusterView, config_map_rv: StringView) -> StatefulSetView;
 }
 
 }

--- a/src/v2/controllers/zookeeper_controller/trusted/spec_types.rs
+++ b/src/v2/controllers/zookeeper_controller/trusted/spec_types.rs
@@ -120,13 +120,13 @@ impl ResourceView for ZookeeperClusterView {
 
     proof fn marshal_preserves_kind() {}
 
-    closed spec fn marshal_spec(s: ZookeeperClusterSpecView) -> Value;
+    uninterp spec fn marshal_spec(s: ZookeeperClusterSpecView) -> Value;
 
-    closed spec fn unmarshal_spec(v: Value) -> Result<ZookeeperClusterSpecView, UnmarshalError>;
+    uninterp spec fn unmarshal_spec(v: Value) -> Result<ZookeeperClusterSpecView, UnmarshalError>;
 
-    closed spec fn marshal_status(s: Option<ZookeeperClusterStatusView>) -> Value;
+    uninterp spec fn marshal_status(s: Option<ZookeeperClusterStatusView>) -> Value;
 
-    closed spec fn unmarshal_status(v: Value) -> Result<Option<ZookeeperClusterStatusView>, UnmarshalError>;
+    uninterp spec fn unmarshal_status(v: Value) -> Result<Option<ZookeeperClusterStatusView>, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_spec_preserves_integrity() {}

--- a/src/v2/kubernetes_cluster/proof/compositionality.rs
+++ b/src/v2/kubernetes_cluster/proof/compositionality.rs
@@ -272,19 +272,19 @@ use super::*;
 
 // Here is an example on how to use HorizontalComposition and VerticalComposition to compose controllers.
 
-pub spec fn cook_controllers() -> Seq<ControllerModel>;
-pub spec fn cook_property(i: int) -> TempPred<ClusterState>;
-pub spec fn cook_cluster_condition(i: int) -> spec_fn(Cluster) -> bool;
-pub spec fn cook_fairness_condition(i: int) -> TempPred<ClusterState>;
-pub spec fn cook_non_interference_condition(i: int) -> spec_fn(good_citizen_id: int) -> StatePred<ClusterState>;
+pub uninterp spec fn cook_controllers() -> Seq<ControllerModel>;
+pub uninterp spec fn cook_property(i: int) -> TempPred<ClusterState>;
+pub uninterp spec fn cook_cluster_condition(i: int) -> spec_fn(Cluster) -> bool;
+pub uninterp spec fn cook_fairness_condition(i: int) -> TempPred<ClusterState>;
+pub uninterp spec fn cook_non_interference_condition(i: int) -> spec_fn(good_citizen_id: int) -> StatePred<ClusterState>;
 
-pub spec fn waiter_controller() -> ControllerModel;
-pub spec fn waiter_cluster_condition() -> spec_fn(Cluster) -> bool;
-pub spec fn waiter_fairness_condition() -> TempPred<ClusterState>;
-pub spec fn waiter_property() -> TempPred<ClusterState>;
-pub spec fn waiter_non_interference_condition() -> spec_fn(good_citizen_id: int) -> StatePred<ClusterState>;
+pub uninterp spec fn waiter_controller() -> ControllerModel;
+pub uninterp spec fn waiter_cluster_condition() -> spec_fn(Cluster) -> bool;
+pub uninterp spec fn waiter_fairness_condition() -> TempPred<ClusterState>;
+pub uninterp spec fn waiter_property() -> TempPred<ClusterState>;
+pub uninterp spec fn waiter_non_interference_condition() -> spec_fn(good_citizen_id: int) -> StatePred<ClusterState>;
 
-pub spec fn waiter_and_cooks_installed_types() -> InstalledTypes;
+pub uninterp spec fn waiter_and_cooks_installed_types() -> InstalledTypes;
 
 pub open spec fn waiter_and_cooks() -> Cluster {
     Cluster {

--- a/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/v2/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -244,7 +244,7 @@ pub open spec fn created_object_validity_check(created_obj: DynamicObjectView, i
     }
 }
 
-pub closed spec fn generate_name(s: APIServerState) -> StringView;
+pub uninterp spec fn generate_name(s: APIServerState) -> StringView;
 
 // TODO: This should be a spec ensures of the generate_name above
 // NOTE: In the actual implementation, the API server might fail to generate a unique name
@@ -338,7 +338,7 @@ pub open spec fn delete_request_admission_check(req: DeleteRequest, s: APIServer
 // only cares whether the object has a deletion timestamp or not.
 // By using this closed deletion_timestamp() function, we make the
 // modeling and proof much easier compared to modelling the real clock.
-pub closed spec fn deletion_timestamp() -> StringView;
+pub uninterp spec fn deletion_timestamp() -> StringView;
 
 // NOTE: Deletion has three modes including background (default), foreground, orphan.
 // For now, we only model background deletion and only allow our controllers to perform background deletion

--- a/src/v2/reconciler/exec/io.rs
+++ b/src/v2/reconciler/exec/io.rs
@@ -138,7 +138,7 @@ pub struct VoidEReq {}
 impl View for VoidEReq {
     type V = VoidEReqView;
 
-    spec fn view(&self) -> VoidEReqView;
+    uninterp spec fn view(&self) -> VoidEReqView;
 }
 
 pub struct VoidEResp {}
@@ -146,7 +146,7 @@ pub struct VoidEResp {}
 impl View for VoidEResp {
     type V = VoidERespView;
 
-    spec fn view(&self) -> VoidERespView;
+    uninterp spec fn view(&self) -> VoidERespView;
 }
 
 #[macro_export]

--- a/src/v2/reconciler/exec/resource_builder.rs
+++ b/src/v2/reconciler/exec/resource_builder.rs
@@ -6,7 +6,7 @@ verus! {
 
 pub trait ResourceBuilder<K: View, T: View, SpecBuilder: resource_builder::ResourceBuilder<K::V, T::V>>
 {
-    spec fn requirements(cr: K::V) -> bool;
+    uninterp spec fn requirements(cr: K::V) -> bool;
 
     fn get_request(cr: &K) -> (req: KubeGetRequest)
         requires Self::requirements(cr@),

--- a/src/v2/reconciler/spec/io.rs
+++ b/src/v2/reconciler/spec/io.rs
@@ -11,9 +11,9 @@ pub struct VoidEReqView {}
 pub struct VoidERespView {}
 
 impl Marshallable for VoidEReqView {
-    spec fn marshal(self) -> Value;
+    uninterp spec fn marshal(self) -> Value;
 
-    spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
+    uninterp spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity()
@@ -22,9 +22,9 @@ impl Marshallable for VoidEReqView {
 }
 
 impl Marshallable for VoidERespView {
-    spec fn marshal(self) -> Value;
+    uninterp spec fn marshal(self) -> Value;
 
-    spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
+    uninterp spec fn unmarshal(v: Value) -> Result<Self, UnmarshalError>;
 
     #[verifier(external_body)]
     proof fn marshal_preserves_integrity()

--- a/src/v2/reconciler/spec/resource_builder.rs
+++ b/src/v2/reconciler/spec/resource_builder.rs
@@ -4,15 +4,15 @@ use vstd::prelude::*;
 verus! {
 
 pub trait ResourceBuilder<K, T> {
-    spec fn get_request(cr: K) -> GetRequest;
+    uninterp spec fn get_request(cr: K) -> GetRequest;
 
-    spec fn make(cr: K, state: T) -> Result<DynamicObjectView, ()>;
+    uninterp spec fn make(cr: K, state: T) -> Result<DynamicObjectView, ()>;
 
-    spec fn update(cr: K, state: T, obj: DynamicObjectView) -> Result<DynamicObjectView, ()>;
+    uninterp spec fn update(cr: K, state: T, obj: DynamicObjectView) -> Result<DynamicObjectView, ()>;
 
-    spec fn state_after_create(cr: K, obj: DynamicObjectView, state: T) -> Result<(T, Option<APIRequest>), ()>;
+    uninterp spec fn state_after_create(cr: K, obj: DynamicObjectView, state: T) -> Result<(T, Option<APIRequest>), ()>;
 
-    spec fn state_after_update(cr: K, obj: DynamicObjectView, state: T) -> Result<(T, Option<APIRequest>), ()>;
+    uninterp spec fn state_after_update(cr: K, obj: DynamicObjectView, state: T) -> Result<(T, Option<APIRequest>), ()>;
 }
 
 }

--- a/src/vstd_ext/string_map.rs
+++ b/src/vstd_ext/string_map.rs
@@ -8,7 +8,7 @@ pub struct StringMap {
 }
 
 impl StringMap {
-    pub spec fn view(&self) -> Map<Seq<char>, Seq<char>>;
+    pub uninterp spec fn view(&self) -> Map<Seq<char>, Seq<char>>;
 
     #[verifier(external_body)]
     pub fn new() -> (m: Self)

--- a/src/vstd_ext/string_view.rs
+++ b/src/vstd_ext/string_view.rs
@@ -23,7 +23,7 @@ pub fn i32_to_string(i: i32) -> (s: String)
     i.to_string()
 }
 
-pub spec fn int_to_string_view(i: int) -> StringView;
+pub uninterp spec fn int_to_string_view(i: int) -> StringView;
 
 #[verifier(external_body)]
 pub proof fn int_to_string_view_injectivity()
@@ -37,7 +37,7 @@ pub fn bool_to_string(b: bool) -> (s: String)
     b.to_string()
 }
 
-pub spec fn bool_to_string_view(b: bool) -> StringView;
+pub uninterp spec fn bool_to_string_view(b: bool) -> StringView;
 
 #[verifier(external_body)]
 pub proof fn bool_to_string_view_injectivity()

--- a/src/vstd_ext/vec_lib.rs
+++ b/src/vstd_ext/vec_lib.rs
@@ -23,6 +23,8 @@ fn vec_filter<V: VerusClone + View + Sized>(v: Vec<V>, f: impl Fn(&V)->bool, f_s
             i <= v.len(),
             r@.to_multiset() =~= v@.subrange(0, i as int).to_multiset().filter(f_spec),
             forall |v:V,r:bool| f.ensures((&v,), r) ==> f_spec(v) == r,
+        decreases
+            v.len() - i,
     {
         proof { lemma_seq_properties::<V>(); }
         let ghost pre_r = r@.to_multiset();


### PR DESCRIPTION
- Update Verus Version to 3b6b805ac
- Mask buggy lifetime check of Verus before https://github.com/verus-lang/verus/issues/1708 is fixed

This PR is the first stage of catching up with Verus' rolling release. We will work with @Chris-Hawblitzel to add Anvil to veritas as both test and performance benchmark. We need further discussions on stabilizing a release branch for this usage.