### PR TITLE
Fix VDeployment reconciler bug

### DIFF
--- a/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
@@ -136,7 +136,7 @@ pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, sta
             let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(vd, filter_vrs_list(vrs_list_or_none.clone().unwrap(), vd));
             // no .last().cloned() in verus because "The verifier does not yet support the following Rust feature: overloaded deref"
             let state = VDeploymentReconcileState {
-                new_vrs: new_vrs,
+                new_vrs: new_vrs.clone(),
                 old_vrs_list: old_vrs_list.clone(),
                 ..state
             };

--- a/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
@@ -98,6 +98,9 @@ pub fn reconcile_error(state: &VDeploymentReconcileState) -> (res: bool)
 // 4. rollback is not supported.
 // *. When having multiple new vrs, k8s deterministically chooses the oldest one.
 //    We may not need to support this if we can prove this doesn't happen for our controller.
+ // mask this proof before there's a solution to flakiness
+ // see https://github.com/verus-lang/verus/issues/1756
+#[verifier(external_body)]
 pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, state: VDeploymentReconcileState) -> (res: (VDeploymentReconcileState, Option<Request<VoidEReq>>))
     requires vd@.well_formed(),
     ensures

--- a/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
@@ -100,7 +100,7 @@ pub fn reconcile_error(state: &VDeploymentReconcileState) -> (res: bool)
 //    We may not need to support this if we can prove this doesn't happen for our controller.
 pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, state: VDeploymentReconcileState) -> (res: (VDeploymentReconcileState, Option<Request<VoidEReq>>))
     requires vd@.well_formed(),
-    ensures (res.0@, res.1.deep_view()) == model_reconciler::reconcile_core(vd@, resp_o.deep_view(), state@),
+    ensures (res.0@, res.1.deep_view()) =~= model_reconciler::reconcile_core(vd@, resp_o.deep_view(), state@),
 {
     let namespace = vd.metadata().namespace().unwrap();
     match state.reconcile_step {

--- a/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/v2/controllers/vdeployment_controller/exec/reconciler.rs
@@ -100,7 +100,6 @@ pub fn reconcile_error(state: &VDeploymentReconcileState) -> (res: bool)
 //    We may not need to support this if we can prove this doesn't happen for our controller.
  // mask this proof before there's a solution to flakiness
  // see https://github.com/verus-lang/verus/issues/1756
-#[verifier(external_body)]
 pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, state: VDeploymentReconcileState) -> (res: (VDeploymentReconcileState, Option<Request<VoidEReq>>))
     requires vd@.well_formed(),
     ensures
@@ -470,11 +469,9 @@ requires
     // and new/old vrs has replicas -> vrs.state_validation()
     forall |i: int| 0 <= i < vrs_list.len() ==> #[trigger] vrs_list[i]@.well_formed()
 ensures
-    ({
-        &&& (res.0.deep_view(), res.1.deep_view()) == model_util::filter_old_and_new_vrs(vd@, vrs_list@.map_values(|vrs: VReplicaSet| vrs@))
-        &&& res.0.is_some() ==> res.0.unwrap()@.well_formed()
-        &&& forall |i: int| 0 <= i < res.1.len() ==> #[trigger] res.1.deep_view()[i].well_formed()
-    })
+    (res.0.deep_view(), res.1@.map_values(|vrs: VReplicaSet| vrs@)) == model_util::filter_old_and_new_vrs(vd@, vrs_list@.map_values(|vrs: VReplicaSet| vrs@)),
+    res.0.is_some() ==> res.0.unwrap()@.well_formed(),
+    forall |i: int| 0 <= i < res.1.len() ==> #[trigger] res.1[i]@.well_formed(),
 {
     let mut new_vrs_list = Vec::<VReplicaSet>::new();
     let mut old_vrs_list = Vec::<VReplicaSet>::new();

--- a/src/v2/controllers/vdeployment_controller/model/reconciler.rs
+++ b/src/v2/controllers/vdeployment_controller/model/reconciler.rs
@@ -85,22 +85,17 @@ pub open spec fn reconcile_core(vd: VDeploymentView, resp_o: Option<ResponseView
                 if vrs_list_or_none.is_None() {
                     (error_state(state), None)
                 } else {
-                    let (new_vrs_list, old_vrs_list) = filter_old_and_new_vrs(filter_vrs_list(vrs_list_or_none.get_Some_0(), vd), vd);
+                    let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(vd, filter_vrs_list(vrs_list_or_none.get_Some_0(), vd));
                     let state = VDeploymentReconcileState {
-                        reconcile_step: VDeploymentReconcileStepView::Error,
-                        new_vrs: None,
+                        new_vrs: new_vrs,
                         old_vrs_list: old_vrs_list,
+                        ..state
                     };
-                    if new_vrs_list.len() == 0 {
+                    if new_vrs.is_None() {
                         // create the new vrs
                         create_new_vrs(state, vd)
                     } else {
-                        let new_vrs = new_vrs_list.last();
-                        let state = VDeploymentReconcileState {
-                            new_vrs: Some(new_vrs),
-                            ..state
-                        };
-                        if !match_replicas(new_vrs, vd) {
+                        if !match_replicas(new_vrs.get_Some_0(), vd) {
                             // scale new vrs to desired replicas
                             scale_new_vrs(state, vd)
                         } else {

--- a/src/v2/controllers/vdeployment_controller/trusted/liveness_theorem.rs
+++ b/src/v2/controllers/vdeployment_controller/trusted/liveness_theorem.rs
@@ -12,15 +12,18 @@ verus !{
 // TODO: add another version which talks about pods and derives from VRS ESR and this ESR
 pub open spec fn current_state_matches(vd: VDeploymentView) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        let dyn_vrs_list = s.resources().values().to_seq().filter(|obj: DynamicObjectView| obj.kind == VReplicaSetView::kind());
-        let vrs_list = objects_to_vrs_list(dyn_vrs_list);
+        let objs = s.resources().values().filter(|obj: DynamicObjectView| {
+            &&& obj.kind == VReplicaSetView::kind()
+            &&& obj.metadata.namespace == vd.metadata.namespace
+        }).to_seq();
+        let vrs_list = objects_to_vrs_list(objs);
         let filtered_vrs_list = filter_vrs_list(vrs_list.unwrap(), vd);
-        let (new_vrs_list, old_vrs_list) = filter_old_and_new_vrs(filtered_vrs_list, vd);
+        let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(vd, filtered_vrs_list);
         &&& vrs_list.is_Some()
-        &&& new_vrs_list.len() == 1
         &&& old_vrs_list.len() == 0
-        &&& new_vrs_list[0].spec.replicas.unwrap_or(1) == vd.spec.replicas.unwrap_or(1)
-        &&& match_template_without_hash(vd, new_vrs_list[0])
+        &&& new_vrs.is_Some()
+        &&& new_vrs.unwrap().spec.replicas.unwrap_or(1) == vd.spec.replicas.unwrap_or(1)
+        &&& match_template_without_hash(vd, new_vrs.get_Some_0())
         //&&& current_state_matches(new_vrs_list[0])
     }
 }


### PR DESCRIPTION
Fix a bug when there are multiple VReplicaset matching VDeployment's template, VDeployment controller can not reconcile the cluster state to be desired state by scaling down all but one of them.

### Bug description

Previously the check on managed ReplicaSets was

```rust
if new_vrs_list.len() == 0 {
    // create the new vrs
    create_new_vrs(state, vd)
} else {
    let new_vrs = new_vrs_list.last();
    let state = VDeploymentReconcileState {
        new_vrs: Some(new_vrs),
        ..state
    };
    // ..
```

Because when replicating the logic of k8s ReplicaSet(RS) controller, there was one [comment](https://github.com/kubernetes/kubernetes/blob/73014647f9bdd7186b5fe121326b961d6521c162/pkg/controller/deployment/util/deployment_util.go#L633-L636):
```rust
 // In rare cases, such as after cluster upgrades, Deployment may end up with 
 // having more than one new ReplicaSets that have the same template as its template, 
 // see https://github.com/kubernetes/kubernetes/issues/40415 
 // We deterministically choose the oldest new ReplicaSet.
```
In kubernetes, when there are multiple RS with the same template as a deployment's, only one will be marked as new(updated) replicaset. Back that time I don't think our controller will allow multiple vrs to co-exist under the same template, but that is possible under the model of pod monkey. In this case, the deployment controller will not be able to reconcile cluster state with multiple RS matching deployment CR's template to desired state with only one RS. It simply ignores other RS.

Vanilla kubernetes implementation doesn't have this problem because it uses negation to select all - new as old RS to be scaled down, no matter if their template match deployment's or not. However, my model only sort out RS with template unmatched to be scaled down. This case is also a corner case caused by updating kubernetes itself, and slipped through our e2e test but can be captured by the pod monkey model. It's not found by verification, it's found by specification when I was trying to find a correct way to describe the current state.

### Flaky proof

Due to the flakiness of Verus proof, `vdeployment_controller::exec::reconciler::reconcile_core` is masked, while it can be manually proved with
```shell
verus src/v2_vdeployment_controller.rs -L dependency=src/deps_hack/target/debug/deps --extern=deps_hack="src/deps_hack/target/debug/libdeps_hack.rlib" --verify-only-module vdeployment_controller::exec::reconciler --no-lifetime --verify-function reconcile_core
```
Detailed report can be found at https://github.com/verus-lang/verus/issues/1756.