### PR TITLE
Use macro for VD termination proof

### DIFF
--- a/src/v2/controllers/vdeployment_controller/proof/liveness/terminate.rs
+++ b/src/v2/controllers/vdeployment_controller/proof/liveness/terminate.rs
@@ -9,7 +9,7 @@ use crate::temporal_logic::{defs::*, rules::*};
 use crate::vdeployment_controller::{
     model::{install::*, reconciler::*},
     trusted::{liveness_theorem::*, spec_types::*, step::*, util::*},
-    proof::predicate::{StepCase::*, IntoSpec, into_spec_all},
+    proof::predicate::*,
 };
 use crate::vreplicaset_controller::trusted::spec_types::VReplicaSetView;
 // make encoding steps easier
@@ -17,6 +17,11 @@ use crate::vdeployment_controller::trusted::step::VDeploymentReconcileStepView::
 use vstd::prelude::*;
 
 verus! {
+
+// just to make Verus happy
+uninterp spec fn dummy_trigger_n(n: nat) -> bool;
+
+uninterp spec fn dummy_trigger_ex(ex: Execution<ClusterState>) -> bool;
 
 pub open spec fn old_vrs_list_len(n: nat) -> spec_fn(VDeploymentReconcileState) -> bool {
     |vds: VDeploymentReconcileState| vds.old_vrs_list.len() == n
@@ -51,16 +56,15 @@ requires
     spec.entails(always(lift_state(Cluster::cr_objects_in_reconcile_satisfy_state_validation::<VDeploymentView>(controller_id)))),
     spec.entails(always(lift_state(Cluster::pending_req_of_key_is_unique_with_unique_id(controller_id, vd.object_ref())))),
     // no request in init
-    spec.entails(always(lift_state(Cluster::no_pending_req_msg_at_reconcile_state(controller_id, vd.object_ref(), Plain(Init).into_local_state_pred())))),
+    spec.entails(always(lift_state(Cluster::no_pending_req_msg_at_reconcile_state(controller_id, vd.object_ref(), at_step_or![Init])))),
     // there is always pending request for vd to proceed
-    spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(controller_id, vd.object_ref(), Plain(AfterListVRS).into_local_state_pred())))),
-    spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(controller_id, vd.object_ref(), Plain(AfterCreateNewVRS).into_local_state_pred())))),
-    spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(controller_id, vd.object_ref(), Plain(AfterScaleNewVRS).into_local_state_pred())))),
-    spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(controller_id, vd.object_ref(), Plain(AfterScaleDownOldVRS).into_local_state_pred())))),
+    spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(controller_id, vd.object_ref(), at_step_or![AfterListVRS])))),
+    spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(controller_id, vd.object_ref(), at_step_or![AfterCreateNewVRS])))),
+    spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(controller_id, vd.object_ref(), at_step_or![AfterScaleNewVRS])))),
+    spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(controller_id, vd.object_ref(), at_step_or![AfterScaleDownOldVRS])))),
 ensures
     spec.entails(true_pred().leads_to(lift_state(|s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(vd.object_ref())))),
 {
-    broadcast use into_spec_all;
     VDeploymentReconcileState::marshal_preserves_integrity();
     let reconcile_idle = |s: ClusterState| !s.ongoing_reconciles(controller_id).contains_key(vd.object_ref());
     let reconcile_done = cluster.reconciler_reconcile_done(controller_id, vd.object_ref());
@@ -69,16 +73,16 @@ ensures
     // Here we simply apply a cluster lemma which uses the wf1 of end_reconcile action.
     cluster.lemma_reconcile_error_leads_to_reconcile_idle(spec, controller_id, vd.object_ref());
     cluster.lemma_reconcile_done_leads_to_reconcile_idle(spec, controller_id, vd.object_ref());
-    temp_pred_equality(Plain(Done).into_temporal_pred(controller_id, vd), lift_state(reconcile_done));
-    temp_pred_equality(Plain(Error).into_temporal_pred(controller_id, vd), lift_state(reconcile_error));
+    temp_pred_equality(lift_state(lift_local(controller_id, vd, at_step_or![Error])), lift_state(reconcile_error));
+    temp_pred_equality(lift_state(lift_local(controller_id, vd, at_step_or![Done])), lift_state(reconcile_done));
     entails_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
     // 2, AfterScaleDownOldVRS ~> reconcile_idle.
     // 2.1, AfterScaleDownOldVRS && state.old_vrs_list.len() == 0 ~> reconcile_idle.
     // Done ~> idle && Error ~> idle => Done \/ Error ~> idle
-    or_leads_to_combine_and_equality!(
-        spec, (Plain(Done), Plain(Error)).into_temporal_pred(controller_id, vd),
-        lift_state(reconcile_done),
-        lift_state(reconcile_error);
+    or_leads_to_combine_and_equality!(spec,
+        lift_state(lift_local(at_step_or![Error, Done])),
+        lift_state(reconcile_error),
+        lift_state(reconcile_done);
         lift_state(reconcile_idle)
     );
     // AfterScaleDownOldVRS && state.old_vrs_list.len() == 0 ~> Done \/ Error ~> idle
@@ -86,33 +90,33 @@ ensures
         spec, vd, controller_id, AfterScaleDownOldVRS, old_vrs_list_len(0)
     );
     // 0 ~> Done | Error ~> idle
-    assert(forall |input_cr, resp_o, s| WithPred(AfterScaleDownOldVRS, old_vrs_list_len(0)).into_local_state_pred()(s)
-        ==> #[trigger] (Plain(Done), Plain(Error)).into_local_state_pred()((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
+    assert(forall |input_cr, resp_o, s| at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(0))](s)
+        ==> #[trigger] at_step_or![Error, Done]((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     cluster.lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
         spec, controller_id, vd.marshal(),
-        WithPred(AfterScaleDownOldVRS, old_vrs_list_len(0)).into_local_state_pred(),
-        (Plain(Done), Plain(Error)).into_local_state_pred()
+        at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(0))],
+        at_step_or![Error, Done]
     );
     let zero = 0 as nat;
     // 0 | Error ~> idle
     or_leads_to_combine_and_equality!(
-        spec, (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(zero)), Plain(Error)).into_temporal_pred(controller_id, vd),
-        Plain(Error).into_temporal_pred(controller_id, vd),
-        WithPred(AfterScaleDownOldVRS, old_vrs_list_len(zero)).into_temporal_pred(controller_id, vd);
+        spec, lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(zero)), Error])),
+        lift_state(lift_local(controller_id, vd, at_step_or![Error])),
+        lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(zero))]));
         lift_state(reconcile_idle)
     );
     // 2.2 AfterScaleDownOldVRS && n ~> 0 | Error ~> idle
-    assert forall |n: nat| #![trigger (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd)]
-        spec.entails((WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd)
-                     .leads_to((WithPred(AfterScaleDownOldVRS, old_vrs_list_len(0)), Plain(Error)).into_temporal_pred(controller_id, vd))) by {
+    assert forall |n: nat| #![trigger dummy_trigger_n(n)]
+        spec.entails(lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error]))
+                     .leads_to(lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(0)), Error])))) by {
         // n | Error ~> n - 1 | Error
-        assert forall |n: nat| #![trigger (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd)]
-            n > 0 implies spec.entails((WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd)
-                                       .leads_to((WithPred(AfterScaleDownOldVRS, old_vrs_list_len((n - 1) as nat)), Plain(Error)).into_temporal_pred(controller_id, vd))) by {
+        assert forall |n: nat| #![trigger dummy_trigger_n(n)]
+            n > 0 implies spec.entails(lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error]))
+                                       .leads_to(lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n - 1)), Error])))) by {
             // Error ~> n - 1
             entails_implies_leads_to(spec,
-                Plain(Error).into_temporal_pred(controller_id, vd),
-                (WithPred(AfterScaleDownOldVRS, old_vrs_list_len((n - 1) as nat)), Plain(Error)).into_temporal_pred(controller_id, vd)
+                lift_state(lift_local(controller_id, vd, at_step_or![Error])),
+                lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n - 1)), Error]))
             );
             // n ~> n - 1
             lemma_from_pending_req_in_flight_or_resp_in_flight_at_step_to_at_step_and_pred(
@@ -120,138 +124,138 @@ ensures
             );
             cluster.lemma_from_some_state_to_arbitrary_next_state(
                 spec, controller_id, vd.marshal(),
-                WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)).into_local_state_pred(),
-                (WithPred(AfterScaleDownOldVRS, old_vrs_list_len((n - 1) as nat)), Plain(Error)).into_local_state_pred()
+                at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n))],
+                at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n - 1)), Error]
             );
             or_leads_to_combine_and_equality!(spec,
-                (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd),
-                Plain(Error).into_temporal_pred(controller_id, vd),
-                WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)).into_temporal_pred(controller_id, vd);
-                (WithPred(AfterScaleDownOldVRS, old_vrs_list_len((n - 1) as nat)), Plain(Error)).into_temporal_pred(controller_id, vd)
+                lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error])),
+                lift_state(lift_local(controller_id, vd, at_step_or![Error])),
+                lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n))]));
+                lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n - 1)), Error]))
             );
         }
         // n | Error ~> n - 1 | Error ~> 0 | Error
-        leads_to_rank_step_one(spec, |n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd));
+        leads_to_rank_step_one(spec, |n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error])));
         // n | Error ~> 0 | Error
         // TODO: investigate why we need |n|f(n) instead of f, could be a bug in verus
-        assert(spec.entails((|n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd))(n)
-                            .leads_to((|n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd))(0))));
+        assert(spec.entails((|n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error])))(n)
+                            .leads_to((|n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error])))(0))));
         // (n | Error() ~> (0 | Error) ~> reconcile_idle
         leads_to_trans_n!(spec,
-            (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd),
-            (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(0)), Plain(Error)).into_temporal_pred(controller_id, vd),
+            lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error])),
+            lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(0)), Error])),
             lift_state(reconcile_idle)
         );
     }
     // \A n | Error |= \E n | Error
     leads_to_exists_intro(spec,
-        |n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd),
-        (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(0)), Plain(Error)).into_temporal_pred(controller_id, vd)
+        |n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error])),
+        lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(0)), Error]))
     );
     // \E n | Error ~> idle
     leads_to_trans_n!(spec,
-        tla_exists(|n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd)),
-        (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(0)), Plain(Error)).into_temporal_pred(controller_id, vd),
+        tla_exists(|n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error]))),
+        lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(0)), Error])),
         lift_state(reconcile_idle)
     );
     // 2.3 AfterScaleDownOldVRS ~> AfterScaleDownOldVRS && \E n | Error ~> idle
-    assert(spec.entails(Plain(AfterScaleDownOldVRS).into_temporal_pred(controller_id, vd).leads_to(lift_state(reconcile_idle)))) by {
+    assert(spec.entails(lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS])).leads_to(lift_state(reconcile_idle)))) by {
         // p |= p(n)
-        assert forall |ex| #[trigger] Plain(AfterScaleDownOldVRS).into_temporal_pred(controller_id, vd).satisfied_by(ex)
-            implies tla_exists(|n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd))
+        assert forall |ex| #[trigger] lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS])).satisfied_by(ex)
+            implies tla_exists(|n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error])))
                     .satisfied_by(ex) by {
                 let s_marshalled = ex.head().ongoing_reconciles(controller_id)[vd.object_ref()].local_state;
                 let witness_n = VDeploymentReconcileState::unmarshal(s_marshalled).unwrap().old_vrs_list.len();
                 tla_exists_proved_by_witness(
-                    ex, |n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd),
+                    ex, |n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error])),
                     witness_n
                 );
             }
-        assert(spec.entails(Plain(AfterScaleDownOldVRS).into_temporal_pred(controller_id, vd).leads_to(lift_state(reconcile_idle)))) by {
+        assert(spec.entails(lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS])).leads_to(lift_state(reconcile_idle)))) by {
             // p ~> p(n)
-            entails_implies_leads_to(spec, Plain(AfterScaleDownOldVRS).into_temporal_pred(controller_id, vd),
-                tla_exists(|n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd)));
+            entails_implies_leads_to(spec, lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS])),
+                tla_exists(|n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error]))));
             // p ~> p(n) ~> idle
             leads_to_trans_n!(spec,
-                Plain(AfterScaleDownOldVRS).into_temporal_pred(controller_id, vd),
-                tla_exists(|n| (WithPred(AfterScaleDownOldVRS, old_vrs_list_len(n)), Plain(Error)).into_temporal_pred(controller_id, vd)),
-                lift_state(reconcile_idle)
+                lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS])),
+                tla_exists(|n| lift_state(lift_local(controller_id, vd, at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(n)), Error]))),
+                lift_state(reconcile_idle), 
             );
         }
     }
     // 3, AfterScaleNewVRS ~> idle.
     or_leads_to_combine_and_equality!(spec,
-        (Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_temporal_pred(controller_id, vd),
-        Plain(AfterScaleDownOldVRS).into_temporal_pred(controller_id, vd),
-        Plain(Error).into_temporal_pred(controller_id, vd),
-        Plain(Done).into_temporal_pred(controller_id, vd);
+        lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS, Error, Done])),
+        lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS])),
+        lift_state(lift_local(controller_id, vd, at_step_or![Error])),
+        lift_state(lift_local(controller_id, vd, at_step_or![Done]));
         lift_state(reconcile_idle)
     );
-    assert(forall |input_cr, resp_o, s| Plain(AfterScaleNewVRS).into_local_state_pred()(s)
-        ==> #[trigger] (Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_local_state_pred()
+    assert(forall |input_cr, resp_o, s| at_step_or![AfterScaleNewVRS](s)
+        ==> #[trigger] at_step_or![AfterScaleDownOldVRS, Error, Done].into_local_state_pred()
                        ((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     cluster.lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
         spec, controller_id, vd.marshal(),
-        Plain(AfterScaleNewVRS).into_local_state_pred(),
-        (Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_local_state_pred()
+        at_step_or![AfterScaleNewVRS],
+        at_step_or![AfterScaleDownOldVRS, Error, Done].into_local_state_pred()
     );
     // 4, AfterCreateNewVRS ~> idle
     or_leads_to_combine_and_equality!(spec,
-        (Plain(AfterScaleNewVRS), Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_temporal_pred(controller_id, vd),
-        (Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_temporal_pred(controller_id, vd),
-        Plain(AfterScaleNewVRS).into_temporal_pred(controller_id, vd);
+        at_step_or![AfterScaleNewVRS, AfterScaleDownOldVRS, Error, Done].into_temporal_pred(controller_id, vd),
+        at_step_or![AfterScaleDownOldVRS, Error, Done].into_temporal_pred(controller_id, vd),
+        lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleNewVRS]));
         lift_state(reconcile_idle)
     );
-    assert(forall |input_cr, resp_o, s| Plain(AfterCreateNewVRS).into_local_state_pred()(s)
-        ==> #[trigger] (Plain(AfterScaleNewVRS), Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_local_state_pred()
+    assert(forall |input_cr, resp_o, s| at_step_or![AfterCreateNewVRS](s)
+        ==> #[trigger] at_step_or![AfterScaleNewVRS, AfterScaleDownOldVRS, Error, Done].into_local_state_pred()
                        ((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     cluster.lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
         spec, controller_id, vd.marshal(),
-        Plain(AfterCreateNewVRS).into_local_state_pred(),
-        (Plain(AfterScaleNewVRS), Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_local_state_pred()
+        at_step_or![AfterCreateNewVRS],
+        at_step_or![AfterScaleNewVRS, AfterScaleDownOldVRS, Error, Done].into_local_state_pred()
     );
     // 5, AfterListVRS ~> idle
     or_leads_to_combine_and_equality!(spec,
-        (Plain(AfterCreateNewVRS), Plain(AfterScaleNewVRS), Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_temporal_pred(controller_id, vd),
-        (Plain(AfterScaleNewVRS), Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_temporal_pred(controller_id, vd),
-        Plain(AfterCreateNewVRS).into_temporal_pred(controller_id, vd);
+        at_step_or![AfterCreateNewVRS, AfterScaleNewVRS, AfterScaleDownOldVRS, Error, Done].into_temporal_pred(controller_id, vd),
+        at_step_or![AfterScaleNewVRS, AfterScaleDownOldVRS, Error, Done].into_temporal_pred(controller_id, vd),
+        lift_state(lift_local(controller_id, vd, at_step_or![AfterCreateNewVRS]));
         lift_state(reconcile_idle)
     );
-    assert(forall |input_cr, resp_o, s| Plain(AfterListVRS).into_local_state_pred()(s)
-        ==> #[trigger] (Plain(AfterCreateNewVRS), Plain(AfterScaleNewVRS), Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_local_state_pred()
+    assert(forall |input_cr, resp_o, s| at_step_or![AfterListVRS](s)
+        ==> #[trigger] at_step_or![AfterCreateNewVRS, AfterScaleNewVRS, AfterScaleDownOldVRS, Error, Done].into_local_state_pred()
                        ((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     cluster.lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
         spec, controller_id, vd.marshal(),
-        Plain(AfterListVRS).into_local_state_pred(),
-        (Plain(AfterCreateNewVRS), Plain(AfterScaleNewVRS), Plain(AfterScaleDownOldVRS), Plain(Error), Plain(Done)).into_local_state_pred()
+        at_step_or![AfterListVRS],
+        at_step_or![AfterCreateNewVRS, AfterScaleNewVRS, AfterScaleDownOldVRS, Error, Done].into_local_state_pred()
     );
     // 6, Init ~> idle
     cluster.lemma_from_init_state_to_next_state_to_reconcile_idle(
         spec, controller_id, vd.marshal(),
-        Plain(Init).into_local_state_pred(),
-        Plain(AfterListVRS).into_local_state_pred()
+        at_step_or![Init],
+        at_step_or![AfterListVRS]
     );
     // Finally, True ~> idle
-    let bundle = Plain(Init).into_temporal_pred(controller_id, vd)
-        .or(Plain(AfterListVRS).into_temporal_pred(controller_id, vd))
-        .or(Plain(AfterCreateNewVRS).into_temporal_pred(controller_id, vd))
-        .or(Plain(AfterScaleNewVRS).into_temporal_pred(controller_id, vd))
-        .or(Plain(AfterScaleDownOldVRS).into_temporal_pred(controller_id, vd))
-        .or(Plain(Done).into_temporal_pred(controller_id, vd))
-        .or(Plain(Error).into_temporal_pred(controller_id, vd))
+    let bundle = lift_state(lift_local(controller_id, vd, at_step_or![Init]))
+        .or(lift_state(lift_local(controller_id, vd, at_step_or![AfterListVRS])))
+        .or(lift_state(lift_local(controller_id, vd, at_step_or![AfterCreateNewVRS])))
+        .or(lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleNewVRS])))
+        .or(lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS])))
+        .or(lift_state(lift_local(controller_id, vd, at_step_or![Done])))
+        .or(lift_state(lift_local(controller_id, vd, at_step_or![Error])))
         .or(lift_state(reconcile_idle));
     assert(forall |ex| true_pred::<ClusterState>().satisfied_by(ex) ==> bundle.satisfied_by(ex));
     temp_pred_equality(bundle, true_pred::<ClusterState>());
     or_leads_to_combine_and_equality!(spec,
         true_pred::<ClusterState>(),
         lift_state(reconcile_idle),
-        Plain(Init).into_temporal_pred(controller_id, vd),
-        Plain(AfterListVRS).into_temporal_pred(controller_id, vd),
-        Plain(AfterCreateNewVRS).into_temporal_pred(controller_id, vd),
-        Plain(AfterScaleNewVRS).into_temporal_pred(controller_id, vd),
-        Plain(AfterScaleDownOldVRS).into_temporal_pred(controller_id, vd),
-        Plain(Done).into_temporal_pred(controller_id, vd),
-        Plain(Error).into_temporal_pred(controller_id, vd);
+        lift_state(lift_local(controller_id, vd, at_step_or![Init])),
+        lift_state(lift_local(controller_id, vd, at_step_or![AfterListVRS])),
+        lift_state(lift_local(controller_id, vd, at_step_or![AfterCreateNewVRS])),
+        lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleNewVRS])),
+        lift_state(lift_local(controller_id, vd, at_step_or![AfterScaleDownOldVRS])),
+        lift_state(lift_local(controller_id, vd, at_step_or![Done])),
+        lift_state(lift_local(controller_id, vd, at_step_or![Error]));
         lift_state(reconcile_idle)
     );
 }
@@ -263,18 +267,18 @@ pub proof fn lemma_from_pending_req_in_flight_or_resp_in_flight_at_step_to_at_st
 )
 requires
     spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
-        controller_id, vd.object_ref(), Plain(step).into_local_state_pred()
+        controller_id, vd.object_ref(), at_step_or![step]
     )))),
 ensures
     spec.entails(always(lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
-        controller_id, vd.object_ref(), WithPred(step, pred).into_local_state_pred()
+        controller_id, vd.object_ref(), at_step_or![(step, pred)]
     )))),
 {
     let pre = lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
-        controller_id, vd.object_ref(), Plain(step).into_local_state_pred()
+        controller_id, vd.object_ref(), at_step_or![step]
     ));
     let post = lift_state(Cluster::pending_req_in_flight_or_resp_in_flight_at_reconcile_state(
-        controller_id, vd.object_ref(), WithPred(step, pred).into_local_state_pred()
+        controller_id, vd.object_ref(), at_step_or![(step, pred)]
     ));
     assert forall |ex| #![auto] spec.satisfied_by(ex) && spec.entails(always(pre)) implies always(post).satisfied_by(ex) by {
         assert(forall |ex| #[trigger] spec.implies(always(pre)).satisfied_by(ex));

--- a/src/v2/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/v2/controllers/vdeployment_controller/proof/predicate.rs
@@ -14,383 +14,56 @@ use vstd::prelude::*;
 
 verus! {
 
-// Represents a reconcile step (optionally with a predicate) for use in spec functions.
-//
-// Usage:
-//
-// Step-only case
-// let step1 = StepCase::Plain(Step1);
-//
-// Step with an additional predicate over VDeploymentReconcileState
-// let step2 = StepCase::WithPred(Step2, |vds: VDeploymentReconcileState| vds.some_field == 5);
-//
-// Convert into a predicate over ReconcileLocalState (used in Cluster::at_expected_reconcile_states)
-// let pred_local: spec_fn(ReconcileLocalState) -> bool = step1.into_local_state_pred();
-//
-// Convert into a predicate over ClusterState
-// let pred_cluster: spec_fn(ClusterState) -> bool = step2.into_cluster_state_pred(controller_id, vd);
-//
-// Convert into a temporal predicate over ClusterState (for use in TempPred context)
-// let temp_pred: TempPred<ClusterState> = step1.into_temporal_pred(controller_id, vd);
-pub enum StepCase {
-    Plain(VDeploymentReconcileStepView),
-    WithPred(VDeploymentReconcileStepView, spec_fn(VDeploymentReconcileState) -> bool),
+#[macro_export]
+macro_rules! at_step_internal_or {
+    ($vds:expr, ($step:expr, $pred:expr)) => {
+        $vds.reconcile_step.eq_step($step) && $pred($vds)
+    };
+
+    // eq_step is the tricky workaround for error, see src/v2/controllers/vdeployment_controller/trusted/step.rs
+    ($vds:expr, $step:expr) => {
+        $vds.reconcile_step.eq_step($step)
+    };
+
+    ($vds:expr, $head:tt, $($tail:tt)+) => {
+        at_step_internal_or!($vds, $head) || at_step_internal_or!($vds, $($tail)+)
+    };
 }
 
-pub trait IntoSpec: Sized {
-    spec fn into_local_state_pred(self) -> spec_fn(ReconcileLocalState) -> bool;
-    spec fn into_cluster_state_pred(self, controller_id: int, vd: VDeploymentView) -> spec_fn(ClusterState) -> bool;
-    spec fn into_temporal_pred(self, controller_id: int, vd: VDeploymentView) -> TempPred<ClusterState>;
-    broadcast proof fn lemma_cluster_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred());
-    broadcast proof fn lemma_temporal_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(self.into_cluster_state_pred(controller_id, vd)),
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(
-                Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-            );
+// usage: at_step![step,*]
+// step_or_pred = step | (step, pred)
+#[macro_export]
+macro_rules! at_step_or {
+    [ $($tokens:tt)+ ] => {
+        closure_to_fn_spec(|s: ReconcileLocalState| {
+            let vds = VDeploymentReconcileState::unmarshal(s).unwrap();
+            at_step_internal_or!(vds, $($tokens)+)
+        })
+    };
 }
 
-pub broadcast group into_spec_all {
-    IntoSpec::lemma_cluster_equiv,
-    IntoSpec::lemma_temporal_equiv,
+// usage: lift_local(controller_id, vd, at_step_or![step_or_pred+])
+pub open spec fn lift_local(controller_id: int, vd: VDeploymentView, step_pred: spec_fn(ReconcileLocalState) -> bool) -> StatePred<ClusterState> {
+    Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), step_pred)
 }
 
-impl IntoSpec for StepCase {
-    open spec fn into_local_state_pred(self) -> spec_fn(ReconcileLocalState) -> bool {
-        |s: ReconcileLocalState| {
-            // VDeploymentReconcileState::marshal_preserves_integrity() may be called to prove
-            let st = VDeploymentReconcileState::unmarshal(s).unwrap();
-            match self {
-                StepCase::Plain(step) => st.reconcile_step == step,
-                StepCase::WithPred(step, pred) => st.reconcile_step == step && pred(st),
-            }
-        }
-    }
-    open spec fn into_cluster_state_pred(self, controller_id: int, vd: VDeploymentView) -> spec_fn(ClusterState) -> bool {
-        |s: ClusterState| {
-            Cluster::at_expected_reconcile_states(
-                controller_id,
-                vd.object_ref(),
-                self.into_local_state_pred(),
-            )(s)
-        }
-    }
-    open spec fn into_temporal_pred(self, controller_id: int, vd: VDeploymentView) -> TempPred<ClusterState> {
-        lift_state(self.into_cluster_state_pred(controller_id, vd))
-    }
-    broadcast proof fn lemma_cluster_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-    {
-        assert(self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred()));
-    }
-    broadcast proof fn lemma_temporal_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(self.into_cluster_state_pred(controller_id, vd)),
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(
-                Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-            )
-    {
-        self.lemma_cluster_equiv(controller_id, vd);
-    }
+// hacky workaround for type conversion bug: error[E0605]: non-primitive cast: `{integer}` as `builtin::nat`
+#[macro_export]
+macro_rules! nat0 {
+    () => {
+        spec_literal_nat("0")
+    };
 }
 
-// TODO: add transitivity lemma
-impl IntoSpec for (StepCase, StepCase) {
-    open spec fn into_local_state_pred(self) -> spec_fn(ReconcileLocalState) -> bool {
-        let (s1, s2) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        |s| f1(s) || f2(s)
-    }
-    // compose s1 and s1 at ReconcileLocalState level
-    open spec fn into_cluster_state_pred(self, controller_id: int, vd: VDeploymentView) -> spec_fn(ClusterState) -> bool {
-        let (s1, s2) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        |s: ClusterState| {
-            Cluster::at_expected_reconcile_states(
-                controller_id,
-                vd.object_ref(),
-                |ls: ReconcileLocalState| f1(ls) || f2(ls),
-            )(s)
-        }
-    }
-    open spec fn into_temporal_pred(self, controller_id: int, vd: VDeploymentView) -> TempPred<ClusterState> {
-        lift_state(self.into_cluster_state_pred(controller_id, vd))
-    }
-    broadcast proof fn lemma_cluster_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-    {
-        assert(self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred()));
-    }
-    broadcast proof fn lemma_temporal_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(self.into_cluster_state_pred(controller_id, vd)),
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(
-                Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-            )
-    {
-        self.lemma_cluster_equiv(controller_id, vd);
-    }
+#[macro_export]
+macro_rules! nat1 {
+    () => {
+        spec_literal_nat("1")
+    };
 }
 
-impl IntoSpec for (StepCase, StepCase, StepCase) {
-    open spec fn into_local_state_pred(self) -> spec_fn(ReconcileLocalState) -> bool {
-        let (s1, s2, s3) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        let f3 = s3.into_local_state_pred();
-        |s| f1(s) || f2(s) || f3(s)
-    }
-    open spec fn into_cluster_state_pred(self, controller_id: int, vd: VDeploymentView) -> spec_fn(ClusterState) -> bool {
-        let (s1, s2, s3) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        let f3 = s3.into_local_state_pred();
-        |s: ClusterState| {
-            Cluster::at_expected_reconcile_states(
-                controller_id,
-                vd.object_ref(),
-                |ls: ReconcileLocalState| f1(ls) || f2(ls) || f3(ls),
-            )(s)
-        }
-    }
-    open spec fn into_temporal_pred(self, controller_id: int, vd: VDeploymentView) -> TempPred<ClusterState> {
-        lift_state(self.into_cluster_state_pred(controller_id, vd))
-    }
-    broadcast proof fn lemma_cluster_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-    {
-        assert(self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred()));
-    }
-    broadcast proof fn lemma_temporal_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(self.into_cluster_state_pred(controller_id, vd)),
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(
-                Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-            )
-    {
-        self.lemma_cluster_equiv(controller_id, vd);
-    }
-}
-
-impl IntoSpec for (StepCase, StepCase, StepCase, StepCase) {
-    open spec fn into_local_state_pred(self) -> spec_fn(ReconcileLocalState) -> bool {
-        let (s1, s2, s3, s4) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        let f3 = s3.into_local_state_pred();
-        let f4 = s4.into_local_state_pred();
-        |s| f1(s) || f2(s) || f3(s) || f4(s)
-    }
-    open spec fn into_cluster_state_pred(self, controller_id: int, vd: VDeploymentView) -> spec_fn(ClusterState) -> bool {
-        let (s1, s2, s3, s4) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        let f3 = s3.into_local_state_pred();
-        let f4 = s4.into_local_state_pred();
-        |s: ClusterState| {
-            Cluster::at_expected_reconcile_states(
-                controller_id,
-                vd.object_ref(),
-                |ls: ReconcileLocalState| f1(ls) || f2(ls) || f3(ls) || f4(ls),
-            )(s)
-        }
-    }
-    open spec fn into_temporal_pred(self, controller_id: int, vd: VDeploymentView) -> TempPred<ClusterState> {
-        lift_state(self.into_cluster_state_pred(controller_id, vd))
-    }
-    broadcast proof fn lemma_cluster_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-    {
-        assert(self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred()));
-    }
-    broadcast proof fn lemma_temporal_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(self.into_cluster_state_pred(controller_id, vd)),
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(
-                Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-            )
-    {
-        self.lemma_cluster_equiv(controller_id, vd);
-    }
-}
-
-impl IntoSpec for (StepCase, StepCase, StepCase, StepCase, StepCase) {
-    open spec fn into_local_state_pred(self) -> spec_fn(ReconcileLocalState) -> bool {
-        let (s1, s2, s3, s4, s5) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        let f3 = s3.into_local_state_pred();
-        let f4 = s4.into_local_state_pred();
-        let f5 = s5.into_local_state_pred();
-        |s| f1(s) || f2(s) || f3(s) || f4(s) || f5(s)
-    }
-    open spec fn into_cluster_state_pred(self, controller_id: int, vd: VDeploymentView) -> spec_fn(ClusterState) -> bool {
-        let (s1, s2, s3, s4, s5) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        let f3 = s3.into_local_state_pred();
-        let f4 = s4.into_local_state_pred();
-        let f5 = s5.into_local_state_pred();
-        |s: ClusterState| {
-            Cluster::at_expected_reconcile_states(
-                controller_id,
-                vd.object_ref(),
-                |ls: ReconcileLocalState| f1(ls) || f2(ls) || f3(ls) || f4(ls) || f5(ls),
-            )(s)
-        }
-    }
-    open spec fn into_temporal_pred(self, controller_id: int, vd: VDeploymentView) -> TempPred<ClusterState> {
-        lift_state(self.into_cluster_state_pred(controller_id, vd))
-    }
-    broadcast proof fn lemma_cluster_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-    {
-        assert(self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred()));
-    }
-    broadcast proof fn lemma_temporal_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(self.into_cluster_state_pred(controller_id, vd)),
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(
-                Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-            )
-    {
-        self.lemma_cluster_equiv(controller_id, vd);
-    }
-}
-
-impl IntoSpec for (StepCase, StepCase, StepCase, StepCase, StepCase, StepCase) {
-    open spec fn into_local_state_pred(self) -> spec_fn(ReconcileLocalState) -> bool {
-        let (s1, s2, s3, s4, s5, s6) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        let f3 = s3.into_local_state_pred();
-        let f4 = s4.into_local_state_pred();
-        let f5 = s5.into_local_state_pred();
-        let f6 = s6.into_local_state_pred();
-        |s| f1(s) || f2(s) || f3(s) || f4(s) || f5(s) || f6(s)
-    }
-    open spec fn into_cluster_state_pred(self, controller_id: int, vd: VDeploymentView) -> spec_fn(ClusterState) -> bool {
-        let (s1, s2, s3, s4, s5, s6) = self;
-        let f1 = s1.into_local_state_pred();
-        let f2 = s2.into_local_state_pred();
-        let f3 = s3.into_local_state_pred();
-        let f4 = s4.into_local_state_pred();
-        let f5 = s5.into_local_state_pred();
-        let f6 = s6.into_local_state_pred();
-        |s: ClusterState| {
-            Cluster::at_expected_reconcile_states(
-                controller_id,
-                vd.object_ref(),
-                |ls: ReconcileLocalState| f1(ls) || f2(ls) || f3(ls) || f4(ls) || f5(ls) || f6(ls),
-            )(s)
-        }
-    }
-    open spec fn into_temporal_pred(self, controller_id: int, vd: VDeploymentView) -> TempPred<ClusterState> {
-        lift_state(self.into_cluster_state_pred(controller_id, vd))
-    }
-    broadcast proof fn lemma_cluster_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-    {
-        assert(self.into_cluster_state_pred(controller_id, vd) == 
-            Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred()));
-    }
-    broadcast proof fn lemma_temporal_equiv(self, controller_id: int, vd: VDeploymentView)
-        ensures
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(self.into_cluster_state_pred(controller_id, vd)),
-            #[trigger] self.into_temporal_pred(controller_id, vd) == lift_state(
-                Cluster::at_expected_reconcile_states(controller_id, vd.object_ref(), self.into_local_state_pred())
-            )
-    {
-        self.lemma_cluster_equiv(controller_id, vd);
-    }
-}
-
-// These macros are abandoned due to the bug in verus, see verus/discussions/1726
-// If macros work better, we can switch back
-// eq_step is the tricky workaround for error, see src/v2/controllers/vdeployment_controller/trusted/step.rs
-//#[macro_export]
-//macro_rules! at_step_internal {
-//    ($vds:expr, ($step:expr, $pred:expr)) => {
-//        $vds.reconcile_step.eq_step($step) && $pred($vds)
-//    };
-//
-//    ($vds:expr, $step:expr) => {
-//        $vds.reconcile_step.eq_step($step)
-//    };
-//
-//    ($vds:expr, $head:tt, $($tail:tt)+) => {
-//        at_step_internal!($vds, $head) || at_step_internal!($vds, $($tail)+)
-//    };
-//}
-//
-//// usage: at_step!(step,*)
-//// step* = step | (step, pred)
-//#[macro_export]
-//macro_rules! at_step {
-//    ( $($tokens:tt)+ ) => {
-//        closure_to_fn_spec(|s: ReconcileLocalState| {
-//            let vds = VDeploymentReconcileState::unmarshal(s).unwrap();
-//            at_step_internal!(vds, $($tokens)+)
-//        })
-//    };
-//}
-//
-//// usage: cluster_at_step!(step,*)
-//#[macro_export]
-//macro_rules! cluster_at_step {
-//    ($controller_id:expr, $vd:expr, $($tokens:tt)+ ) => {
-//        Cluster::at_expected_reconcile_states($controller_id, $vd.object_ref(), at_step!($($tokens)+))
-//    }
-//}
-//
-//// usage: temp_at_step!(step,*)
-//#[macro_export]
-//macro_rules! temp_at_step {
-//    ($controller_id:expr, $vd:expr, $($tokens:tt)+ ) => {
-//        lift_state(cluster_at_step!($controller_id, $vd, $($tokens)+))
-//    }
-//}
-//
-//// hacky workaround for type conversion bug: error[E0605]: non-primitive cast: `{integer}` as `builtin::nat`
-//#[macro_export]
-//macro_rules! nat0 {
-//    () => {
-//        spec_literal_nat("0")
-//    };
-//}
-//
-//#[macro_export]
-//macro_rules! nat1 {
-//    () => {
-//        spec_literal_nat("1")
-//    };
-//}
-//pub use nat0;
-//pub use nat1;
-//pub use at_step_internal;
-//pub use at_step;
-//pub use cluster_at_step;
-//pub use temp_at_step;
+pub use nat0;
+pub use nat1;
+pub use at_step_internal_or;
+pub use at_step_or;
 }

--- a/src/v2/controllers/vdeployment_controller/trusted/step.rs
+++ b/src/v2/controllers/vdeployment_controller/trusted/step.rs
@@ -57,8 +57,8 @@ pub enum VDeploymentReconcileStepView {
     Error,
 }
 
-impl VDeploymentReconcileStep {
-    open spec fn eq_step(self, other: VDeploymentReconcileStep) -> bool {
+impl VDeploymentReconcileStepView {
+    pub open spec fn eq_step(self, other: VDeploymentReconcileStepView) -> bool {
         self == other
     }
 }

--- a/src/v2/controllers/vdeployment_controller/trusted/step.rs
+++ b/src/v2/controllers/vdeployment_controller/trusted/step.rs
@@ -46,7 +46,6 @@ impl View for VDeploymentReconcileStep {
 }
 
 #[is_variant]
-#[derive(PartialEq)]
 pub enum VDeploymentReconcileStepView {
     Init,
     AfterListVRS,

--- a/src/v2/controllers/vdeployment_controller/trusted/step.rs
+++ b/src/v2/controllers/vdeployment_controller/trusted/step.rs
@@ -46,6 +46,7 @@ impl View for VDeploymentReconcileStep {
 }
 
 #[is_variant]
+#[derive(PartialEq)]
 pub enum VDeploymentReconcileStepView {
     Init,
     AfterListVRS,
@@ -54,6 +55,12 @@ pub enum VDeploymentReconcileStepView {
     AfterScaleDownOldVRS,
     Done,
     Error,
+}
+
+impl VDeploymentReconcileStep {
+    open spec fn eq_step(self, other: VDeploymentReconcileStep) -> bool {
+        self == other
+    }
 }
 
 }

--- a/src/v2/controllers/vdeployment_controller/trusted/step.rs
+++ b/src/v2/controllers/vdeployment_controller/trusted/step.rs
@@ -56,6 +56,10 @@ pub enum VDeploymentReconcileStepView {
     Error,
 }
 
+// eq_step is the tricky workaround for error:
+// The verifier does not yet support the following Rust feature: ==/!= for non smt equality types:
+// (The type is not available in log, I hacked verus)
+// Datatype(Path(Path(Some("v2_vdeployment_controller"), ["vdeployment_controller" :: "trusted" :: "step" :: "VDeploymentReconcileStepView"])), [], [])
 impl VDeploymentReconcileStepView {
     pub open spec fn eq_step(self, other: VDeploymentReconcileStepView) -> bool {
         self == other


### PR DESCRIPTION
Follow up of https://github.com/anvil-verifier/anvil/pull/644
Managed to use macro instead of trait, made several compromising:

- Use dummy trigger
- Use wrapper of macro as trigger
- Use trigger at inner layer
- But again it works and proof isn't slow