### PR TITLE
Prove API Action and Auxiliary Lemmas

### DIFF
--- a/src/v2/controllers/vreplicaset_controller/proof/helper_lemmas.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/helper_lemmas.rs
@@ -132,6 +132,18 @@ pub proof fn vrs_rely_condition_equivalent_to_lifted_vrs_rely_condition_action(
     );
 }
 
+pub proof fn matching_pods_equal_to_matching_pod_entries_values(vrs: VReplicaSetView, s: StoredState)
+    ensures
+        matching_pods(vrs, s) =~= matching_pod_entries(vrs, s).values()
+{
+    assert forall |o: DynamicObjectView| #[trigger] matching_pods(vrs, s).contains(o)
+        implies matching_pod_entries(vrs, s).values().contains(o) by {
+        assert(s.values().contains(o));
+        let key = choose |key: ObjectRef| s.contains_key(key) && #[trigger] s[key] == o;
+        assert(matching_pod_entries(vrs, s).contains_key(key) && matching_pod_entries(vrs, s)[key] == o);
+    }
+}
+
 pub proof fn lemma_filtered_pods_set_equals_matching_pods(
     s: ClusterState, vrs: VReplicaSetView, cluster: Cluster, 
     controller_id: int, resp_msg: Message

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/api_actions.rs
@@ -10,7 +10,7 @@ use crate::kubernetes_cluster::spec::{
 use crate::temporal_logic::{defs::*, rules::*};
 use crate::vreplicaset_controller::{
     model::{install::*, reconciler::*},
-    proof::{helper_invariants, predicate::*},
+    proof::{helper_invariants, helper_lemmas, predicate::*},
     trusted::{liveness_theorem::*, rely_guarantee::*, spec_types::*, step::*},
 };
 use crate::vstd_ext::{map_lib::*, seq_lib::*, set_lib::*};
@@ -18,8 +18,6 @@ use vstd::{map::*, map_lib::*, prelude::*};
 
 verus! {
 
-// TODO: Prove this
-#[verifier(external_body)]
 pub proof fn lemma_api_request_other_than_pending_req_msg_maintains_matching_pods(
     s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
     msg: Message,
@@ -31,59 +29,46 @@ pub proof fn lemma_api_request_other_than_pending_req_msg_maintains_matching_pod
         cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s),
         cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s),
         Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s),
+        Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s),
         helper_invariants::no_other_pending_request_interferes_with_vrs_reconcile(vrs, controller_id)(s),
-        forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)
-            ==> #[trigger] vrs_rely(other_id)(s),
         !Cluster::pending_req_msg_is(controller_id, s, vrs.object_ref(), msg),
     ensures
         matching_pods(vrs, s.resources()) == matching_pods(vrs, s_prime.resources()),
 {
-    if msg.src.is_Controller() {
-        let id = msg.src.get_Controller_0();
-        assert(
-            (id != controller_id ==> cluster.controller_models.remove(controller_id).contains_key(id)));
-        // Invoke non-interference lemma by trigger.
-        assert(id != controller_id ==> vrs_rely(id)(s));
-
-        assume(id == controller_id ==> false);
+    if msg.content.is_get_then_delete_request() {
+        let req = msg.content.get_get_then_delete_request();
+        if req.key.kind == Kind::PodKind && s.resources().contains_key(req.key) {
+            let obj = s.resources()[req.key];
+            if obj.metadata.owner_references_contains(req.owner_ref) {
+                let owners = obj.metadata.owner_references.get_Some_0();
+                let controller_owners = owners.filter(
+                    |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                );
+                assert(req.owner_ref.controller.is_Some() && req.owner_ref.controller.get_Some_0());
+                assert(controller_owners.contains(req.owner_ref));
+                assert(!controller_owners.contains(vrs.controller_owner_ref()));
+            }
+        }
+    } else if msg.content.is_get_then_update_request() {
+        let req = msg.content.get_get_then_update_request();
+        if req.obj.kind == Kind::PodKind && s.resources().contains_key(req.key()) {
+            let obj = s.resources()[req.key()];
+            if obj.metadata.owner_references_contains(req.owner_ref) {
+                let owners = obj.metadata.owner_references.get_Some_0();
+                let controller_owners = owners.filter(
+                    |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                );
+                assert(req.owner_ref.controller.is_Some() && req.owner_ref.controller.get_Some_0());
+                assert(controller_owners.contains(req.owner_ref));
+                assert(!controller_owners.contains(vrs.controller_owner_ref()));
+            }
+        }
     }
-
-    // Dispatch through all the requests which may mutate the k-v store.
-    let mutates_key = if msg.content.is_create_request() {
-        let req = msg.content.get_create_request();
-        Some(ObjectRef{
-            kind: req.obj.kind,
-            name: if req.obj.metadata.name.is_Some() {
-                req.obj.metadata.name.unwrap()
-            } else {
-                generate_name(s.api_server)
-            },
-            namespace: req.namespace,
-        })
-    } else if msg.content.is_delete_request() {
-        let req = msg.content.get_delete_request();
-        Some(req.key)
-    } else if msg.content.is_update_request() {
-        let req = msg.content.get_update_request();
-        Some(req.key())
-    } else if msg.content.is_update_status_request() {
-        let req = msg.content.get_update_status_request();
-        Some(req.key())
-    } else {
-        None
-    };
-
-    match mutates_key {
-        Some(key) => {
-            assert_maps_equal!(s.resources().remove(key) == s_prime.resources().remove(key));
-            assert_maps_equal!(matching_pod_entries(vrs, s.resources()) == matching_pod_entries(vrs, s_prime.resources()));
-        },
-        _ => {}
-    };
+    assert(matching_pod_entries(vrs, s.resources()) == matching_pod_entries(vrs, s_prime.resources()));
+    helper_lemmas::matching_pods_equal_to_matching_pod_entries_values(vrs, s.resources());
+    helper_lemmas::matching_pods_equal_to_matching_pod_entries_values(vrs, s_prime.resources());
 }
 
-// TODO: Prove this
-#[verifier(external_body)]
 pub proof fn lemma_list_pods_request_returns_ok_list_resp_containing_matching_pods(
     s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
     msg: Message,
@@ -91,174 +76,203 @@ pub proof fn lemma_list_pods_request_returns_ok_list_resp_containing_matching_po
     requires
         cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
         req_msg_is_list_pods_req(vrs, msg),
+        Cluster::desired_state_is(vrs)(s),
         Cluster::each_object_in_etcd_is_weakly_well_formed()(s),
         cluster.each_builtin_object_in_etcd_is_well_formed()(s),
         cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s),
         cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s),
+        Cluster::etcd_is_finite()(s),
     ensures
         resp_msg == handle_list_request_msg(msg, s.api_server).1,
         resp_msg_is_ok_list_resp_containing_matching_pods(s_prime, vrs, resp_msg),
 {
-    // required to type-check
-    return handle_list_request_msg(msg, s.api_server).1;
+    let pre = {
+        &&& cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg)))
+        &&& req_msg_is_list_pods_req(vrs, msg)
+        &&& Cluster::desired_state_is(vrs)(s)
+        &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
+        &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
+        &&& cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s)
+        &&& Cluster::etcd_is_finite()(s)
+    };
 
-    // proof hint in comment
-    // let resp_msg = handle_list_request_msg(req_msg, s.api_server).1;
-    //     let resp_objs = resp_msg.content.get_list_response().res.unwrap();
-    //     assert forall |o: DynamicObjectView| #![auto]
-    //     pre(s) && matching_pods(vrs, s_prime.resources()).contains(o)
-    //     implies resp_objs.to_set().contains(o) by {
-    //         // Tricky reasoning about .to_seq
-    //         let selector = |o: DynamicObjectView| {
-    //             &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
-    //             &&& o.object_ref().kind == PodView::kind()
-    //         };
-    //         let selected_elements = s.resources().values().filter(selector);
-    //         assert(selected_elements.contains(o));
-    //         lemma_values_finite(s.resources());
-    //         finite_set_to_seq_contains_all_set_elements(selected_elements);
-    //     }
+    let resp_msg = handle_list_request_msg(msg, s.api_server).1;
+    let resp_objs = resp_msg.content.get_list_response().res.unwrap();
+    let resp_obj_keys = resp_objs.map_values((|obj: DynamicObjectView| obj.object_ref()));
 
-    //     assert forall |o: DynamicObjectView| #![auto]
-    //     pre(s) && resp_objs.contains(o)
-    //     implies !PodView::unmarshal(o).is_err()
-    //             && o.metadata.namespace == vrs.metadata.namespace by {
-    //         // Tricky reasoning about .to_seq
-    //         let selector = |o: DynamicObjectView| {
-    //             &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
-    //             &&& o.object_ref().kind == PodView::kind()
-    //         };
-    //         let selected_elements = s.resources().values().filter(selector);
-    //         lemma_values_finite(s.resources());
-    //         finite_set_to_seq_contains_all_set_elements(selected_elements);
-    //         assert(resp_objs == selected_elements.to_seq());
-    //         assert(selected_elements.contains(o));
-    //     }
-    //     seq_pred_false_on_all_elements_is_equivalent_to_empty_filter(resp_objs, |o: DynamicObjectView| PodView::unmarshal(o).is_err());
+    assert forall |o: DynamicObjectView| #![auto]
+    pre && matching_pods(vrs, s_prime.resources()).contains(o)
+    implies resp_objs.to_set().contains(o) by {
+        // Tricky reasoning about .to_seq
+        let selector = |o: DynamicObjectView| {
+            &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
+            &&& o.object_ref().kind == PodView::kind()
+        };
+        let selected_elements = s.resources().values().filter(selector);
+        assert(selected_elements.contains(o));
+        lemma_values_finite(s.resources());
+        finite_set_to_seq_contains_all_set_elements(selected_elements);
+    }
 
-    //     // TODO: Shorten up this proof.
-    //     assert_by(objects_to_pods(resp_objs).unwrap().no_duplicates(), {
-    //         let selector = |o: DynamicObjectView| {
-    //             &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
-    //             &&& o.object_ref().kind == PodView::kind()
-    //         };
-    //         let selected_elements = s.resources().values().filter(selector);
-    //         lemma_values_finite(s.resources());
-    //         finite_set_to_seq_has_no_duplicates(selected_elements);
-    //         let selected_elements_seq = selected_elements.to_seq();
-    //         let pods_seq = objects_to_pods(selected_elements_seq).unwrap();
-    //         assert(selected_elements_seq.no_duplicates());
+    assert forall |o: DynamicObjectView| #![auto]
+    pre && resp_objs.contains(o)
+    implies !PodView::unmarshal(o).is_err()
+            && o.metadata.namespace == vrs.metadata.namespace by {
+        // Tricky reasoning about .to_seq
+        let selector = |o: DynamicObjectView| {
+            &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
+            &&& o.object_ref().kind == PodView::kind()
+        };
+        let selected_elements = s.resources().values().filter(selector);
+        lemma_values_finite(s.resources());
+        finite_set_to_seq_contains_all_set_elements(selected_elements);
+        assert(resp_objs == selected_elements.to_seq());
+        assert(selected_elements.contains(o));
+    }
+    seq_pred_false_on_all_elements_is_equivalent_to_empty_filter(resp_objs, |o: DynamicObjectView| PodView::unmarshal(o).is_err());
 
-    //         assert forall |x: DynamicObjectView, y: DynamicObjectView| #![auto]
-    //             x != y
-    //             && selected_elements_seq.contains(x)
-    //             && selected_elements_seq.contains(y) implies x.object_ref() != y.object_ref() by {
-    //             finite_set_to_seq_contains_all_set_elements(selected_elements);
-    //             assert(selected_elements.contains(x));
-    //             assert(selected_elements.contains(y));
-    //         }
+    // TODO: Shorten up this proof.
+    assert_by(objects_to_pods(resp_objs).unwrap().no_duplicates(), {
+        let selector = |o: DynamicObjectView| {
+            &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
+            &&& o.object_ref().kind == PodView::kind()
+        };
+        let selected_elements = s.resources().values().filter(selector);
+        lemma_values_finite(s.resources());
+        finite_set_to_seq_has_no_duplicates(selected_elements);
+        let selected_elements_seq = selected_elements.to_seq();
+        let pods_seq = objects_to_pods(selected_elements_seq).unwrap();
+        assert(selected_elements_seq.no_duplicates());
 
-    //         let lem = forall |x: DynamicObjectView, y: DynamicObjectView| #![auto]
-    //             x != y
-    //             && selected_elements_seq.contains(x)
-    //             && selected_elements_seq.contains(y) ==> x.object_ref() != y.object_ref();
+        assert forall |x: DynamicObjectView, y: DynamicObjectView| #![auto]
+            x != y
+            && selected_elements_seq.contains(x)
+            && selected_elements_seq.contains(y) implies x.object_ref() != y.object_ref() by {
+            finite_set_to_seq_contains_all_set_elements(selected_elements);
+            assert(selected_elements.contains(x));
+            assert(selected_elements.contains(y));
+        }
 
-    //         assert forall |i: int, j: int| #![auto]
-    //             0 <= i && i < pods_seq.len() && (0 <= j && j < pods_seq.len()) && !(i == j)
-    //             && objects_to_pods(selected_elements_seq).is_Some()
-    //             && lem
-    //             implies pods_seq[i] != pods_seq[j] by {
-    //             let o1 = selected_elements_seq[i];
-    //             let o2 = selected_elements_seq[j];
-    //             assert(o1.object_ref() != o2.object_ref());
-    //             PodView::marshal_preserves_integrity();
-    //             seq_pred_false_on_all_elements_is_equivalent_to_empty_filter(selected_elements_seq, |o: DynamicObjectView| PodView::unmarshal(o).is_err());
-    //             assert(selected_elements_seq.filter(|o: DynamicObjectView| PodView::unmarshal(o).is_err()).len() == 0);
-    //             assert(selected_elements_seq.contains(o1));
-    //             assert(selected_elements_seq.contains(o2));
-    //         }
+        let lem = forall |x: DynamicObjectView, y: DynamicObjectView| #![auto]
+            x != y
+            && selected_elements_seq.contains(x)
+            && selected_elements_seq.contains(y) ==> x.object_ref() != y.object_ref();
 
-    //         assert(pods_seq.no_duplicates());
-    //     });
-    //     assert(matching_pods(vrs, s.resources()) == resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set() && resp_objs.no_duplicates()) by {
-    //         // reveal API server spec
-    //         let selector = |o: DynamicObjectView| {
-    //             &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
-    //             &&& o.object_ref().kind == PodView::kind()
-    //         };
-    //         assert(resp_objs == s.resources().values().filter(selector).to_seq());
-    //         // consistency of no_duplicates
-    //         lemma_values_finite(s.resources());
-    //         finite_set_to_finite_filtered_set(s.resources().values(), selector);
-    //         finite_set_to_seq_has_no_duplicates(s.resources().values().filter(selector));
-    //         assert(resp_objs.no_duplicates());
+        assert forall |i: int, j: int| #![auto]
+            0 <= i && i < pods_seq.len() && (0 <= j && j < pods_seq.len()) && !(i == j)
+            && objects_to_pods(selected_elements_seq).is_Some()
+            && lem
+            implies pods_seq[i] != pods_seq[j] by {
+            let o1 = selected_elements_seq[i];
+            let o2 = selected_elements_seq[j];
+            assert(o1.object_ref() != o2.object_ref());
+            PodView::marshal_preserves_integrity();
+            seq_pred_false_on_all_elements_is_equivalent_to_empty_filter(selected_elements_seq, |o: DynamicObjectView| PodView::unmarshal(o).is_err());
+            assert(selected_elements_seq.filter(|o: DynamicObjectView| PodView::unmarshal(o).is_err()).len() == 0);
+            assert(selected_elements_seq.contains(o1));
+            assert(selected_elements_seq.contains(o2));
+        }
 
-    //         // reveal matching_pods logic
-    //         let matched_pods = matching_pods(vrs, s.resources());
-    //         assert(matched_pods =~= s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj))) by {
-    //             assert forall |obj| s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) implies matched_pods.contains(obj) by {
-    //                 assert(owned_selector_match_is(vrs, obj));
-    //                 assert(s.resources().contains_key(obj.object_ref()) && s.resources()[obj.object_ref()] == obj);
-    //                 assert(matched_pods.contains(obj));                                                
-    //             }
-    //             assert forall |obj| matched_pods.contains(obj) implies s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) by {
-    //                 assert(s.resources().contains_key(obj.object_ref()));
-    //                 assert(owned_selector_match_is(vrs, obj));
-    //             }
-    //             // optional if antisymmetry_of_set_equality is imported
-    //             assert(forall |obj| matched_pods.contains(obj) == s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj));
-    //         }
-    //         assert(s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)) == matching_pods(vrs, s.resources()));
-            
-    //         // get rid of DS conversion, basically babysitting Verus
-    //         assert(resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set() =~= s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj))) by {
-    //             assert(resp_objs == s.resources().values().filter(selector).to_seq());
-    //             assert((|obj : DynamicObjectView| owned_selector_match_is(vrs, obj) && selector(obj)) =~= (|obj : DynamicObjectView| owned_selector_match_is(vrs, obj)));
-    //             seq_filter_preserves_no_duplicates(resp_objs, |obj| owned_selector_match_is(vrs, obj));
-    //             seq_filter_is_a_subset_of_original_seq(resp_objs, |obj| owned_selector_match_is(vrs, obj));
-    //             finite_set_to_seq_contains_all_set_elements(s.resources().values().filter(selector));
-    //             finite_set_to_seq_contains_all_set_elements(s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)));
-    //             assert(forall |obj| resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set().contains(obj) ==> {
-    //                 &&& resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj)
-    //                 &&& #[trigger] resp_objs.contains(obj)
-    //                 &&& s.resources().values().filter(selector).to_seq().contains(obj)
-    //                 &&& s.resources().values().filter(selector).contains(obj)
-    //                 &&& s.resources().values().contains(obj)
-    //                 &&& #[trigger] owned_selector_match_is(vrs, obj)
-    //                 &&& s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj)
-    //             });
-    //             assert(forall |obj| s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) ==> {
-    //                 &&& s.resources().values().contains(obj)
-    //                 &&& owned_selector_match_is(vrs, obj)
-    //                 &&& #[trigger] selector(obj)
-    //                 &&& s.resources().values().filter(selector).contains(obj)
-    //                 &&& s.resources().values().filter(selector).to_seq().contains(obj)
-    //                 &&& resp_objs.contains(obj)
-    //                 &&& resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj)
-    //                 &&& resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set().contains(obj)
-    //             });
-    //         }
-    //     }
-    //     assert({
-    //         &&& s_prime.in_flight().contains(resp_msg)
-    //         &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-    //         &&& resp_msg.content.get_list_response().res.is_Ok()
-    //         &&& {
-    //             let resp_objs = resp_msg.content.get_list_response().res.unwrap();
-    //             //&&& resp_objs.no_duplicates()
-    //             &&& objects_to_pods(resp_objs).is_Some()
-    //             &&& objects_to_pods(resp_objs).unwrap().no_duplicates()
-    //             &&& resp_objs.no_duplicates()
-    //             &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).is_Ok()
-    //             &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).unwrap().metadata.namespace.is_Some()
-    //             &&& forall |obj| resp_objs.contains(obj) ==> #[trigger] PodView::unmarshal(obj).unwrap().metadata.namespace == vrs.metadata.namespace
-    //         }
-    //     });
-    //     assert(post(s_prime));
+        assert(pods_seq.no_duplicates());
+    });
+
+    assert_by(resp_obj_keys.no_duplicates(), {
+        let selector = |o: DynamicObjectView| {
+            &&& o.object_ref().namespace == msg.content.get_list_request().namespace
+            &&& o.object_ref().kind == msg.content.get_list_request().kind
+        };
+        let selected_elements = s.resources().values().filter(selector);
+        lemma_values_finite(s.resources());
+        finite_set_to_seq_has_no_duplicates(selected_elements);
+        let selected_elements_seq = selected_elements.to_seq();
+        assert(selected_elements_seq.no_duplicates());
+        assert forall |o1: DynamicObjectView, o2: DynamicObjectView| #![auto]
+            o1 != o2
+            && selected_elements_seq.contains(o1)
+            && selected_elements_seq.contains(o2)
+            && pre
+            implies o1.object_ref() != o2.object_ref() by {
+            finite_set_to_seq_contains_all_set_elements(selected_elements);
+            assert(selected_elements.contains(o1));
+            assert(selected_elements.contains(o2));
+            assert(s.resources().values().contains(o1));
+            assert(s.resources().values().contains(o2));
+            assert(o1.object_ref() != o2.object_ref());
+        }
+        let selected_element_keys = selected_elements_seq.map_values(|o: DynamicObjectView| o.object_ref());
+        assert(selected_element_keys.no_duplicates());
+        assert(resp_obj_keys =~= selected_element_keys);
+    });
+
+    assert(matching_pods(vrs, s.resources()) == resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set() && resp_objs.no_duplicates()) by {
+        // reveal API server spec
+        let selector = |o: DynamicObjectView| {
+            &&& o.object_ref().namespace == vrs.metadata.namespace.unwrap()
+            &&& o.object_ref().kind == PodView::kind()
+        };
+        assert(resp_objs == s.resources().values().filter(selector).to_seq());
+        // consistency of no_duplicates
+        lemma_values_finite(s.resources());
+        finite_set_to_finite_filtered_set(s.resources().values(), selector);
+        finite_set_to_seq_has_no_duplicates(s.resources().values().filter(selector));
+        assert(resp_objs.no_duplicates());
+
+        // reveal matching_pods logic
+        let matched_pods = matching_pods(vrs, s.resources());
+        assert(matched_pods =~= s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj))) by {
+            assert forall |obj| s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) implies matched_pods.contains(obj) by {
+                assert(owned_selector_match_is(vrs, obj));
+                assert(s.resources().contains_key(obj.object_ref()) && s.resources()[obj.object_ref()] == obj);
+                assert(matched_pods.contains(obj));                                                
+            }
+            assert forall |obj| matched_pods.contains(obj) implies s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) by {
+                assert(s.resources().contains_key(obj.object_ref()));
+                assert(owned_selector_match_is(vrs, obj));
+            }
+            // optional if antisymmetry_of_set_equality is imported
+            assert(forall |obj| matched_pods.contains(obj) == s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj));
+        }
+        assert(s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)) == matching_pods(vrs, s.resources()));
+        
+        // get rid of DS conversion, basically babysitting Verus
+        assert(resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set() =~= s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj))) by {
+            assert(resp_objs == s.resources().values().filter(selector).to_seq());
+            assert((|obj : DynamicObjectView| owned_selector_match_is(vrs, obj) && selector(obj)) =~= (|obj : DynamicObjectView| owned_selector_match_is(vrs, obj)));
+            seq_filter_preserves_no_duplicates(resp_objs, |obj| owned_selector_match_is(vrs, obj));
+            seq_filter_is_a_subset_of_original_seq(resp_objs, |obj| owned_selector_match_is(vrs, obj));
+            finite_set_to_seq_contains_all_set_elements(s.resources().values().filter(selector));
+            finite_set_to_seq_contains_all_set_elements(s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)));
+            // Fix to get rid of flaky proof.
+            assert forall |obj| #![trigger owned_selector_match_is(vrs, obj)]
+                resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set().contains(obj)
+                implies
+                s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj) by {
+                assert(resp_objs.contains(obj));
+                assert(s.resources().values().filter(selector).to_seq().contains(obj));
+                assert(s.resources().values().filter(selector).contains(obj));
+                assert(s.resources().values().contains(obj));
+                assert(owned_selector_match_is(vrs, obj));
+                assert(s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj));
+            }
+            assert forall |obj| #![trigger owned_selector_match_is(vrs, obj)]
+                s.resources().values().filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj)
+                implies
+                resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set().contains(obj) by {
+                assert(s.resources().values().contains(obj));
+                assert(selector(obj));
+                assert(s.resources().values().filter(selector).contains(obj));
+                assert(s.resources().values().filter(selector).to_seq().contains(obj));
+                assert(resp_objs.contains(obj));
+                assert(resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).contains(obj));
+                assert(resp_objs.filter(|obj| owned_selector_match_is(vrs, obj)).to_set().contains(obj));
+            }
+        }
+    }
+
+    return resp_msg;
 }
 
-// TODO: Prove this
-#[verifier(external_body)]
 pub proof fn lemma_create_matching_pod_request_adds_matching_pod_and_returns_ok(
     s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
     msg: Message,
@@ -266,29 +280,83 @@ pub proof fn lemma_create_matching_pod_request_adds_matching_pod_and_returns_ok(
     requires
         cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
         req_msg_is_create_matching_pod_req(vrs, msg),
+        Cluster::desired_state_is(vrs)(s),
         Cluster::each_object_in_etcd_is_weakly_well_formed()(s),
         cluster.each_builtin_object_in_etcd_is_well_formed()(s),
         cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s),
         cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s),
         Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s),
         helper_invariants::no_other_pending_request_interferes_with_vrs_reconcile(vrs, controller_id)(s),
-        forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)
-            ==> #[trigger] vrs_rely(other_id)(s),
+        Cluster::etcd_is_finite()(s),
         cluster.type_is_installed_in_cluster::<VReplicaSetView>(),
     ensures
         resp_msg == handle_create_request_msg(cluster.installed_types, msg, s.api_server).1,
         resp_msg.content.get_create_response().res.is_Ok(),
         matching_pods(vrs, s.resources()).insert(
-            new_obj_in_etcd(s, cluster, make_pod(vrs).marshal())
+            new_obj_in_etcd(
+                s, cluster, 
+                CreateRequest {
+                    namespace: vrs.metadata.namespace.unwrap(),
+                    obj: make_pod(vrs).marshal(),
+                }
+            )
         ) == matching_pods(vrs, s_prime.resources()),
-        // should be an obvious corollary of `generated_name_is_unique`.
         matching_pods(vrs, s.resources()).len() + 1 == matching_pods(vrs, s_prime.resources()).len(),
 {
+    let created_obj = new_obj_in_etcd(s, cluster, msg.content.get_create_request());
+
+    PodView::marshal_preserves_integrity();
+    generated_name_is_unique(s.api_server);
+
+    // reasoning about owner_references to prove that 
+    // our request creates a vrs-owned pod.
+    assert(created_obj.metadata.owner_references == Some(seq![vrs.controller_owner_ref()]));
+    assert(created_obj.metadata.owner_references.get_Some_0()[0] == vrs.controller_owner_ref());
+    assert(created_obj.metadata.owner_references_contains(vrs.controller_owner_ref()));
+    
+    assert(owned_selector_match_is(vrs, created_obj));
+
+    assert(
+        matching_pod_entries(vrs, s_prime.resources())
+        == matching_pod_entries(vrs, s.resources()).insert(created_obj.object_ref(), created_obj)
+    );
+    assert_by(
+        matching_pod_entries(vrs, s.resources()).insert(created_obj.object_ref(), created_obj).values()
+        =~= matching_pod_entries(vrs, s.resources()).values().insert(created_obj),
+        {
+            assert forall |o: DynamicObjectView|
+                #[trigger] matching_pod_entries(vrs, s.resources()).values().insert(created_obj).contains(o) 
+                implies matching_pod_entries(vrs, s.resources()).insert(created_obj.object_ref(), created_obj).values().contains(o) by {
+                if o == created_obj {
+                    assert(
+                        matching_pod_entries(vrs, s.resources())
+                            .insert(created_obj.object_ref(), created_obj)[created_obj.object_ref()] == created_obj
+                    );
+                } else {
+                    assert(matching_pod_entries(vrs, s.resources()).values().contains(o));
+                    let key = choose |key: ObjectRef|
+                        matching_pod_entries(vrs, s.resources()).contains_key(key)
+                        && #[trigger] matching_pod_entries(vrs, s.resources())[key] == o;
+                    assert(
+                        matching_pod_entries(vrs, s.resources())
+                            .insert(created_obj.object_ref(), created_obj)[key] == o
+                    );
+                }
+            }
+        }
+    );
+
+    a_submap_of_a_finite_map_is_finite(
+        matching_pod_entries(vrs, s.resources()),
+        s.resources()
+    );
+    lemma_values_finite(matching_pod_entries(vrs, s.resources()));
+    
+    helper_lemmas::matching_pods_equal_to_matching_pod_entries_values(vrs, s.resources());
+    helper_lemmas::matching_pods_equal_to_matching_pod_entries_values(vrs, s_prime.resources());
     return handle_create_request_msg(cluster.installed_types, msg, s.api_server).1;
 }
 
-// TODO: Prove this (I imagine we'll need a subtly different precondition and postcondition).
-#[verifier(external_body)]
 pub proof fn lemma_get_then_delete_matching_pod_request_deletes_matching_pod_and_returns_ok(
     s: ClusterState, s_prime: ClusterState, vrs: VReplicaSetView, cluster: Cluster, controller_id: int, 
     msg: Message,
@@ -302,12 +370,11 @@ pub proof fn lemma_get_then_delete_matching_pod_request_deletes_matching_pod_and
         cluster.every_in_flight_req_msg_from_controller_has_valid_controller_id()(s),
         Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s),
         helper_invariants::no_other_pending_request_interferes_with_vrs_reconcile(vrs, controller_id)(s),
-        forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)
-            ==> #[trigger] vrs_rely(other_id)(s),
+        Cluster::etcd_is_finite()(s),
         cluster.type_is_installed_in_cluster::<VReplicaSetView>(),
     ensures
         resp_msg == handle_get_then_delete_request_msg(msg, s.api_server).1,
-        resp_msg.content.get_create_response().res.is_Ok(),
+        resp_msg.content.get_get_then_delete_response().res.is_Ok(),
         // identifies specific pod deleted.
         ({
             let state = VReplicaSetReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vrs.object_ref()].local_state).unwrap();
@@ -321,6 +388,26 @@ pub proof fn lemma_get_then_delete_matching_pod_request_deletes_matching_pod_and
         // should be an obvious corollary of `generated_name_is_unique`.
         matching_pods(vrs, s.resources()).len() == matching_pods(vrs, s_prime.resources()).len() + 1,
 {
+    let key = msg.content.get_get_then_delete_request().key;
+    let obj = s.resources()[key];
+
+    assert(
+        matching_pod_entries(vrs, s_prime.resources())
+        == matching_pod_entries(vrs, s.resources()).remove(key)
+    );
+    assert(
+        matching_pod_entries(vrs, s.resources()).remove(key).values()
+        == matching_pod_entries(vrs, s.resources()).values().remove(obj)
+    );
+
+    a_submap_of_a_finite_map_is_finite(
+        matching_pod_entries(vrs, s.resources()),
+        s.resources()
+    );
+    lemma_values_finite(matching_pod_entries(vrs, s.resources()));
+
+    helper_lemmas::matching_pods_equal_to_matching_pod_entries_values(vrs, s.resources());
+    helper_lemmas::matching_pods_equal_to_matching_pod_entries_values(vrs, s_prime.resources());
     return handle_get_then_delete_request_msg(msg, s.api_server).1;
 }
 

--- a/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
+++ b/src/v2/controllers/vreplicaset_controller/proof/liveness/resource_match.rs
@@ -477,6 +477,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_receive_create_pod_resp(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -625,6 +626,7 @@ pub proof fn lemma_from_after_receive_create_pod_resp_to_receive_create_pod_resp
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -748,6 +750,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_receive_delete_pod_resp(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -899,6 +902,7 @@ pub proof fn lemma_from_after_receive_delete_pod_resp_to_receive_delete_pod_resp
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -1145,6 +1149,7 @@ pub proof fn lemma_from_after_send_list_pods_req_to_receive_list_pods_resp(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(Cluster::etcd_is_finite()))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
@@ -1190,6 +1195,7 @@ pub proof fn lemma_from_after_send_list_pods_req_to_receive_list_pods_resp(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -1214,6 +1220,7 @@ pub proof fn lemma_from_after_send_list_pods_req_to_receive_list_pods_resp(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -1283,6 +1290,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_done(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(Cluster::etcd_is_finite()))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
@@ -1329,6 +1337,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_done(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -1354,6 +1363,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_done(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -1412,6 +1422,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_create_pod_req(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -1459,6 +1470,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_create_pod_req(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -1484,6 +1496,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_create_pod_req(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -1540,6 +1553,7 @@ pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -1587,6 +1601,7 @@ pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -1611,6 +1626,7 @@ pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -1679,6 +1695,7 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_create_pod_req(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -1727,6 +1744,7 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_create_pod_req(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -1751,6 +1769,7 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_create_pod_req(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -1803,6 +1822,7 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_create_pod_step_to_done(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -1849,6 +1869,7 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_create_pod_step_to_done(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -1873,6 +1894,7 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_create_pod_step_to_done(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -1929,6 +1951,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_delete_pod_req(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -1977,6 +2000,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_delete_pod_req(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -2001,6 +2025,7 @@ pub proof fn lemma_from_after_receive_list_pods_resp_to_send_delete_pod_req(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -2102,6 +2127,7 @@ pub proof fn lemma_from_after_send_delete_pod_req_to_receive_ok_resp(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -2153,6 +2179,7 @@ pub proof fn lemma_from_after_send_delete_pod_req_to_receive_ok_resp(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -2177,6 +2204,7 @@ pub proof fn lemma_from_after_send_delete_pod_req_to_receive_ok_resp(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -2296,6 +2324,7 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_delete_pod_req(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -2348,6 +2377,7 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_delete_pod_req(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -2372,6 +2402,7 @@ pub proof fn lemma_from_after_receive_ok_resp_to_send_delete_pod_req(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),
@@ -2459,6 +2490,7 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_delete_pod_step_to_done(
         spec.entails(always(lift_state(Cluster::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Cluster::every_in_flight_msg_has_unique_id()))),
         spec.entails(always(lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()))),
+        spec.entails(always(lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()))),
         spec.entails(always(lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())))),
         spec.entails(always(lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()))),
         spec.entails(always(lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()))),
@@ -2507,6 +2539,7 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_delete_pod_step_to_done(
         &&& Cluster::pod_monkey_disabled()(s)
         &&& Cluster::every_in_flight_msg_has_unique_id()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
+        &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())(s)
         &&& cluster.each_builtin_object_in_etcd_is_well_formed()(s)
         &&& cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()(s)
@@ -2531,6 +2564,7 @@ pub proof fn lemma_from_after_receive_ok_resp_at_after_delete_pod_step_to_done(
         lift_state(Cluster::pod_monkey_disabled()),
         lift_state(Cluster::every_in_flight_msg_has_unique_id()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed()),
+        lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::every_msg_from_key_is_pending_req_msg_of(controller_id, vrs.object_ref())),
         lift_state(cluster.each_builtin_object_in_etcd_is_well_formed()),
         lift_state(cluster.each_custom_object_in_etcd_is_well_formed::<VReplicaSetView>()),

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -130,7 +130,7 @@ pub open spec fn pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cont
     }
 }
 
-pub open spec fn pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(
+pub open spec fn pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(
     controller_id: int, key: ObjectRef
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
@@ -141,6 +141,11 @@ pub open spec fn pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(
             &&& Self::request_sent_by_controller(controller_id, msg)
             &&& (s.in_flight().contains(msg)
                 || exists |resp_msg: Message| {
+                    &&& #[trigger] s.in_flight().contains(resp_msg)
+                    &&& resp_msg_matches_req_msg(resp_msg, msg)
+                })
+            &&& !(s.in_flight().contains(msg)
+                && exists |resp_msg: Message| {
                     &&& #[trigger] s.in_flight().contains(resp_msg)
                     &&& resp_msg_matches_req_msg(resp_msg, msg)
                 })

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_liveness.rs
@@ -130,6 +130,24 @@ pub open spec fn pending_req_in_flight_or_resp_in_flight_at_reconcile_state(cont
     }
 }
 
+pub open spec fn pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(
+    controller_id: int, key: ObjectRef
+) -> StatePred<ClusterState> {
+    |s: ClusterState| {
+        (s.ongoing_reconciles(controller_id).contains_key(key)
+        && Self::has_pending_req_msg(controller_id, s, key))
+        ==> {
+            let msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+            &&& Self::request_sent_by_controller(controller_id, msg)
+            &&& (s.in_flight().contains(msg)
+                || exists |resp_msg: Message| {
+                    &&& #[trigger] s.in_flight().contains(resp_msg)
+                    &&& resp_msg_matches_req_msg(resp_msg, msg)
+                })
+        }
+    }
+}
+
 pub open spec fn resp_in_flight_matches_pending_req_at_reconcile_state(controller_id: int, key: ObjectRef, current_state: spec_fn(ReconcileLocalState) -> bool) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -838,7 +838,6 @@ pub open spec fn every_msg_from_key_is_pending_req_msg_of(
     controller_id: int, key: ObjectRef
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        // true
         forall |msg: Message| #![trigger s.in_flight().contains(msg)] {
             &&& msg.src == HostId::Controller(controller_id, key)
             &&& msg.content.is_APIRequest()
@@ -851,28 +850,6 @@ pub open spec fn every_msg_from_key_is_pending_req_msg_of(
     }
 }
 
-// TODO: prove this.
-// dummy proof; not entirely sure which phase this should go in.
-// #[verifier(external_body)]
-// pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of(
-//     self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef
-// )
-//     requires
-//         spec.entails(always(lift_action(self.next()))),
-//         self.controller_models.contains_key(controller_id),
-//         spec.entails(tla_forall(|i| self.api_server_next().weak_fairness(i))),
-//         spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
-//         spec.entails(always(lift_state(Self::crash_disabled(controller_id)))),
-//         spec.entails(always(lift_state(Self::req_drop_disabled()))),
-//         spec.entails(always(lift_state(Self::pod_monkey_disabled()))),
-//         spec.entails(always(lift_state(Self::every_in_flight_msg_has_unique_id()))),
-//         spec.entails(always(lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()))),
-//     ensures spec.entails(true_pred().leads_to(always(lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key))))),
-// {
-    
-// }
-
-//#[verifier(external_body)]
 pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef)
     requires
         spec.entails(always(lift_action(self.next()))),
@@ -883,178 +860,113 @@ pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of
         spec.entails(always(lift_state(Self::req_drop_disabled()))),
         spec.entails(always(lift_state(Self::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)))),
+        spec.entails(always(lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()))),
         spec.entails(always(lift_state(Self::pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(controller_id, key)))),
-        spec.entails(always(lift_state(Cluster::no_pending_req_msg_at_reconcile_state(
+        spec.entails(always(lift_state(Self::no_pending_req_msg_at_reconcile_state(
                 controller_id,
                 key,
                 self.reconcile_model(controller_id).done
             )))),
-        spec.entails(always(lift_state(Cluster::no_pending_req_msg_at_reconcile_state(
+        spec.entails(always(lift_state(Self::no_pending_req_msg_at_reconcile_state(
                 controller_id,
                 key,
                 self.reconcile_model(controller_id).error
             )))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key))))),
 {
-    let invariant = Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key);
-
-
+    let requirements = |msg: Message, s: ClusterState| {
+        ({
+            &&& msg.src == HostId::Controller(controller_id, key)
+            &&& msg.content.is_APIRequest()
+            &&& msg.dst.is_APIServer()
+            &&& s.in_flight().contains(msg)
+        }) ==> ({
+            &&& s.ongoing_reconciles(controller_id).contains_key(key)
+            &&& Self::pending_req_msg_is(controller_id, s, key, msg)
+        })
+    };
+    let requirements_antecedent = |msg: Message, s: ClusterState| {
+        &&& msg.src == HostId::Controller(controller_id, key)
+        &&& msg.content.is_APIRequest()
+        &&& msg.dst.is_APIServer()
+        &&& s.in_flight().contains(msg)
+    };
 
     let stronger_next = |s, s_prime| {
         &&& self.next()(s, s_prime)
-        &&& Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s)
         &&& Self::there_is_the_controller_state(controller_id)(s)
-        &&& Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key)(s)
+        &&& Self::crash_disabled(controller_id)(s)
+        &&& Self::req_drop_disabled()(s)
+        &&& Self::pod_monkey_disabled()(s)
+        &&& Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s)
+        &&& Self::pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(controller_id, key)(s)
+        &&& Self::no_pending_req_msg_at_reconcile_state(
+                controller_id,
+                key,
+                self.reconcile_model(controller_id).done
+            )(s)
+        &&& Self::no_pending_req_msg_at_reconcile_state(
+                controller_id,
+                key,
+                self.reconcile_model(controller_id).error
+            )(s)
     };
 
-    assert forall |s, s_prime| invariant(s) && #[trigger] stronger_next(s, s_prime) implies invariant(s_prime) by {
-        assert forall |msg| #![trigger s.in_flight().contains(msg)] {
-            &&& invariant(s)
-            &&& stronger_next(s, s_prime)
-            &&& msg.src == HostId::Controller(controller_id, key)
-            &&& msg.content.is_APIRequest()
-            &&& s_prime.in_flight().contains(msg)
-        } implies {
-            &&& s_prime.ongoing_reconciles(controller_id).contains_key(key)
-            &&& Cluster::pending_req_msg_is(controller_id, s_prime, key, msg)
-        }  by {
-            if s.in_flight().contains(msg) {}
-            assume(Self::pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(controller_id, key)(s));
-            assume(Self::crash_disabled(controller_id)(s));
-            assume(Cluster::no_pending_req_msg_at_reconcile_state(
-                    controller_id,
-                    key,
-                    self.reconcile_model(controller_id).done
-                )(s));
-            assume(Cluster::no_pending_req_msg_at_reconcile_state(
-                    controller_id,
-                    key,
-                    self.reconcile_model(controller_id).error
-                )(s));
-            let next_step = choose |step| self.next_step(s, s_prime, step);
-             match next_step {
-                Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
-                    let resp_msg = resp_msg_opt.unwrap();
-                    let cr_key = cr_key_opt.unwrap();
+    assert forall |s: ClusterState, s_prime: ClusterState| #[trigger]  #[trigger] stronger_next(s, s_prime) implies Self::every_new_req_msg_if_in_flight_then_satisfies(requirements)(s, s_prime) by {
+        assert forall |msg: Message| (!s.in_flight().contains(msg) || requirements(msg, s)) && #[trigger] s_prime.in_flight().contains(msg)
+        implies requirements(msg, s_prime) by {
+            if requirements_antecedent(msg, s_prime) {
+                if s.in_flight().contains(msg) {}
 
-                    if id == controller_id
-                        && cr_key_opt.is_Some() && cr_key == key {
-                        // Requires invariant 
-                        // `pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg`
-                        // if there's an incoming message, the `no_pending_req_msg_at_reconcile_state`
-                        // family if there's not one (meaning we're done).
-                        // 
-                        // (comment left to provide a hint of the reasoning needed).
-                    }
-                },
-                _ => {},
-            }
-            //assume(false);
-        }
-        // if s_prime.ongoing_reconciles(controller_id).contains_key(key)
-        //     && Self::has_pending_req_msg(controller_id, s_prime, key) {
-        //     let next_step = choose |step| self.next_step(s, s_prime, step);
-        //     let pending_req_msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
-        //     let resp = choose |msg| {
-        //         #[trigger] s.in_flight().contains(msg)
-        //         && resp_msg_matches_req_msg(msg, pending_req_msg)
-        //     };
-        //     match next_step {
-        //         Step::APIServerStep(input) => {
-        //             if input == Some(pending_req_msg) {
-        //                 let resp_msg = transition_by_etcd(self.installed_types, pending_req_msg, s.api_server).1;
-        //                 assert(s_prime.in_flight().contains(resp_msg));
-        //             } else {
-        //                 if !s.in_flight().contains(pending_req_msg) {
-        //                     assert(s_prime.in_flight().contains(resp));
-        //                 }
-        //             }
-        //         }
-        //         Step::BuiltinControllersStep(input) => {
-        //             if s.in_flight().contains(pending_req_msg) {
-        //                 assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
-        //             } else {
-        //                 assert(s_prime.in_flight().contains(resp));
-        //             }
-        //         }
-        //         Step::DropReqStep(input) => {
-        //             if input.0 == pending_req_msg {
-        //                 let resp_msg = form_matched_err_resp_msg(pending_req_msg, input.1);
-        //                 assert(s_prime.in_flight().contains(resp_msg));
-        //             } else {
-        //                 if !s.in_flight().contains(pending_req_msg) {
-        //                     assert(s_prime.in_flight().contains(resp));
-        //                 }
-        //             }
-        //         }
-        //         Step::ControllerStep(input) => {
-        //             let input_controller_id = input.0;
-        //             let input_cr_key = input.2.get_Some_0();
-        //             if input_controller_id != controller_id || input_cr_key != key {
-        //                 if s.in_flight().contains(pending_req_msg) {
-        //                     assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
-        //                 } else {
-        //                     assert(s_prime.in_flight().contains(resp));
-        //                 }
-        //             } else {
-        //                 assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
-        //             }
-        //         }
-        //         Step::PodMonkeyStep(input) => {
-        //             if s.in_flight().contains(pending_req_msg) {
-        //                 assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
-        //             } else {
-        //                 assert(s_prime.in_flight().contains(resp));
-        //             }
-        //         }
-        //         Step::ExternalStep(input) => {
-        //             if input.0 == controller_id && input.1 == Some(pending_req_msg) {
-        //                 let resp_msg = transition_by_external(self.controller_models[controller_id].external_model.get_Some_0(), pending_req_msg, s.api_server.resources, s.controller_and_externals[controller_id].external.get_Some_0()).1;
-        //                 assert(s_prime.in_flight().contains(resp_msg));
-        //             } else {
-        //                 if !s.in_flight().contains(pending_req_msg) {
-        //                     assert(s_prime.in_flight().contains(resp));
-        //                 }
-        //             }
-        //         }
-        //         _ => {
-        //             assert(invariant(s_prime));
-        //         }
-        //     }
-        // }
-    }
-    self.lemma_always_there_is_the_controller_state(spec, controller_id);
-    self.lemma_always_pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(spec, controller_id, key);
-    combine_spec_entails_always_n!(
-        spec, lift_action(stronger_next), lift_action(self.next()),
-        lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)),
-        lift_state(Self::there_is_the_controller_state(controller_id)),
-        lift_state(Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key))
-    );
-    init_invariant::<ClusterState>(spec, self.init(), stronger_next, invariant);
-}
+                let next_step = choose |step| self.next_step(s, s_prime, step);
+                match next_step {
+                    Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
+                        let resp_msg = resp_msg_opt.unwrap();
+                        let cr_key = cr_key_opt.unwrap();
 
-pub proof fn test_lemma(self, s: ClusterState, s_prime: ClusterState, controller_id: int, key: ObjectRef) 
-    requires
-        self.controller_models.contains_key(controller_id),
-        self.next()(s, s_prime),
-        Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s),
-        Self::there_is_the_controller_state(controller_id)(s),
-        Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key)(s),
-        s.ongoing_reconciles(controller_id).contains_key(key),
-        s_prime.ongoing_reconciles(controller_id).contains_key(key),
-{
-    let next_step = choose |step| self.next_step(s, s_prime, step);
-    match next_step {
-        Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
-            if id == controller_id && cr_key_opt.is_Some() && cr_key_opt.get_Some_0() == key {
-                if s.ongoing_reconciles(controller_id)[key].pending_req_msg.is_Some() {
-                    assert(resp_msg_opt.is_Some());
+                        if id == controller_id
+                            && cr_key_opt.is_Some() && cr_key == key {
+                            // Requires invariant 
+                            // `pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg`
+                            // if there's an incoming message, the `no_pending_req_msg_at_reconcile_state`
+                            // family if there's not one (meaning we're done).
+                            // 
+                            // (comment left to provide a hint of the reasoning needed).
+                        }
+                    },
+                    _ => {},
                 }
             }
-        },
-        _ => {},
+        }
     }
+
+    invariant_n!(
+        spec, lift_action(stronger_next),
+        lift_action(Self::every_new_req_msg_if_in_flight_then_satisfies(requirements)),
+        lift_action(self.next()),
+        lift_state(Self::there_is_the_controller_state(controller_id)),
+        lift_state(Self::crash_disabled(controller_id)),
+        lift_state(Self::req_drop_disabled()),
+        lift_state(Self::pod_monkey_disabled()),
+        lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)),
+        lift_state(Self::pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(controller_id, key)),
+        lift_state(Self::no_pending_req_msg_at_reconcile_state(
+            controller_id,
+            key,
+            self.reconcile_model(controller_id).done
+        )),
+        lift_state(Self::no_pending_req_msg_at_reconcile_state(
+            controller_id,
+            key,
+            self.reconcile_model(controller_id).error
+        ))
+    );
+
+    self.lemma_true_leads_to_always_every_in_flight_req_msg_satisfies(spec, requirements);
+    temp_pred_equality(
+        lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key)),
+        lift_state(Self::every_in_flight_req_msg_satisfies(requirements))
+    );
 }
 
 }

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -189,100 +189,222 @@ pub proof fn lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_s
     init_invariant::<ClusterState>(spec, self.init(), stronger_next, invariant);
 }
 
-pub proof fn lemma_always_pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef)
+pub proof fn lemma_true_leads_to_always_pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef)
     requires
-        self.controller_models.contains_key(controller_id),
-        spec.entails(lift_state(self.init())),
         spec.entails(always(lift_action(self.next()))),
+        self.controller_models.contains_key(controller_id),
+        spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| self.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+        spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
+        spec.entails(always(lift_state(Self::crash_disabled(controller_id)))),
+        spec.entails(always(lift_state(Self::req_drop_disabled()))),
+        spec.entails(always(lift_state(Self::pod_monkey_disabled()))),
         spec.entails(always(lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)))),
-    ensures spec.entails(always(lift_state(Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key)))),
+        spec.entails(always(lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)))),
+        spec.entails(always(lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()))),
+        spec.entails(always(lift_state(Self::ongoing_reconciles_is_finite(controller_id)))),
+        spec.entails(always(lift_state(Self::every_in_flight_msg_has_no_replicas_and_has_unique_id()))),
+        spec.entails(tla_forall(|key: ObjectRef| true_pred().leads_to(lift_state(|s: ClusterState| !(s.ongoing_reconciles(controller_id).contains_key(key)))))),
+    ensures spec.entails(true_pred().leads_to(always(lift_state(Self::pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(controller_id, key))))),
 {
-    let invariant = Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key);
-    let stronger_next = |s, s_prime| {
-        &&& self.next()(s, s_prime)
-        &&& Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s)
-        &&& Self::there_is_the_controller_state(controller_id)(s)
+    let requirements = |ky: ObjectRef, s: ClusterState| {
+        (s.ongoing_reconciles(controller_id).contains_key(key)
+        && Self::has_pending_req_msg(controller_id, s, key)
+        && ky == key)
+        ==> {
+            let msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+            &&& Self::request_sent_by_controller(controller_id, msg)
+            &&& (s.in_flight().contains(msg)
+                || exists |resp_msg: Message| {
+                    &&& #[trigger] s.in_flight().contains(resp_msg)
+                    &&& resp_msg_matches_req_msg(resp_msg, msg)
+                })
+            &&& !(s.in_flight().contains(msg)
+                && exists |resp_msg: Message| {
+                    &&& #[trigger] s.in_flight().contains(resp_msg)
+                    &&& resp_msg_matches_req_msg(resp_msg, msg)
+                })
+        }
     };
-    assert forall |s, s_prime| invariant(s) && #[trigger] stronger_next(s, s_prime) implies invariant(s_prime) by {
-        if s_prime.ongoing_reconciles(controller_id).contains_key(key)
-            && Self::has_pending_req_msg(controller_id, s_prime, key) {
-            let next_step = choose |step| self.next_step(s, s_prime, step);
-            let pending_req_msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
-            let resp = choose |msg| {
-                #[trigger] s.in_flight().contains(msg)
-                && resp_msg_matches_req_msg(msg, pending_req_msg)
-            };
-            match next_step {
-                Step::APIServerStep(input) => {
-                    if input == Some(pending_req_msg) {
-                        let resp_msg = transition_by_etcd(self.installed_types, pending_req_msg, s.api_server).1;
-                        assert(s_prime.in_flight().contains(resp_msg));
-                    } else {
-                        if !s.in_flight().contains(pending_req_msg) {
-                            assert(s_prime.in_flight().contains(resp));
+    let requirements_antecedent = |ky: ObjectRef, s: ClusterState| {
+        (s.ongoing_reconciles(controller_id).contains_key(key)
+        && Self::has_pending_req_msg(controller_id, s, key)
+        && ky == key)
+    };
+
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& self.next()(s, s_prime)
+        &&& Self::there_is_the_controller_state(controller_id)(s)
+        &&& Self::crash_disabled(controller_id)(s)
+        &&& Self::req_drop_disabled()(s)
+        &&& Self::pod_monkey_disabled()(s)
+        &&& Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s)
+        &&& Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)(s)
+        &&& Self::every_in_flight_msg_has_lower_id_than_allocator()(s)
+        &&& Self::ongoing_reconciles_is_finite(controller_id)(s)
+        &&& Self::every_in_flight_msg_has_no_replicas_and_has_unique_id()(s)
+    };
+
+    assert forall |s: ClusterState, s_prime: ClusterState| #[trigger] stronger_next(s, s_prime) ==> Cluster::every_new_ongoing_reconcile_satisfies(controller_id, requirements)(s, s_prime) by {
+        assert forall |ky: ObjectRef| (!s.ongoing_reconciles(controller_id).contains_key(ky) || requirements(ky, s))
+        && #[trigger] s_prime.ongoing_reconciles(controller_id).contains_key(ky) && stronger_next(s, s_prime) implies requirements(ky, s_prime) by {
+            if requirements_antecedent(ky, s_prime) {
+                let next_step = choose |step| self.next_step(s, s_prime, step);
+                let pending_req_msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+                let resp = choose |msg| {
+                    #[trigger] s.in_flight().contains(msg)
+                    && resp_msg_matches_req_msg(msg, pending_req_msg)
+                };
+                // The difficult part of this case splitting is showing mutual exclusion:
+                // i.e., ~(A /\ \Ex.B(x)). In many places, I need to prove ~\Ex.B(x) which
+                // is equivalent to \Ax.~B(x).
+                // (note A: pending msg in flight, \Ex.B(x): exists response in flight).
+                match next_step {
+                    Step::APIServerStep(input) => {
+                        if input == Some(pending_req_msg) {
+                            let resp_msg = transition_by_etcd(self.installed_types, pending_req_msg, s.api_server).1;
+                            assert(s_prime.in_flight().contains(resp_msg));
+                            assert(!s_prime.in_flight().contains(pending_req_msg));
+                        } else {
+                            if !s.in_flight().contains(pending_req_msg) {
+                                assert(s_prime.in_flight().contains(resp));
+                                assert(!s_prime.in_flight().contains(pending_req_msg));
+                            } else {
+                                let req_msg = input.unwrap();
+                                let resp_msg = transition_by_etcd(self.installed_types, req_msg, s.api_server).1;
+                                assert(s_prime.in_flight().contains(pending_req_msg));
+                                assert(pending_req_msg != req_msg);
+                                assert(!resp_msg_matches_req_msg(resp_msg, pending_req_msg));
+                                assert forall |resp_msg: Message| {
+                                    &&& (!s.ongoing_reconciles(controller_id).contains_key(key) || requirements(key, s))
+                                    &&& s.ongoing_reconciles(controller_id).contains_key(key)
+                                    &&& stronger_next(s, s_prime)
+                                } implies {
+                                    ||| ! #[trigger] s_prime.in_flight().contains(resp_msg)
+                                    ||| !resp_msg_matches_req_msg(resp_msg, pending_req_msg)
+                                } by {
+                                    if s.in_flight().contains(resp_msg) {}
+                                }
+                            }
                         }
                     }
-                }
-                Step::BuiltinControllersStep(input) => {
-                    if s.in_flight().contains(pending_req_msg) {
-                        assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
-                    } else {
-                        assert(s_prime.in_flight().contains(resp));
-                    }
-                }
-                Step::DropReqStep(input) => {
-                    if input.0 == pending_req_msg {
-                        let resp_msg = form_matched_err_resp_msg(pending_req_msg, input.1);
-                        assert(s_prime.in_flight().contains(resp_msg));
-                    } else {
-                        if !s.in_flight().contains(pending_req_msg) {
-                            assert(s_prime.in_flight().contains(resp));
-                        }
-                    }
-                }
-                Step::ControllerStep(input) => {
-                    let input_controller_id = input.0;
-                    let input_cr_key = input.2.get_Some_0();
-                    if input_controller_id != controller_id || input_cr_key != key {
+                    Step::BuiltinControllersStep(input) => {
                         if s.in_flight().contains(pending_req_msg) {
                             assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+                            assert(!exists |resp_msg: Message| {
+                                &&& #[trigger] s.in_flight().contains(resp_msg)
+                                &&& resp_msg_matches_req_msg(resp_msg, pending_req_msg)
+                            });
+                            assert forall |resp_msg: Message| {
+                                &&& (!s.ongoing_reconciles(controller_id).contains_key(key) || requirements(key, s))
+                                &&& s.ongoing_reconciles(controller_id).contains_key(key)
+                                &&& stronger_next(s, s_prime)
+                            } implies {
+                                ||| ! #[trigger] s_prime.in_flight().contains(resp_msg)
+                                ||| !resp_msg_matches_req_msg(resp_msg, pending_req_msg)
+                            } by {
+                                if s.in_flight().contains(resp_msg) {}
+                            }
                         } else {
                             assert(s_prime.in_flight().contains(resp));
-                        }
-                    } else {
-                        assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
-                    }
-                }
-                Step::PodMonkeyStep(input) => {
-                    if s.in_flight().contains(pending_req_msg) {
-                        assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
-                    } else {
-                        assert(s_prime.in_flight().contains(resp));
-                    }
-                }
-                Step::ExternalStep(input) => {
-                    if input.0 == controller_id && input.1 == Some(pending_req_msg) {
-                        let resp_msg = transition_by_external(self.controller_models[controller_id].external_model.get_Some_0(), pending_req_msg, s.api_server.resources, s.controller_and_externals[controller_id].external.get_Some_0()).1;
-                        assert(s_prime.in_flight().contains(resp_msg));
-                    } else {
-                        if !s.in_flight().contains(pending_req_msg) {
-                            assert(s_prime.in_flight().contains(resp));
+                            assert(!s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
                         }
                     }
-                }
-                _ => {
-                    assert(invariant(s_prime));
+                    Step::ControllerStep(input) => {
+                        let input_controller_id = input.0;
+                        let input_cr_key = input.2.get_Some_0();
+                        if input_controller_id != controller_id || input_cr_key != key {
+                            if s.in_flight().contains(pending_req_msg) {
+                                assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+                                assert(!exists |resp_msg: Message| {
+                                    &&& #[trigger] s.in_flight().contains(resp_msg)
+                                    &&& resp_msg_matches_req_msg(resp_msg, pending_req_msg)
+                                });
+                                assert forall |resp_msg: Message| {
+                                    &&& (!s.ongoing_reconciles(controller_id).contains_key(key) || requirements(key, s))
+                                    &&& s.ongoing_reconciles(controller_id).contains_key(key)
+                                    &&& stronger_next(s, s_prime)
+                                } implies {
+                                    ||| ! #[trigger] s_prime.in_flight().contains(resp_msg)
+                                    ||| !resp_msg_matches_req_msg(resp_msg, pending_req_msg)
+                                } by {
+                                    if s.in_flight().contains(resp_msg) {}
+                                }
+                            } else {
+                                assert(s_prime.in_flight().contains(resp));
+                                assert(!s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+                            }
+                        } else {
+                            let new_pending_req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+                            assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+                            assert forall |resp_msg: Message| {
+                                &&& (!s.ongoing_reconciles(controller_id).contains_key(key) || requirements(key, s))
+                                &&& s.ongoing_reconciles(controller_id).contains_key(key)
+                                &&& stronger_next(s, s_prime)
+                            } implies {
+                                ||| ! #[trigger] s_prime.in_flight().contains(resp_msg)
+                                ||| !resp_msg_matches_req_msg(resp_msg, new_pending_req_msg)
+                            } by {
+                                if s.in_flight().contains(resp_msg) {}
+                            }
+                        }
+                    }
+                    Step::ExternalStep(input) => {
+                        if input.0 == controller_id && input.1 == Some(pending_req_msg) {
+                            let resp_msg = transition_by_external(self.controller_models[controller_id].external_model.get_Some_0(), pending_req_msg, s.api_server.resources, s.controller_and_externals[controller_id].external.get_Some_0()).1;
+                            assert(s_prime.in_flight().contains(resp_msg));
+                            assert(!s_prime.in_flight().contains(pending_req_msg));
+                        } else if input.0 == controller_id {
+                            if !s.in_flight().contains(pending_req_msg) {
+                                assert(s_prime.in_flight().contains(resp));
+                                assert(!s_prime.in_flight().contains(pending_req_msg));
+                            } else {
+                                let req_msg = input.1.unwrap();
+                                let resp_msg = transition_by_external(self.controller_models[controller_id].external_model.get_Some_0(), req_msg, s.api_server.resources, s.controller_and_externals[controller_id].external.get_Some_0()).1;
+                                assert(s_prime.in_flight().contains(pending_req_msg));
+                                assert(pending_req_msg != req_msg);
+                                assert(!resp_msg_matches_req_msg(resp_msg, pending_req_msg));
+                                assert forall |resp_msg: Message| {
+                                    &&& (!s.ongoing_reconciles(controller_id).contains_key(key) || requirements(key, s))
+                                    &&& s.ongoing_reconciles(controller_id).contains_key(key)
+                                    &&& stronger_next(s, s_prime)
+                                } implies {
+                                    ||| ! #[trigger] s_prime.in_flight().contains(resp_msg)
+                                    ||| !resp_msg_matches_req_msg(resp_msg, pending_req_msg)
+                                } by {
+                                    if s.in_flight().contains(resp_msg) {}
+                                }
+                            }
+                        }
+                    }
+                    _ => {
+                        assert(requirements(ky, s_prime));
+                    }
                 }
             }
         }
     }
-    self.lemma_always_there_is_the_controller_state(spec, controller_id);
-    combine_spec_entails_always_n!(
-        spec, lift_action(stronger_next), lift_action(self.next()),
+
+    invariant_n!(
+        spec, lift_action(stronger_next), 
+        lift_action(Cluster::every_new_ongoing_reconcile_satisfies(controller_id, requirements)),
+        lift_action(self.next()),
+        lift_state(Self::there_is_the_controller_state(controller_id)),
+        lift_state(Self::crash_disabled(controller_id)),
+        lift_state(Self::req_drop_disabled()),
+        lift_state(Self::pod_monkey_disabled()),
         lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)),
-        lift_state(Self::there_is_the_controller_state(controller_id))
+        lift_state(Self::every_ongoing_reconcile_has_lower_id_than_allocator(controller_id)),
+        lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()),
+        lift_state(Self::ongoing_reconciles_is_finite(controller_id)),
+        lift_state(Self::every_in_flight_msg_has_no_replicas_and_has_unique_id())
     );
-    init_invariant::<ClusterState>(spec, self.init(), stronger_next, invariant);
+
+    self.lemma_true_leads_to_always_every_ongoing_reconcile_satisfies(spec, controller_id, requirements);
+
+    temp_pred_equality(
+        lift_state(Self::pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(controller_id, key)),
+        lift_state(Cluster::every_ongoing_reconcile_satisfies(controller_id, requirements))
+    );
 }
 
 pub proof fn lemma_always_no_pending_req_msg_at_reconcile_state(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef, state: spec_fn(ReconcileLocalState) -> bool)
@@ -716,15 +838,14 @@ pub open spec fn every_msg_from_key_is_pending_req_msg_of(
     controller_id: int, key: ObjectRef
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        //true
-        forall |msg: Message| {
-            &&& #[trigger] s.in_flight().contains(msg)
-            &&& s.ongoing_reconciles(controller_id).contains_key(key)
+        // true
+        forall |msg: Message| #![trigger s.in_flight().contains(msg)] {
             &&& msg.src == HostId::Controller(controller_id, key)
-            &&& (msg.content.is_APIRequest()
-                || msg.content.is_ExternalRequest())
+            &&& msg.content.is_APIRequest()
+            &&& msg.dst.is_APIServer()
+            &&& s.in_flight().contains(msg)
         } ==> {
-            // &&& Cluster::has_pending_req_msg(controller_id, s, key)
+            &&& s.ongoing_reconciles(controller_id).contains_key(key)
             &&& Cluster::pending_req_msg_is(controller_id, s, key, msg)
         }
     }
@@ -732,10 +853,27 @@ pub open spec fn every_msg_from_key_is_pending_req_msg_of(
 
 // TODO: prove this.
 // dummy proof; not entirely sure which phase this should go in.
-#[verifier(external_body)]
-pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of(
-    self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef
-)
+// #[verifier(external_body)]
+// pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of(
+//     self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef
+// )
+//     requires
+//         spec.entails(always(lift_action(self.next()))),
+//         self.controller_models.contains_key(controller_id),
+//         spec.entails(tla_forall(|i| self.api_server_next().weak_fairness(i))),
+//         spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
+//         spec.entails(always(lift_state(Self::crash_disabled(controller_id)))),
+//         spec.entails(always(lift_state(Self::req_drop_disabled()))),
+//         spec.entails(always(lift_state(Self::pod_monkey_disabled()))),
+//         spec.entails(always(lift_state(Self::every_in_flight_msg_has_unique_id()))),
+//         spec.entails(always(lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()))),
+//     ensures spec.entails(true_pred().leads_to(always(lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key))))),
+// {
+    
+// }
+
+//#[verifier(external_body)]
+pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef)
     requires
         spec.entails(always(lift_action(self.next()))),
         self.controller_models.contains_key(controller_id),
@@ -744,29 +882,24 @@ pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of
         spec.entails(always(lift_state(Self::crash_disabled(controller_id)))),
         spec.entails(always(lift_state(Self::req_drop_disabled()))),
         spec.entails(always(lift_state(Self::pod_monkey_disabled()))),
-        spec.entails(always(lift_state(Self::every_in_flight_msg_has_unique_id()))),
-        spec.entails(always(lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()))),
+        spec.entails(always(lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)))),
+        spec.entails(always(lift_state(Self::pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(controller_id, key)))),
+        spec.entails(always(lift_state(Cluster::no_pending_req_msg_at_reconcile_state(
+                controller_id,
+                key,
+                self.reconcile_model(controller_id).done
+            )))),
+        spec.entails(always(lift_state(Cluster::no_pending_req_msg_at_reconcile_state(
+                controller_id,
+                key,
+                self.reconcile_model(controller_id).error
+            )))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key))))),
 {
-    
-}
-
-#[verifier(external_body)]
-pub proof fn lemma_always_every_msg_from_key_is_pending_req_msg_of(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef)
-    requires
-        self.controller_models.contains_key(controller_id),
-        spec.entails(lift_state(self.init())),
-        spec.entails(always(lift_action(self.next()))),
-        spec.entails(always(lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)))),
-    ensures spec.entails(always(lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key)))),
-{
     let invariant = Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key);
-    let invariant_antecedent = |msg: Message, s: ClusterState| {
-        &&& s.in_flight().contains(msg)
-        &&& msg.src == HostId::Controller(controller_id, key)
-        &&& msg.dst.is_APIServer()
-        &&& msg.content.is_APIRequest()
-    };
+
+
+
     let stronger_next = |s, s_prime| {
         &&& self.next()(s, s_prime)
         &&& Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s)
@@ -775,53 +908,43 @@ pub proof fn lemma_always_every_msg_from_key_is_pending_req_msg_of(self, spec: T
     };
 
     assert forall |s, s_prime| invariant(s) && #[trigger] stronger_next(s, s_prime) implies invariant(s_prime) by {
-        assert forall |msg| {
+        assert forall |msg| #![trigger s.in_flight().contains(msg)] {
             &&& invariant(s)
             &&& stronger_next(s, s_prime)
-            &&& #[trigger] s_prime.in_flight().contains(msg)
-            &&& s_prime.ongoing_reconciles(controller_id).contains_key(key)
             &&& msg.src == HostId::Controller(controller_id, key)
-            &&& (msg.content.is_APIRequest()
-                || msg.content.is_ExternalRequest())
+            &&& msg.content.is_APIRequest()
+            &&& s_prime.in_flight().contains(msg)
         } implies {
+            &&& s_prime.ongoing_reconciles(controller_id).contains_key(key)
             &&& Cluster::pending_req_msg_is(controller_id, s_prime, key, msg)
         }  by {
             if s.in_flight().contains(msg) {}
+            assume(Self::pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg(controller_id, key)(s));
+            assume(Self::crash_disabled(controller_id)(s));
+            assume(Cluster::no_pending_req_msg_at_reconcile_state(
+                    controller_id,
+                    key,
+                    self.reconcile_model(controller_id).done
+                )(s));
+            assume(Cluster::no_pending_req_msg_at_reconcile_state(
+                    controller_id,
+                    key,
+                    self.reconcile_model(controller_id).error
+                )(s));
             let next_step = choose |step| self.next_step(s, s_prime, step);
              match next_step {
                 Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
                     let resp_msg = resp_msg_opt.unwrap();
                     let cr_key = cr_key_opt.unwrap();
-                    assume(Self::crash_disabled(controller_id)(s));
 
-                    if cr_key_opt.is_Some() && cr_key == key {
-                        if resp_msg_opt.is_None() {
-                            //assume(cr_key_opt.is_Some());
-                            //assert(continue_reconcile(self.reconcile_model(controller_id), 
-                            assert(s_prime.ongoing_reconciles(controller_id).contains_key(key));
-                            if s.ongoing_reconciles(controller_id).contains_key(key) {
-                                if s.ongoing_reconciles(controller_id)[key].pending_req_msg.is_Some() {
-                                    assert(resp_msg_opt.is_Some());
-                                }
-                            }
-                                
-                            assume(false);
-                            //assume(!Cluster::pending_req_msg_is(controller_id, s, key, msg));
-                            // if s.ongoing_reconciles(controller_id).contains_key(key) {
-                                
-                            // }
-                            //assume(false);
-                            // // here, there was no pending request message
-                            // assume(s.ongoing_reconciles(controller_id).contains_key(key));
-                            // assert(s.ongoing_reconciles(controller_id)[key].pending_req_msg.is_None());
-                            // //assert(!Cluster::pending_req_msg_is(controller_id, s, key, msg));
-                            // //assert(resp_msg_opt.is_Some());
-                            // if !s.in_flight().contains(msg) {
-                            // assume(false);
-                            // }
-                        } else {
-                            assume(false);
-                        }
+                    if id == controller_id
+                        && cr_key_opt.is_Some() && cr_key == key {
+                        // Requires invariant 
+                        // `pending_req_in_flight_xor_resp_in_flight_if_has_pending_req_msg`
+                        // if there's an incoming message, the `no_pending_req_msg_at_reconcile_state`
+                        // family if there's not one (meaning we're done).
+                        // 
+                        // (comment left to provide a hint of the reasoning needed).
                     }
                 },
                 _ => {},
@@ -924,7 +1047,7 @@ pub proof fn test_lemma(self, s: ClusterState, s_prime: ClusterState, controller
     let next_step = choose |step| self.next_step(s, s_prime, step);
     match next_step {
         Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
-            if cr_key_opt.is_Some() && cr_key_opt.get_Some_0() == key {
+            if id == controller_id && cr_key_opt.is_Some() && cr_key_opt.get_Some_0() == key {
                 if s.ongoing_reconciles(controller_id)[key].pending_req_msg.is_Some() {
                     assert(resp_msg_opt.is_Some());
                 }

--- a/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
+++ b/src/v2/kubernetes_cluster/proof/controller_runtime_safety.rs
@@ -189,6 +189,102 @@ pub proof fn lemma_always_pending_req_in_flight_or_resp_in_flight_at_reconcile_s
     init_invariant::<ClusterState>(spec, self.init(), stronger_next, invariant);
 }
 
+pub proof fn lemma_always_pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef)
+    requires
+        self.controller_models.contains_key(controller_id),
+        spec.entails(lift_state(self.init())),
+        spec.entails(always(lift_action(self.next()))),
+        spec.entails(always(lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)))),
+    ensures spec.entails(always(lift_state(Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key)))),
+{
+    let invariant = Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key);
+    let stronger_next = |s, s_prime| {
+        &&& self.next()(s, s_prime)
+        &&& Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s)
+        &&& Self::there_is_the_controller_state(controller_id)(s)
+    };
+    assert forall |s, s_prime| invariant(s) && #[trigger] stronger_next(s, s_prime) implies invariant(s_prime) by {
+        if s_prime.ongoing_reconciles(controller_id).contains_key(key)
+            && Self::has_pending_req_msg(controller_id, s_prime, key) {
+            let next_step = choose |step| self.next_step(s, s_prime, step);
+            let pending_req_msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+            let resp = choose |msg| {
+                #[trigger] s.in_flight().contains(msg)
+                && resp_msg_matches_req_msg(msg, pending_req_msg)
+            };
+            match next_step {
+                Step::APIServerStep(input) => {
+                    if input == Some(pending_req_msg) {
+                        let resp_msg = transition_by_etcd(self.installed_types, pending_req_msg, s.api_server).1;
+                        assert(s_prime.in_flight().contains(resp_msg));
+                    } else {
+                        if !s.in_flight().contains(pending_req_msg) {
+                            assert(s_prime.in_flight().contains(resp));
+                        }
+                    }
+                }
+                Step::BuiltinControllersStep(input) => {
+                    if s.in_flight().contains(pending_req_msg) {
+                        assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+                    } else {
+                        assert(s_prime.in_flight().contains(resp));
+                    }
+                }
+                Step::DropReqStep(input) => {
+                    if input.0 == pending_req_msg {
+                        let resp_msg = form_matched_err_resp_msg(pending_req_msg, input.1);
+                        assert(s_prime.in_flight().contains(resp_msg));
+                    } else {
+                        if !s.in_flight().contains(pending_req_msg) {
+                            assert(s_prime.in_flight().contains(resp));
+                        }
+                    }
+                }
+                Step::ControllerStep(input) => {
+                    let input_controller_id = input.0;
+                    let input_cr_key = input.2.get_Some_0();
+                    if input_controller_id != controller_id || input_cr_key != key {
+                        if s.in_flight().contains(pending_req_msg) {
+                            assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+                        } else {
+                            assert(s_prime.in_flight().contains(resp));
+                        }
+                    } else {
+                        assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+                    }
+                }
+                Step::PodMonkeyStep(input) => {
+                    if s.in_flight().contains(pending_req_msg) {
+                        assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+                    } else {
+                        assert(s_prime.in_flight().contains(resp));
+                    }
+                }
+                Step::ExternalStep(input) => {
+                    if input.0 == controller_id && input.1 == Some(pending_req_msg) {
+                        let resp_msg = transition_by_external(self.controller_models[controller_id].external_model.get_Some_0(), pending_req_msg, s.api_server.resources, s.controller_and_externals[controller_id].external.get_Some_0()).1;
+                        assert(s_prime.in_flight().contains(resp_msg));
+                    } else {
+                        if !s.in_flight().contains(pending_req_msg) {
+                            assert(s_prime.in_flight().contains(resp));
+                        }
+                    }
+                }
+                _ => {
+                    assert(invariant(s_prime));
+                }
+            }
+        }
+    }
+    self.lemma_always_there_is_the_controller_state(spec, controller_id);
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next), lift_action(self.next()),
+        lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)),
+        lift_state(Self::there_is_the_controller_state(controller_id))
+    );
+    init_invariant::<ClusterState>(spec, self.init(), stronger_next, invariant);
+}
+
 pub proof fn lemma_always_no_pending_req_msg_at_reconcile_state(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef, state: spec_fn(ReconcileLocalState) -> bool)
     requires
         self.controller_models.contains_key(controller_id),
@@ -620,12 +716,17 @@ pub open spec fn every_msg_from_key_is_pending_req_msg_of(
     controller_id: int, key: ObjectRef
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
+        //true
         forall |msg: Message| {
             &&& #[trigger] s.in_flight().contains(msg)
+            &&& s.ongoing_reconciles(controller_id).contains_key(key)
             &&& msg.src == HostId::Controller(controller_id, key)
-            &&& msg.dst.is_APIServer()
-            &&& msg.content.is_APIRequest()
-        } ==> Cluster::pending_req_msg_is(controller_id, s, key, msg)
+            &&& (msg.content.is_APIRequest()
+                || msg.content.is_ExternalRequest())
+        } ==> {
+            // &&& Cluster::has_pending_req_msg(controller_id, s, key)
+            &&& Cluster::pending_req_msg_is(controller_id, s, key, msg)
+        }
     }
 }
 
@@ -635,8 +736,203 @@ pub open spec fn every_msg_from_key_is_pending_req_msg_of(
 pub proof fn lemma_true_leads_to_always_every_msg_from_key_is_pending_req_msg_of(
     self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef
 )
+    requires
+        spec.entails(always(lift_action(self.next()))),
+        self.controller_models.contains_key(controller_id),
+        spec.entails(tla_forall(|i| self.api_server_next().weak_fairness(i))),
+        spec.entails(always(lift_state(Self::there_is_the_controller_state(controller_id)))),
+        spec.entails(always(lift_state(Self::crash_disabled(controller_id)))),
+        spec.entails(always(lift_state(Self::req_drop_disabled()))),
+        spec.entails(always(lift_state(Self::pod_monkey_disabled()))),
+        spec.entails(always(lift_state(Self::every_in_flight_msg_has_unique_id()))),
+        spec.entails(always(lift_state(Self::every_in_flight_msg_has_lower_id_than_allocator()))),
     ensures spec.entails(true_pred().leads_to(always(lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key))))),
-{}
+{
+    
+}
+
+#[verifier(external_body)]
+pub proof fn lemma_always_every_msg_from_key_is_pending_req_msg_of(self, spec: TempPred<ClusterState>, controller_id: int, key: ObjectRef)
+    requires
+        self.controller_models.contains_key(controller_id),
+        spec.entails(lift_state(self.init())),
+        spec.entails(always(lift_action(self.next()))),
+        spec.entails(always(lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)))),
+    ensures spec.entails(always(lift_state(Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key)))),
+{
+    let invariant = Self::every_msg_from_key_is_pending_req_msg_of(controller_id, key);
+    let invariant_antecedent = |msg: Message, s: ClusterState| {
+        &&& s.in_flight().contains(msg)
+        &&& msg.src == HostId::Controller(controller_id, key)
+        &&& msg.dst.is_APIServer()
+        &&& msg.content.is_APIRequest()
+    };
+    let stronger_next = |s, s_prime| {
+        &&& self.next()(s, s_prime)
+        &&& Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s)
+        &&& Self::there_is_the_controller_state(controller_id)(s)
+        &&& Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key)(s)
+    };
+
+    assert forall |s, s_prime| invariant(s) && #[trigger] stronger_next(s, s_prime) implies invariant(s_prime) by {
+        assert forall |msg| {
+            &&& invariant(s)
+            &&& stronger_next(s, s_prime)
+            &&& #[trigger] s_prime.in_flight().contains(msg)
+            &&& s_prime.ongoing_reconciles(controller_id).contains_key(key)
+            &&& msg.src == HostId::Controller(controller_id, key)
+            &&& (msg.content.is_APIRequest()
+                || msg.content.is_ExternalRequest())
+        } implies {
+            &&& Cluster::pending_req_msg_is(controller_id, s_prime, key, msg)
+        }  by {
+            if s.in_flight().contains(msg) {}
+            let next_step = choose |step| self.next_step(s, s_prime, step);
+             match next_step {
+                Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
+                    let resp_msg = resp_msg_opt.unwrap();
+                    let cr_key = cr_key_opt.unwrap();
+                    assume(Self::crash_disabled(controller_id)(s));
+
+                    if cr_key_opt.is_Some() && cr_key == key {
+                        if resp_msg_opt.is_None() {
+                            //assume(cr_key_opt.is_Some());
+                            //assert(continue_reconcile(self.reconcile_model(controller_id), 
+                            assert(s_prime.ongoing_reconciles(controller_id).contains_key(key));
+                            if s.ongoing_reconciles(controller_id).contains_key(key) {
+                                if s.ongoing_reconciles(controller_id)[key].pending_req_msg.is_Some() {
+                                    assert(resp_msg_opt.is_Some());
+                                }
+                            }
+                                
+                            assume(false);
+                            //assume(!Cluster::pending_req_msg_is(controller_id, s, key, msg));
+                            // if s.ongoing_reconciles(controller_id).contains_key(key) {
+                                
+                            // }
+                            //assume(false);
+                            // // here, there was no pending request message
+                            // assume(s.ongoing_reconciles(controller_id).contains_key(key));
+                            // assert(s.ongoing_reconciles(controller_id)[key].pending_req_msg.is_None());
+                            // //assert(!Cluster::pending_req_msg_is(controller_id, s, key, msg));
+                            // //assert(resp_msg_opt.is_Some());
+                            // if !s.in_flight().contains(msg) {
+                            // assume(false);
+                            // }
+                        } else {
+                            assume(false);
+                        }
+                    }
+                },
+                _ => {},
+            }
+            //assume(false);
+        }
+        // if s_prime.ongoing_reconciles(controller_id).contains_key(key)
+        //     && Self::has_pending_req_msg(controller_id, s_prime, key) {
+        //     let next_step = choose |step| self.next_step(s, s_prime, step);
+        //     let pending_req_msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+        //     let resp = choose |msg| {
+        //         #[trigger] s.in_flight().contains(msg)
+        //         && resp_msg_matches_req_msg(msg, pending_req_msg)
+        //     };
+        //     match next_step {
+        //         Step::APIServerStep(input) => {
+        //             if input == Some(pending_req_msg) {
+        //                 let resp_msg = transition_by_etcd(self.installed_types, pending_req_msg, s.api_server).1;
+        //                 assert(s_prime.in_flight().contains(resp_msg));
+        //             } else {
+        //                 if !s.in_flight().contains(pending_req_msg) {
+        //                     assert(s_prime.in_flight().contains(resp));
+        //                 }
+        //             }
+        //         }
+        //         Step::BuiltinControllersStep(input) => {
+        //             if s.in_flight().contains(pending_req_msg) {
+        //                 assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+        //             } else {
+        //                 assert(s_prime.in_flight().contains(resp));
+        //             }
+        //         }
+        //         Step::DropReqStep(input) => {
+        //             if input.0 == pending_req_msg {
+        //                 let resp_msg = form_matched_err_resp_msg(pending_req_msg, input.1);
+        //                 assert(s_prime.in_flight().contains(resp_msg));
+        //             } else {
+        //                 if !s.in_flight().contains(pending_req_msg) {
+        //                     assert(s_prime.in_flight().contains(resp));
+        //                 }
+        //             }
+        //         }
+        //         Step::ControllerStep(input) => {
+        //             let input_controller_id = input.0;
+        //             let input_cr_key = input.2.get_Some_0();
+        //             if input_controller_id != controller_id || input_cr_key != key {
+        //                 if s.in_flight().contains(pending_req_msg) {
+        //                     assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+        //                 } else {
+        //                     assert(s_prime.in_flight().contains(resp));
+        //                 }
+        //             } else {
+        //                 assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+        //             }
+        //         }
+        //         Step::PodMonkeyStep(input) => {
+        //             if s.in_flight().contains(pending_req_msg) {
+        //                 assert(s_prime.in_flight().contains(s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0()));
+        //             } else {
+        //                 assert(s_prime.in_flight().contains(resp));
+        //             }
+        //         }
+        //         Step::ExternalStep(input) => {
+        //             if input.0 == controller_id && input.1 == Some(pending_req_msg) {
+        //                 let resp_msg = transition_by_external(self.controller_models[controller_id].external_model.get_Some_0(), pending_req_msg, s.api_server.resources, s.controller_and_externals[controller_id].external.get_Some_0()).1;
+        //                 assert(s_prime.in_flight().contains(resp_msg));
+        //             } else {
+        //                 if !s.in_flight().contains(pending_req_msg) {
+        //                     assert(s_prime.in_flight().contains(resp));
+        //                 }
+        //             }
+        //         }
+        //         _ => {
+        //             assert(invariant(s_prime));
+        //         }
+        //     }
+        // }
+    }
+    self.lemma_always_there_is_the_controller_state(spec, controller_id);
+    self.lemma_always_pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(spec, controller_id, key);
+    combine_spec_entails_always_n!(
+        spec, lift_action(stronger_next), lift_action(self.next()),
+        lift_state(Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)),
+        lift_state(Self::there_is_the_controller_state(controller_id)),
+        lift_state(Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key))
+    );
+    init_invariant::<ClusterState>(spec, self.init(), stronger_next, invariant);
+}
+
+pub proof fn test_lemma(self, s: ClusterState, s_prime: ClusterState, controller_id: int, key: ObjectRef) 
+    requires
+        self.controller_models.contains_key(controller_id),
+        self.next()(s, s_prime),
+        Self::pending_req_of_key_is_unique_with_unique_id(controller_id, key)(s),
+        Self::there_is_the_controller_state(controller_id)(s),
+        Self::pending_req_in_flight_or_resp_in_flight_if_has_pending_req_msg(controller_id, key)(s),
+        s.ongoing_reconciles(controller_id).contains_key(key),
+        s_prime.ongoing_reconciles(controller_id).contains_key(key),
+{
+    let next_step = choose |step| self.next_step(s, s_prime, step);
+    match next_step {
+        Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
+            if cr_key_opt.is_Some() && cr_key_opt.get_Some_0() == key {
+                if s.ongoing_reconciles(controller_id)[key].pending_req_msg.is_Some() {
+                    assert(resp_msg_opt.is_Some());
+                }
+            }
+        },
+        _ => {},
+    }
+}
 
 }
 }


### PR DESCRIPTION
Here I prove lemmas talking about the effects of specific API requests on `matching_pods(vrs, s.resources())` (the set of pods associated with `vrs`), and an auxiliary invariant about an ongoing reconcile's pending request message. 

These comprise a full fix for the WF1 reasoning that lies on top of our boundary invariant `no_other_pending_request_interferes_with_vrs_reconcile`.