### PR TITLE
Fix off-by-one error in controller action precondition

### DIFF
--- a/src/v2/kubernetes_cluster/spec/cluster.rs
+++ b/src/v2/kubernetes_cluster/spec/cluster.rs
@@ -680,7 +680,7 @@ impl Cluster {
             let network_result = network().next_result(msg_ops, s.network);
 
             &&& self.controller_models.contains_key(input.0)
-            &&& input.1.is_Some()
+            &&& input.2.is_Some()
             &&& received_msg_destined_for(input.1, HostId::Controller(controller_id, input.2.get_Some_0()))
             &&& host_result.is_Enabled()
             &&& network_result.is_Enabled()


### PR DESCRIPTION
This fixes an off-by-one error in `controller_action_pre`: instead of forcing the `ObjectRef` to be non-null, it forces the message to be `null`, whereas it is allowed that a controller takes a step without a message as input.

This is separate from the rest of subtask in (https://github.com/xlab-uiuc/anvil/issues/26) since spec/trusted code is modified.