### PR TITLE
Specify simplified boundary invariant between invariant and WF1 reasoning

### DIFF
--- a/src/v2/kubernetes_cluster/proof/objects_in_store.rs
+++ b/src/v2/kubernetes_cluster/proof/objects_in_store.rs
@@ -28,6 +28,8 @@ pub open spec fn each_object_in_etcd_is_weakly_well_formed() -> StatePred<Cluste
     }
 }
 
+// TODO: investigate flaky proof
+#[verifier(rlimit(200))]
 pub proof fn lemma_always_each_object_in_etcd_is_weakly_well_formed(self, spec: TempPred<ClusterState>)
     requires
         spec.entails(lift_state(self.init())),


### PR DESCRIPTION
Here I specify a boundary invariant which states that any message sent not by the reconcile associated with the particular `vrs` we prove ESR for will not interfere with that reconcile process.

The body of the invariant is inspired by https://github.com/anvil-verifier/anvil/pull/630