### PR TITLE
Fix WF1 proofs on 'top' (liveness) side of Bridge Invariant

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/predicate.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_invariants/predicate.rs
@@ -91,7 +91,7 @@ pub open spec fn no_other_pending_get_then_update_request_interferes_with_vrs_re
             // a vrs-owned pod.
             &&& req.owner_ref.controller.is_Some()
             &&& req.owner_ref.controller.get_Some_0()
-            &&& req.owner_ref.kind != VReplicaSetView::kind()
+            &&& req.owner_ref != vrs.controller_owner_ref()
             // Prevents 2): where any message not from our specific vrs updates 
             // pods so they become owned by another VReplicaSet.
             &&& (req.obj.metadata.owner_references.is_Some() ==>
@@ -129,7 +129,7 @@ pub open spec fn no_other_pending_get_then_delete_request_interferes_with_vrs_re
         req.key.kind == Kind::PodKind ==> {
             &&& req.owner_ref.controller.is_Some()
             &&& req.owner_ref.controller.get_Some_0()
-            &&& req.owner_ref.kind != VReplicaSetView::kind()
+            &&& req.owner_ref != vrs.controller_owner_ref()
         }
     }
 }

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
@@ -18,6 +18,234 @@ use vstd::{map::*, map_lib::*, prelude::*};
 
 verus! {
 
+// TODO: Prove this
+#[verifier(external_body)]
+pub proof fn lemma_api_request_other_than_pending_req_msg_maintains_matching_pods(
+    s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
+    msg: Message,
+)
+    requires
+        cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
+        Cluster::each_object_in_etcd_is_weakly_well_formed()(s),
+        cluster.each_builtin_object_in_etcd_is_well_formed()(s),
+        cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s),
+        cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s),
+        Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s),
+        helper_invariants::no_other_pending_request_interferes_with_vrs_reconcile(vrs, controller_id)(s),
+        forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)
+            ==> #[trigger] vrs_rely(other_id)(s),
+        !Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg),
+    ensures
+        matching_pods(vrs, s.resources()) == matching_pods(vrs, s_prime.resources()),
+{}
+
+// TODO: Prove this
+#[verifier(external_body)]
+pub proof fn lemma_list_pods_request_returns_ok_list_resp_containing_matching_pods(
+    s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
+    msg: Message,
+) -> (resp_msg: Message)
+    requires
+        cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
+        req_msg_is_list_pods_req(vrs, msg),
+        Cluster::each_object_in_etcd_is_weakly_well_formed()(s),
+        cluster.each_builtin_object_in_etcd_is_well_formed()(s),
+        cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s),
+        cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s),
+    ensures
+        resp_msg == handle_list_request_msg(msg, s.api_server).1,
+        resp_msg_is_ok_list_resp_containing_matching_pods(s_prime, vrs, resp_msg),
+{
+    // required to type-check
+    return handle_list_request_msg(msg, s.api_server).1;
+
+    // proof hint in comment
+    // let resp_msg = handle_list_request_msg(req_msg, s.api_server).1;
+    //     let resp_objs = resp_msg.content.get_list_response().res.unwrap();
+    //     assert forall |o: DynamicObjectView| #![auto]
+    //     pre(s) && matching_pods(vrs, s_prime.resources()).contains(o)
+    //     implies resp_objs.to_set().contains(o) by {
+    //         // Tricky reasoning about .to_seq
+    //         let selector = |o: DynamicObjectView| {
+    //             &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
+    //             &&& o.object_ref().kind == PodView::kind()
+    //         };
+    //         let selected_elements = s.resources().values().filter(selector);
+    //         assert(selected_elements.contains(o));
+    //         lemma_values_finite(s.resources());
+    //         finite_set_to_seq_contains_all_set_elements(selected_elements);
+    //     }
+
+    //     assert forall |o: DynamicObjectView| #![auto]
+    //     pre(s) && resp_objs.contains(o)
+    //     implies !PodView::unmarshal(o).is_err()
+    //             && o.metadata.namespace == vrs.metadata.namespace by {
+    //         // Tricky reasoning about .to_seq
+    //         let selector = |o: DynamicObjectView| {
+    //             &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
+    //             &&& o.object_ref().kind == PodView::kind()
+    //         };
+    //         let selected_elements = s.resources().values().filter(selector);
+    //         lemma_values_finite(s.resources());
+    //         finite_set_to_seq_contains_all_set_elements(selected_elements);
+    //         assert(resp_objs == selected_elements.to_seq());
+    //         assert(selected_elements.contains(o));
+    //     }
+    //     seq_pred_false_on_all_elements_is_equivalent_to_empty_filter(resp_objs, |o: DynamicObjectView| PodView::unmarshal(o).is_err());
+
+    //     // TODO: Shorten up this proof.
+    //     assert_by(objects_to_pods(resp_objs).unwrap().no_duplicates(), {
+    //         let selector = |o: DynamicObjectView| {
+    //             &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
+    //             &&& o.object_ref().kind == PodView::kind()
+    //         };
+    //         let selected_elements = s.resources().values().filter(selector);
+    //         lemma_values_finite(s.resources());
+    //         finite_set_to_seq_has_no_duplicates(selected_elements);
+    //         let selected_elements_seq = selected_elements.to_seq();
+    //         let pods_seq = objects_to_pods(selected_elements_seq).unwrap();
+    //         assert(selected_elements_seq.no_duplicates());
+
+    //         assert forall |x: DynamicObjectView, y: DynamicObjectView| #![auto]
+    //             x != y
+    //             && selected_elements_seq.contains(x)
+    //             && selected_elements_seq.contains(y) implies x.object_ref() != y.object_ref() by {
+    //             finite_set_to_seq_contains_all_set_elements(selected_elements);
+    //             assert(selected_elements.contains(x));
+    //             assert(selected_elements.contains(y));
+    //         }
+
+    //         let lem = forall |x: DynamicObjectView, y: DynamicObjectView| #![auto]
+    //             x != y
+    //             && selected_elements_seq.contains(x)
+    //             && selected_elements_seq.contains(y) ==> x.object_ref() != y.object_ref();
+
+    //         assert forall |i: int, j: int| #![auto]
+    //             0 <= i && i < pods_seq.len() && (0 <= j && j < pods_seq.len()) && !(i == j)
+    //             && objects_to_pods(selected_elements_seq).is_Some()
+    //             && lem
+    //             implies pods_seq[i] != pods_seq[j] by {
+    //             let o1 = selected_elements_seq[i];
+    //             let o2 = selected_elements_seq[j];
+    //             assert(o1.object_ref() != o2.object_ref());
+    //             PodView::marshal_preserves_integrity();
+    //             seq_pred_false_on_all_elements_is_equivalent_to_empty_filter(selected_elements_seq, |o: DynamicObjectView| PodView::unmarshal(o).is_err());
+    //             assert(selected_elements_seq.filter(|o: DynamicObjectView| PodView::unmarshal(o).is_err()).len() == 0);
+    //             assert(selected_elements_seq.contains(o1));
+    //             assert(selected_elements_seq.contains(o2));
+    //         }
+
+    //         assert(pods_seq.no_duplicates());
+    //     });
+    //     assert(matching_pods(vrs, s.resources()) == resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set() && resp_objs.no_duplicates()) by {
+    //         // reveal API server spec
+    //         let selector = |o: DynamicObjectView| {
+    //             &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
+    //             &&& o.object_ref().kind == PodView::kind()
+    //         };
+    //         assert(resp_objs == s.resources().values().filter(selector).to_seq());
+    //         // consistency of no_duplicates
+    //         lemma_values_finite(s.resources());
+    //         finite_set_to_finite_filtered_set(s.resources().values(), selector);
+    //         finite_set_to_seq_has_no_duplicates(s.resources().values().filter(selector));
+    //         assert(resp_objs.no_duplicates());
+
+    //         // reveal matching_pods logic
+    //         let matched_pods = matching_pods(vrs, s.resources());
+    //         assert(matched_pods =~= s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj))) by {
+    //             assert forall |obj| s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) implies matched_pods.contains(obj) by {
+    //                 assert(owned_selector_match_is(vrs, obj));
+    //                 assert(s.resources().contains_key(obj.object_ref()) && s.resources()[obj.object_ref()] == obj);
+    //                 assert(matched_pods.contains(obj));                                                
+    //             }
+    //             assert forall |obj| matched_pods.contains(obj) implies s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) by {
+    //                 assert(s.resources().contains_key(obj.object_ref()));
+    //                 assert(owned_selector_match_is(vrs, obj));
+    //             }
+    //             // optional if antisymmetry_of_set_equality is imported
+    //             assert(forall |obj| matched_pods.contains(obj) == s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj));
+    //         }
+    //         assert(s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)) == matching_pods(vrs, s.resources()));
+            
+    //         // get rid of DS conversion, basically babysitting Verus
+    //         assert(resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set() =~= s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj))) by {
+    //             assert(resp_objs == s.resources().values().filter(selector).to_seq());
+    //             assert((|obj : DynamicObjectView| owned_selector_match_is(vrs, obj) && selector(obj)) =~= (|obj : DynamicObjectView| owned_selector_match_is(vrs, obj)));
+    //             seq_filter_preserves_no_duplicates(resp_objs, |obj| owned_selector_match_is(vrs, obj));
+    //             seq_filter_is_a_subset_of_original_seq(resp_objs, |obj| owned_selector_match_is(vrs, obj));
+    //             finite_set_to_seq_contains_all_set_elements(s.resources().values().filter(selector));
+    //             finite_set_to_seq_contains_all_set_elements(s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)));
+    //             assert(forall |obj| resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set().contains(obj) ==> {
+    //                 &&& resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj)
+    //                 &&& #[trigger] resp_objs.contains(obj)
+    //                 &&& s.resources().values().filter(selector).to_seq().contains(obj)
+    //                 &&& s.resources().values().filter(selector).contains(obj)
+    //                 &&& s.resources().values().contains(obj)
+    //                 &&& #[trigger] owned_selector_match_is(vrs, obj)
+    //                 &&& s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj)
+    //             });
+    //             assert(forall |obj| s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) ==> {
+    //                 &&& s.resources().values().contains(obj)
+    //                 &&& owned_selector_match_is(vrs, obj)
+    //                 &&& #[trigger] selector(obj)
+    //                 &&& s.resources().values().filter(selector).contains(obj)
+    //                 &&& s.resources().values().filter(selector).to_seq().contains(obj)
+    //                 &&& resp_objs.contains(obj)
+    //                 &&& resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj)
+    //                 &&& resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set().contains(obj)
+    //             });
+    //         }
+    //     }
+    //     assert({
+    //         &&& s_prime.in_flight().contains(resp_msg)
+    //         &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+    //         &&& resp_msg.content.get_list_response().res.is_Ok()
+    //         &&& {
+    //             let resp_objs = resp_msg.content.get_list_response().res.unwrap();
+    //             //&&& resp_objs.no_duplicates()
+    //             &&& objects_to_pods(resp_objs).is_Some()
+    //             &&& objects_to_pods(resp_objs).unwrap().no_duplicates()
+    //             &&& resp_objs.no_duplicates()
+    //             &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).is_Ok()
+    //             &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).unwrap().metadata.namespace.is_Some()
+    //             &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).unwrap().metadata.namespace == vrs.metadata.namespace
+    //         }
+    //     });
+    //     assert(post(s_prime));
+}
+
+// TODO: Prove this
+#[verifier(external_body)]
+pub proof fn lemma_create_matching_pod_request_adds_matching_pod_and_returns_ok(
+    s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
+    msg: Message,
+) -> (resp_msg: Message)
+    requires
+        cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
+        req_msg_is_create_matching_pod_req(vrs, msg),
+        Cluster::each_object_in_etcd_is_weakly_well_formed()(s),
+        cluster.each_builtin_object_in_etcd_is_well_formed()(s),
+        cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s),
+        cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s),
+        Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s),
+        helper_invariants::no_other_pending_request_interferes_with_vrs_reconcile(vrs, controller_id)(s),
+        forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)
+            ==> #[trigger] vrs_rely(other_id)(s),
+        cluster.type_is_installed_in_cluster::<VReplicaSetView>(),
+    ensures
+        resp_msg == handle_create_request_msg(cluster.installed_types, msg, s.api_server).1,
+        resp_msg.content.get_create_response().res.is_Ok(),
+        matching_pods(vrs, s.resources()).insert(
+            new_obj_in_etcd(s, cluster, make_pod(vrs).marshal())
+        ) == matching_pods(vrs, s_prime.resources()),
+        // should be an obvious corollary of `generated_name_is_unique`.
+        matching_pods(vrs, s.resources()).len() + 1 == matching_pods(vrs, s_prime.resources()).len(),
+{
+    return handle_create_request_msg(cluster.installed_types, msg, s.api_server).1;
+}
+
+// OBSOLETE FUNCTIONS ------ Remove as others get used.
+
 // TODO: broken by changed ESR spec, needs new set-based (rather than map-based) argument.
 #[verifier(external_body)]
 pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_pods(
@@ -30,14 +258,7 @@ pub proof fn lemma_api_request_outside_create_or_delete_loop_maintains_matching_
         cluster.each_builtin_object_in_etcd_is_well_formed()(s),
         cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s),
         cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s),
-        helper_invariants::every_create_request_is_well_formed(cluster, controller_id)(s),
-        helper_invariants::no_pending_interfering_update_request()(s),
-        helper_invariants::no_pending_interfering_update_status_request()(s),
-        helper_invariants::garbage_collector_does_not_delete_vrs_pods(vrs)(s),
-        helper_invariants::no_pending_create_or_delete_request_not_from_controller_on_pods()(s),
-        helper_invariants::every_delete_request_from_vrs_has_rv_precondition_that_is_less_than_rv_counter(vrs, controller_id)(s),
-        helper_invariants::every_create_matching_pod_request_implies_at_after_create_pod_step(vrs, cluster.installed_types, controller_id)(s),
-        helper_invariants::every_delete_matching_pod_request_implies_at_after_delete_pod_step(vrs, controller_id)(s),
+        helper_invariants::no_other_pending_request_interferes_with_vrs_reconcile(vrs, controller_id)(s),
         forall |diff: nat| !(#[trigger] at_vrs_step_with_vrs(vrs, controller_id, VReplicaSetRecStepView::AfterCreatePod(diff))(s)),
         forall |diff: nat| !(#[trigger] at_vrs_step_with_vrs(vrs, controller_id, VReplicaSetRecStepView::AfterDeletePod(diff))(s)),
         forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/proof.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/proof.rs
@@ -92,8 +92,9 @@ proof fn eventually_stable_reconciliation_holds_per_cr(spec: TempPred<ClusterSta
         stable_spec, cluster, controller_id
     );
     lemma_true_leads_to_always_current_state_matches(stable_spec, vrs, cluster, controller_id);
-    reveal_with_fuel(spec_before_phase_n, 7);
+    reveal_with_fuel(spec_before_phase_n, 8);
 
+    spec_before_phase_n_entails_true_leads_to_current_state_matches(7, stable_spec, vrs, cluster, controller_id);
     spec_before_phase_n_entails_true_leads_to_current_state_matches(6, stable_spec, vrs, cluster, controller_id);
     spec_before_phase_n_entails_true_leads_to_current_state_matches(5, stable_spec, vrs, cluster, controller_id);
     spec_before_phase_n_entails_true_leads_to_current_state_matches(4, stable_spec, vrs, cluster, controller_id);
@@ -129,7 +130,7 @@ proof fn eventually_stable_reconciliation_holds_per_cr(spec: TempPred<ClusterSta
 
 proof fn spec_before_phase_n_entails_true_leads_to_current_state_matches(i: nat, spec: TempPred<ClusterState>, vrs: VReplicaSetView, cluster: Cluster, controller_id: int)
     requires
-        1 <= i <= 6,
+        1 <= i <= 7,
         valid(stable(spec.and(spec_before_phase_n(i, vrs, cluster, controller_id)))),
         spec.and(spec_before_phase_n(i + 1, vrs, cluster, controller_id)).entails(true_pred().leads_to(always(lift_state(current_state_matches(vrs))))),
         cluster.type_is_installed_in_cluster::<VReplicaSetView>(),
@@ -138,7 +139,7 @@ proof fn spec_before_phase_n_entails_true_leads_to_current_state_matches(i: nat,
             ==> spec.entails(always(lift_state(#[trigger] vrs_rely(other_id)))),
     ensures spec.and(spec_before_phase_n(i, vrs, cluster, controller_id)).entails(true_pred().leads_to(always(lift_state(current_state_matches(vrs))))),
 {
-    reveal_with_fuel(spec_before_phase_n, 7);
+    reveal_with_fuel(spec_before_phase_n, 8);
     temp_pred_equality(
         spec.and(spec_before_phase_n(i + 1, vrs, cluster, controller_id)),
         spec.and(spec_before_phase_n(i, vrs, cluster, controller_id))

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
@@ -1911,6 +1911,8 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_create_pod_step_to_done(
 
 // Delete lemmas
 
+// TODO: Investigate flaky proof and weird assertion needed.
+#[verifier(spinoff_prover)]
 pub proof fn lemma_from_after_receive_list_pods_resp_to_send_delete_pod_req(
     vrs: VReplicaSetView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
     resp_msg: Message, diff: int

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/spec.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/spec.rs
@@ -36,15 +36,16 @@ pub open spec fn assumption_and_invariants_of_all_phases(vrs: VReplicaSetView, c
     .and(invariants_since_phase_iv(vrs, cluster, controller_id))
     .and(invariants_since_phase_v(vrs, cluster, controller_id))
     .and(invariants_since_phase_vi(vrs, cluster, controller_id))
+    .and(invariants_since_phase_vii(vrs, cluster, controller_id))
 }
 
 pub proof fn assumption_and_invariants_of_all_phases_is_stable(vrs: VReplicaSetView, cluster: Cluster, controller_id: int)
     ensures
         valid(stable(assumption_and_invariants_of_all_phases(vrs, cluster, controller_id))),
         valid(stable(invariants(vrs, cluster, controller_id))),
-        forall |i: nat| 0 <= i <= 6 ==> valid(stable(#[trigger] spec_before_phase_n(i, vrs, cluster, controller_id))),
+        forall |i: nat| 0 <= i <= 7 ==> valid(stable(#[trigger] spec_before_phase_n(i, vrs, cluster, controller_id))),
 {
-    reveal_with_fuel(spec_before_phase_n, 6);
+    reveal_with_fuel(spec_before_phase_n, 7);
     invariants_is_stable(vrs, cluster, controller_id);
     always_p_is_stable(lift_state(Cluster::desired_state_is(vrs)));
     invariants_since_phase_i_is_stable(controller_id, vrs);
@@ -53,6 +54,7 @@ pub proof fn assumption_and_invariants_of_all_phases_is_stable(vrs: VReplicaSetV
     invariants_since_phase_iv_is_stable(vrs, cluster, controller_id);
     invariants_since_phase_v_is_stable(vrs, cluster, controller_id);
     invariants_since_phase_vi_is_stable(vrs, cluster, controller_id);
+    invariants_since_phase_vii_is_stable(vrs, cluster, controller_id);
     stable_and_n!(
         invariants(vrs, cluster, controller_id),
         always(lift_state(Cluster::desired_state_is(vrs))),
@@ -61,7 +63,8 @@ pub proof fn assumption_and_invariants_of_all_phases_is_stable(vrs: VReplicaSetV
         invariants_since_phase_iii(vrs, cluster, controller_id),
         invariants_since_phase_iv(vrs, cluster, controller_id),
         invariants_since_phase_v(vrs, cluster, controller_id),
-        invariants_since_phase_vi(vrs, cluster, controller_id)
+        invariants_since_phase_vi(vrs, cluster, controller_id),
+        invariants_since_phase_vii(vrs, cluster, controller_id)
     );
 }
 
@@ -69,12 +72,12 @@ pub proof fn stable_spec_and_assumption_and_invariants_of_all_phases_is_stable(v
     requires
         valid(stable(assumption_and_invariants_of_all_phases(vrs, cluster, controller_id))),
         valid(stable(invariants(vrs, cluster, controller_id))),
-        forall |i: nat| 0 <= i <= 6 ==> valid(stable(#[trigger] spec_before_phase_n(i, vrs, cluster, controller_id))),
+        forall |i: nat| 0 <= i <= 7 ==> valid(stable(#[trigger] spec_before_phase_n(i, vrs, cluster, controller_id))),
     ensures
         valid(stable(stable_spec(cluster, controller_id))),
         valid(stable(stable_spec(cluster, controller_id).and(assumption_and_invariants_of_all_phases(vrs, cluster, controller_id)))),
         valid(stable(stable_spec(cluster, controller_id).and(invariants(vrs, cluster, controller_id)))),
-        forall |i: nat| 0 <= i <= 6 ==> valid(stable(#[trigger] stable_spec(cluster, controller_id).and(spec_before_phase_n(i, vrs, cluster, controller_id)))),
+        forall |i: nat| 0 <= i <= 7 ==> valid(stable(#[trigger] stable_spec(cluster, controller_id).and(spec_before_phase_n(i, vrs, cluster, controller_id)))),
 {
     stable_spec_is_stable(cluster, controller_id);
     stable_and_n!(
@@ -86,9 +89,9 @@ pub proof fn stable_spec_and_assumption_and_invariants_of_all_phases_is_stable(v
         invariants(vrs, cluster, controller_id)
     );
     assert forall |i: nat| 
-        0 <= i <= 6 
+        0 <= i <= 7 
         && valid(stable(stable_spec(cluster, controller_id)))
-        && forall |i: nat| 0 <= i <= 6 ==> valid(stable(#[trigger] spec_before_phase_n(i, vrs, cluster, controller_id)))
+        && forall |i: nat| 0 <= i <= 7 ==> valid(stable(#[trigger] spec_before_phase_n(i, vrs, cluster, controller_id)))
         implies valid(stable(#[trigger] stable_spec(cluster, controller_id).and(spec_before_phase_n(i, vrs, cluster, controller_id)))) by {
         stable_and_n!(
             stable_spec(cluster, controller_id),
@@ -113,6 +116,8 @@ pub open spec fn invariants_since_phase_n(n: nat, vrs: VReplicaSetView, cluster:
         invariants_since_phase_v(vrs, cluster, controller_id)
     } else if n == 6 {
         invariants_since_phase_vi(vrs, cluster, controller_id)
+    } else if n == 7 {
+        invariants_since_phase_vii(vrs, cluster, controller_id)
     } else {
         true_pred()
     }
@@ -123,7 +128,7 @@ pub open spec fn spec_before_phase_n(n: nat, vrs: VReplicaSetView, cluster: Clus
 {
     if n == 1 {
         invariants(vrs, cluster, controller_id).and(always(lift_state(Cluster::desired_state_is(vrs))))
-    } else if 2 <= n <= 7 {
+    } else if 2 <= n <= 8 {
         spec_before_phase_n((n-1) as nat, vrs, cluster, controller_id).and(invariants_since_phase_n((n-1) as nat, vrs, cluster, controller_id))
     } else {
         true_pred()
@@ -225,9 +230,20 @@ pub proof fn invariants_since_phase_vi_is_stable(vrs: VReplicaSetView, cluster: 
     always_p_is_stable(lift_state(at_after_delete_pod_step_implies_filtered_pods_in_matching_pod_entries(vrs, controller_id)));
 }
 
+pub open spec fn invariants_since_phase_vii(vrs: VReplicaSetView, cluster: Cluster, controller_id: int) -> TempPred<ClusterState>
+{
+    always(lift_state(no_other_pending_request_interferes_with_vrs_reconcile(vrs, controller_id)))
+}
+
+pub proof fn invariants_since_phase_vii_is_stable(vrs: VReplicaSetView, cluster: Cluster, controller_id: int)
+    ensures valid(stable(invariants_since_phase_vii(vrs, cluster, controller_id))),
+{
+    always_p_is_stable(lift_state(no_other_pending_request_interferes_with_vrs_reconcile(vrs, controller_id)));
+}
+
 pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(provided_spec: TempPred<ClusterState>, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, i: nat)
     requires 
-        1 <= i <= 6,
+        1 <= i <= 7,
         // The vrs type is installed in the cluster.
         cluster.type_is_installed_in_cluster::<VReplicaSetView>(),
         // The vrs controller runs in the cluster.
@@ -261,7 +277,7 @@ pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(provided_
         }
     }
 
-    reveal_with_fuel(spec_before_phase_n, 6);
+    reveal_with_fuel(spec_before_phase_n, 7);
     if i == 1 {
         use_tla_forall(spec, |input| cluster.disable_crash().weak_fairness(input), controller_id);
         cluster.lemma_true_leads_to_crash_always_disabled(spec, controller_id);
@@ -330,6 +346,9 @@ pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(provided_
             );
         } else if i == 6 {
             lemma_eventually_always_at_after_delete_pod_step_implies_filtered_pods_in_matching_pod_entries(spec, vrs, cluster, controller_id);
+        } else if i == 7 {
+            always_tla_forall_apply(spec, |vrs: VReplicaSetView| lift_state(Cluster::pending_req_of_key_is_unique_with_unique_id(controller_id, vrs.object_ref())), vrs);
+            lemma_eventually_always_no_other_pending_request_interferes_with_vrs_reconcile(spec, vrs, cluster, controller_id);
         }
     }
 }

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/spec.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/spec.rs
@@ -157,6 +157,7 @@ pub open spec fn invariants_since_phase_ii(controller_id: int, vrs: VReplicaSetV
 {
     always(lift_state(Cluster::the_object_in_reconcile_has_spec_and_uid_as(controller_id, vrs)))
     .and(always(lift_state(vrs_in_schedule_does_not_have_deletion_timestamp(vrs, controller_id))))
+    .and(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref()))))
 }
 
 pub proof fn invariants_since_phase_ii_is_stable(controller_id: int, vrs: VReplicaSetView)
@@ -164,7 +165,8 @@ pub proof fn invariants_since_phase_ii_is_stable(controller_id: int, vrs: VRepli
 {
     stable_and_always_n!(
         lift_state(Cluster::the_object_in_reconcile_has_spec_and_uid_as(controller_id, vrs)),
-        lift_state(vrs_in_schedule_does_not_have_deletion_timestamp(vrs, controller_id))
+        lift_state(vrs_in_schedule_does_not_have_deletion_timestamp(vrs, controller_id)),
+        lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref()))
     );
 }
 
@@ -308,11 +310,13 @@ pub proof fn spec_of_previous_phases_entails_eventually_new_invariants(provided_
             );
             cluster.lemma_true_leads_to_always_the_object_in_reconcile_has_spec_and_uid_as(spec, controller_id, vrs);
             lemma_eventually_always_vrs_in_schedule_does_not_have_deletion_timestamp(spec, vrs, cluster, controller_id);
+            cluster.lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of(spec, controller_id, vrs.object_ref());
             leads_to_always_combine_n!(
                 spec,
                 true_pred(),
                 lift_state(Cluster::the_object_in_reconcile_has_spec_and_uid_as(controller_id, vrs)),
-                lift_state(vrs_in_schedule_does_not_have_deletion_timestamp(vrs, controller_id))
+                lift_state(vrs_in_schedule_does_not_have_deletion_timestamp(vrs, controller_id)),
+                lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref()))
             );
         } else if i == 3 {
             lemma_eventually_always_no_pending_interfering_update_request(spec, cluster, controller_id);

--- a/src/v2/controllers/vreplicaset_controller/proof/predicate.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/predicate.rs
@@ -184,12 +184,14 @@ pub open spec fn resp_msg_is_ok_list_resp_containing_matching_pods(
     s: ClusterState, vrs: VReplicaSetView, resp_msg: Message
 ) -> bool {
     let resp_objs = resp_msg.content.get_list_response().res.unwrap();
+    let resp_obj_keys = resp_objs.map_values(|obj: DynamicObjectView| obj.object_ref());
     &&& resp_msg.content.is_list_response()
     &&& resp_msg.content.get_list_response().res.is_Ok()
     &&& matching_pods(vrs, s.resources()) == resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set()
     &&& objects_to_pods(resp_objs).is_Some()
     &&& objects_to_pods(resp_objs).unwrap().no_duplicates()
     &&& resp_objs.no_duplicates()
+    &&& resp_obj_keys.no_duplicates()
     &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).is_Ok()
     &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).unwrap().metadata.namespace.is_Some()
     &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).unwrap().metadata.namespace == vrs.metadata.namespace
@@ -301,44 +303,17 @@ pub open spec fn new_obj_in_etcd(
 
 // Pod deletion predicates
 
-// The delete request must be on a matching pod.
-pub open spec fn delete_constraint(
-    vrs: VReplicaSetView, req: DeleteRequest
-) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        let obj = s.resources()[req.key];
-        &&& s.resources().contains_key(req.key)
-        &&& matching_pods(vrs, s.resources()).contains(obj)
-    }
-}
-
 pub open spec fn pending_req_in_flight_at_after_delete_pod_step(
     vrs: VReplicaSetView, controller_id: int, diff: nat
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let step = VReplicaSetRecStepView::AfterDeletePod(diff);
         let msg = s.ongoing_reconciles(controller_id)[vrs.object_ref()].pending_req_msg.get_Some_0();
-        let request = msg.content.get_APIRequest_0();
-        let key = request.get_DeleteRequest_0().key;
-        let obj = s.resources()[key];
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg)
         &&& s.in_flight().contains(msg)
-        &&& msg.src.is_controller_id(controller_id)
-        &&& msg.dst == HostId::APIServer
-        &&& msg.content.is_APIRequest()
-        &&& request.is_DeleteRequest()
-        &&& delete_constraint(vrs, request.get_DeleteRequest_0())(s)
-        // NOTE: We require that the resource version in etcd is
-        // equal to the one carried by the delete request to
-        // exclude the case where another reconcile working on another
-        // vrs object tries to delete the same object.
-        &&& request.get_DeleteRequest_0().preconditions.is_Some()
-        &&& request.get_DeleteRequest_0().preconditions.unwrap().resource_version.is_Some()
-        &&& request.get_DeleteRequest_0().preconditions.unwrap().uid.is_None()
-        &&& obj.metadata.resource_version.is_Some()
-        &&& obj.metadata.resource_version.unwrap() == 
-                request.get_DeleteRequest_0().preconditions.unwrap().resource_version.unwrap()
+        &&& msg.src == HostId::Controller(controller_id, vrs.object_ref())
+        &&& req_msg_is_get_then_delete_matching_pod_req(vrs, controller_id, msg)(s)
     }
 }
 
@@ -347,27 +322,11 @@ pub open spec fn req_msg_is_the_in_flight_delete_request_at_after_delete_pod_ste
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let step = VReplicaSetRecStepView::AfterDeletePod(diff);
-        let request = req_msg.content.get_APIRequest_0();
-        let key = request.get_DeleteRequest_0().key;
-        let obj = s.resources()[key];
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), req_msg)
         &&& s.in_flight().contains(req_msg)
-        &&& req_msg.src.is_controller_id(controller_id)
-        &&& req_msg.dst == HostId::APIServer
-        &&& req_msg.content.is_APIRequest()
-        &&& request.is_DeleteRequest()
-        &&& delete_constraint(vrs, request.get_DeleteRequest_0())(s)
-        // NOTE: We require that the resource version in etcd is
-        // equal to the one carried by the delete request to
-        // exclude the case where another reconcile working on another
-        // vrs object tries to delete the same object.
-        &&& request.get_DeleteRequest_0().preconditions.is_Some()
-        &&& request.get_DeleteRequest_0().preconditions.unwrap().resource_version.is_Some()
-        &&& request.get_DeleteRequest_0().preconditions.unwrap().uid.is_None()
-        &&& obj.metadata.resource_version.is_Some()
-        &&& obj.metadata.resource_version.unwrap() == 
-                request.get_DeleteRequest_0().preconditions.unwrap().resource_version.unwrap()
+        &&& req_msg.src == HostId::Controller(controller_id, vrs.object_ref())
+        &&& req_msg_is_get_then_delete_matching_pod_req(vrs, controller_id, req_msg)(s)
     }
 }
 
@@ -380,14 +339,14 @@ pub open spec fn exists_ok_resp_in_flight_at_after_delete_pod_step(
         let request = msg.content.get_APIRequest_0();
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::has_pending_k8s_api_req_msg(controller_id, s, vrs.object_ref())
-        &&& msg.src.is_controller_id(controller_id)
+        &&& msg.src == HostId::Controller(controller_id, vrs.object_ref())
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
-        &&& request.is_DeleteRequest()
+        &&& request.is_GetThenDeleteRequest()
         &&& exists |resp_msg| {
             &&& #[trigger] s.in_flight().contains(resp_msg)
             &&& resp_msg_matches_req_msg(resp_msg, msg)
-            &&& resp_msg.content.get_delete_response().res.is_Ok()
+            &&& resp_msg.content.get_get_then_delete_response().res.is_Ok()
         }
     }
 }
@@ -401,13 +360,63 @@ pub open spec fn resp_msg_is_the_in_flight_ok_resp_at_after_delete_pod_step(
         let request = msg.content.get_APIRequest_0();
         &&& at_vrs_step_with_vrs(vrs, controller_id, step)(s)
         &&& Cluster::has_pending_k8s_api_req_msg(controller_id, s, vrs.object_ref())
-        &&& msg.src.is_controller_id(controller_id)
+        &&& msg.src == HostId::Controller(controller_id, vrs.object_ref())
         &&& msg.dst == HostId::APIServer
         &&& msg.content.is_APIRequest()
-        &&& request.is_DeleteRequest()
+        &&& request.is_GetThenDeleteRequest()
         &&& s.in_flight().contains(resp_msg)
         &&& resp_msg_matches_req_msg(resp_msg, msg)
-        &&& resp_msg.content.get_delete_response().res.is_Ok()
+        &&& resp_msg.content.get_get_then_delete_response().res.is_Ok()
+    }
+}
+
+pub open spec fn req_msg_is_get_then_delete_matching_pod_req(
+    vrs: VReplicaSetView, controller_id: int, req_msg: Message,
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        let request = req_msg.content.get_APIRequest_0();
+        let key = request.get_GetThenDeleteRequest_0().key;
+        let obj = s.resources()[key];
+        let state = VReplicaSetReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vrs.object_ref()].local_state).unwrap();
+        let filtered_pods = state.filtered_pods.unwrap();
+        let filtered_pod_keys = filtered_pods.map_values(|p: PodView| p.object_ref());
+        let diff = state.reconcile_step.get_AfterDeletePod_0();
+        // Basic requirements.
+        &&& req_msg.dst == HostId::APIServer
+        &&& req_msg.content.is_APIRequest()
+        &&& request.is_GetThenDeleteRequest()
+        // We require the key we are deleting is a pod in etcd owned by vrs.
+        &&& s.resources().contains_key(key)
+        &&& matching_pods(vrs, s.resources()).contains(obj)
+        // We further require that the attached owner reference is the vrs 
+        // controller owner reference.
+        &&& request.get_GetThenDeleteRequest_0().owner_ref
+            == vrs.controller_owner_ref()
+        // We further require that the key of the sent request is the last index of
+        // filtered_pods.
+        &&& key == filtered_pod_keys[diff as int]
+    }
+}
+
+pub open spec fn filtered_pods_in_vrs_matching_pods(
+    vrs: VReplicaSetView, controller_id: int,
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        let state = VReplicaSetReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vrs.object_ref()].local_state).unwrap();
+        let filtered_pods = state.filtered_pods.unwrap();
+        let filtered_pod_keys = filtered_pods.map_values(|p: PodView| p.object_ref());
+        let diff = state.reconcile_step.get_AfterDeletePod_0();
+        &&& s.ongoing_reconciles(controller_id).contains_key(vrs.object_ref())
+        &&& VReplicaSetReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vrs.object_ref()].local_state).is_ok()
+        &&& state.reconcile_step.is_AfterDeletePod()
+        &&& state.filtered_pods.is_Some()
+        &&& filtered_pod_keys.no_duplicates()
+        &&& diff < filtered_pods.len()
+        &&& forall |i| #![trigger state.filtered_pods.unwrap()[i]] 0 <= i < diff ==> {
+            &&& s.resources().contains_key(filtered_pod_keys[i])
+            &&& matching_pods(vrs, s.resources()).contains(s.resources()[filtered_pod_keys[i]])
+            &&& PodView::unmarshal(s.resources()[filtered_pod_keys[i]]).get_Ok_0() == filtered_pods[i]
+        }
     }
 }
 

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -616,7 +616,6 @@ pub proof fn lemma_always_every_ongoing_reconcile_has_unique_id(
     init_invariant::<ClusterState>(spec, self.init(), stronger_next, invariant);
 }
 
-// TODO: prove this.
 pub open spec fn every_msg_from_key_is_pending_req_msg_of(
     controller_id: int, key: ObjectRef
 ) -> StatePred<ClusterState> {
@@ -629,6 +628,15 @@ pub open spec fn every_msg_from_key_is_pending_req_msg_of(
         } ==> Cluster::pending_req_msg_is(controller_id, s, key, msg)
     }
 }
+
+// TODO: prove this.
+// dummy proof; not entirely sure which phase this should go in.
+#[verifier(external_body)]
+pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of(
+    self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef
+)
+    ensures spec.entails(true_pred().leads_to(always(lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key))))),
+{}
 
 }
 }

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -616,6 +616,19 @@ pub proof fn lemma_always_every_ongoing_reconcile_has_unique_id(
     init_invariant::<ClusterState>(spec, self.init(), stronger_next, invariant);
 }
 
+// TODO: prove this.
+pub open spec fn every_msg_from_key_is_pending_req_msg_of(
+    controller_id: int, key: ObjectRef
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        forall |msg: Message| {
+            &&& #[trigger] s.in_flight().contains(msg)
+            &&& msg.src == HostId::Controller(controller_id, key)
+            &&& msg.dst.is_APIServer()
+            &&& msg.content.is_APIRequest()
+        } ==> Cluster::pending_req_msg_is(controller_id, s, key, msg)
+    }
 }
 
+}
 }


### PR DESCRIPTION
This PR rewrites the liveness proof to use a bridge invariant saying that no message potentially interfering with the current reconcile for `vrs` can be in the network, unless the source is precisely the reconcile for `vrs`. The fixes are complete minus a helper lemma, and lemmas specifying the results of the API server taking an action.