### PR TITLE
Add AfterEnsureNewVRS to VD States

### DIFF
--- a/src/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/controllers/vdeployment_controller/exec/reconciler.rs
@@ -133,68 +133,24 @@ pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, sta
             if vrs_list_or_none.is_none() {
                 return (error_state(state), None);
             }
-            let (new_vrs, mut old_vrs_list) = filter_old_and_new_vrs(vd, filter_vrs_list(vrs_list_or_none.clone().unwrap(), vd));
+            let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(vd, filter_vrs_list(vd, vrs_list_or_none.clone().unwrap()));
             // no .last().cloned() in verus because "The verifier does not yet support the following Rust feature: overloaded deref"
+
             if new_vrs.is_none() {
                 // no new vrs, create one
-                let new_vrs = make_replica_set(vd);
-                let req = KubeAPIRequest::CreateRequest(KubeCreateRequest {
-                    api_resource: VReplicaSet::api_resource(),
-                    namespace: vd.metadata().namespace().unwrap(),
-                    obj: new_vrs.clone().marshal(),
-                });
-                let state_prime = VDeploymentReconcileState {
-                    reconcile_step: VDeploymentReconcileStep::AfterCreateNewVRS,
-                    new_vrs: Some(new_vrs),
-                    old_vrs_list: old_vrs_list,
-                };
-                return (state_prime, Some(Request::KRequest(req)))
+                return create_new_vrs(old_vrs_list.clone(), vd);
             }
-            let mut new_vrs = new_vrs.unwrap();
-            if new_vrs.spec().replicas().unwrap_or(1) != vd.spec().replicas().unwrap_or(1) {
+            let new_vrs = new_vrs.unwrap();
+            if !match_replicas(&vd, &new_vrs) {
                 // scale new vrs to desired replicas
-                let mut new_spec = new_vrs.spec();
-                new_spec.set_replicas(vd.spec().replicas().unwrap_or(1));
-                new_vrs.set_spec(new_spec);
-                let req = KubeAPIRequest::GetThenUpdateRequest(KubeGetThenUpdateRequest {
-                    api_resource: VReplicaSet::api_resource(),
-                    namespace: vd.metadata().namespace().unwrap(),
-                    name: new_vrs.metadata().name().unwrap(),
-                    owner_ref: vd.controller_owner_ref(),
-                    obj: new_vrs.clone().marshal()
-                });
-                let state_prime = VDeploymentReconcileState {
-                    reconcile_step: VDeploymentReconcileStep::AfterScaleNewVRS,
-                    new_vrs: Some(new_vrs),
-                    old_vrs_list: old_vrs_list,
-                };
-                return (state_prime, Some(Request::KRequest(req)))
+                return scale_new_vrs(new_vrs, old_vrs_list, &vd);
             }
             if old_vrs_list.len() > 0 {
                 if !old_vrs_list[old_vrs_list.len() - 1].well_formed() {
                     return (error_state(state), None);
                 }
                 // scale old vrs to zero
-                let mut old_vrs = old_vrs_list[old_vrs_list.len() - 1].clone();
-                old_vrs_list.pop();
-                // somehow it's necessary
-                assert(old_vrs_list.deep_view() == model_reconciler::reconcile_core(vd@, resp_o.deep_view(), state@).0.old_vrs_list);
-                let mut new_spec = old_vrs.spec();
-                new_spec.set_replicas(0);
-                old_vrs.set_spec(new_spec);
-                let req = KubeAPIRequest::GetThenUpdateRequest(KubeGetThenUpdateRequest {
-                    api_resource: VReplicaSet::api_resource(),
-                    namespace: vd.metadata().namespace().unwrap(),
-                    name: old_vrs.metadata().name().unwrap(),
-                    owner_ref: vd.controller_owner_ref(),
-                    obj: old_vrs.clone().marshal()
-                });
-                let state_prime = VDeploymentReconcileState {
-                    reconcile_step: VDeploymentReconcileStep::AfterScaleDownOldVRS,
-                    old_vrs_list: old_vrs_list,
-                    new_vrs: Some(new_vrs),
-                };
-                return (state_prime, Some(Request::KRequest(req)))
+                return scale_down_old_vrs(Some(new_vrs), old_vrs_list, &vd);
             }
             // all good
             return (done_state(state), None);
@@ -206,54 +162,18 @@ pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, sta
             if state.new_vrs.is_none() {
                 return (error_state(state), None);
             }
-            let mut new_vrs = state.new_vrs.clone().unwrap();
+            let new_vrs = state.new_vrs.clone().unwrap();
             if !new_vrs.well_formed() {
                 return (error_state(state), None);
             }
-            if new_vrs.spec().replicas().unwrap_or(1) != vd.spec().replicas().unwrap_or(1) {
-                let mut new_spec = new_vrs.spec();
-                new_spec.set_replicas(vd.spec().replicas().unwrap_or(1));
-                new_vrs.set_spec(new_spec);
-                return (
-                    VDeploymentReconcileState {
-                        reconcile_step: VDeploymentReconcileStep::AfterScaleNewVRS,
-                        new_vrs: Some(new_vrs.clone()),
-                        old_vrs_list: state.old_vrs_list,
-                    },
-                    Some(Request::KRequest(KubeAPIRequest::GetThenUpdateRequest(KubeGetThenUpdateRequest {
-                        api_resource: VReplicaSet::api_resource(),
-                        namespace: vd.metadata().namespace().unwrap(),
-                        name: new_vrs.metadata().name().unwrap(),
-                        owner_ref: vd.controller_owner_ref(),
-                        obj: new_vrs.marshal()
-                    }
-                ))))
+            if !match_replicas(&vd, &new_vrs) {
+                return scale_new_vrs(new_vrs, state.old_vrs_list, &vd);
             }
-            let mut old_vrs_list = state.old_vrs_list.clone();
-            if old_vrs_list.len() > 0 {
-                if !old_vrs_list[old_vrs_list.len() - 1].well_formed() {
+            if state.old_vrs_list.len() > 0 {
+                if !state.old_vrs_list[state.old_vrs_list.len() - 1].well_formed() {
                     return (error_state(state), None);
                 }
-                let mut old_vrs = old_vrs_list[old_vrs_list.len() - 1].clone();
-                old_vrs_list.pop();
-                // somehow it's necessary
-                assert(old_vrs_list.deep_view() == model_reconciler::reconcile_core(vd@, resp_o.deep_view(), state@).0.old_vrs_list);
-                let mut new_spec = old_vrs.spec();
-                new_spec.set_replicas(0);
-                old_vrs.set_spec(new_spec);
-                let req = KubeAPIRequest::GetThenUpdateRequest(KubeGetThenUpdateRequest {
-                    api_resource: VReplicaSet::api_resource(),
-                    namespace: vd.metadata().namespace().unwrap(),
-                    name: old_vrs.metadata().name().unwrap(),
-                    owner_ref: vd.controller_owner_ref(),
-                    obj: old_vrs.clone().marshal()
-                });
-                let state_prime = VDeploymentReconcileState {
-                    reconcile_step: VDeploymentReconcileStep::AfterScaleDownOldVRS,
-                    old_vrs_list: old_vrs_list,
-                    new_vrs: Some(new_vrs),
-                };
-                return (state_prime, Some(Request::KRequest(req)))
+                return scale_down_old_vrs(state.new_vrs, state.old_vrs_list, &vd);
             } else {
                 return (done_state(state), None)
             }
@@ -262,31 +182,11 @@ pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, sta
             if !(is_some_k_get_then_update_resp!(resp_o) && extract_some_k_get_then_update_resp_as_ref!(resp_o).is_ok()) {
                 return (error_state(state), None);
             }
-            let mut old_vrs_list = state.old_vrs_list.clone();
-            if old_vrs_list.len() > 0 {
-                if !(old_vrs_list[old_vrs_list.len() - 1].well_formed()) {
+            if state.old_vrs_list.len() > 0 {
+                if !state.old_vrs_list[state.old_vrs_list.len() - 1].well_formed() {
                     return (error_state(state), None);
                 }
-                let mut old_vrs = old_vrs_list[old_vrs_list.len() - 1].clone();
-                old_vrs_list.pop();
-                // somehow it's necessary
-                assert(old_vrs_list.deep_view() == model_reconciler::reconcile_core(vd@, resp_o.deep_view(), state@).0.old_vrs_list);
-                let mut new_spec = old_vrs.spec();
-                new_spec.set_replicas(0);
-                old_vrs.set_spec(new_spec);
-                let req = KubeAPIRequest::GetThenUpdateRequest(KubeGetThenUpdateRequest {
-                    api_resource: VReplicaSet::api_resource(),
-                    namespace: vd.metadata().namespace().unwrap(),
-                    name: old_vrs.metadata().name().unwrap(),
-                    owner_ref: vd.controller_owner_ref(),
-                    obj: old_vrs.clone().marshal()
-                });
-                let state_prime = VDeploymentReconcileState {
-                    reconcile_step: VDeploymentReconcileStep::AfterScaleDownOldVRS,
-                    old_vrs_list: old_vrs_list,
-                    new_vrs: state.new_vrs,
-                };
-                return (state_prime, Some(Request::KRequest(req)))
+                return scale_down_old_vrs(state.new_vrs, state.old_vrs_list, &vd);
             } else {
                 return (done_state(state), None)
             }
@@ -295,31 +195,11 @@ pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, sta
             if !(is_some_k_get_then_update_resp!(resp_o) && extract_some_k_get_then_update_resp_as_ref!(resp_o).is_ok()) {
                 return (error_state(state), None);
             }
-            let mut old_vrs_list = state.old_vrs_list.clone();
-            if old_vrs_list.len() > 0 {
-                if !old_vrs_list[old_vrs_list.len() - 1].well_formed() {
+            if state.old_vrs_list.len() > 0 {
+                if !state.old_vrs_list[state.old_vrs_list.len() - 1].well_formed() {
                     return (error_state(state), None);
                 }
-                let mut old_vrs = old_vrs_list[old_vrs_list.len() - 1].clone();
-                old_vrs_list.pop();
-                // somehow it's necessary
-                assert(old_vrs_list.deep_view() == model_reconciler::reconcile_core(vd@, resp_o.deep_view(), state@).0.old_vrs_list);
-                let mut new_spec = old_vrs.spec();
-                new_spec.set_replicas(0);
-                old_vrs.set_spec(new_spec);
-                let req = KubeAPIRequest::GetThenUpdateRequest(KubeGetThenUpdateRequest {
-                    api_resource: VReplicaSet::api_resource(),
-                    namespace: vd.metadata().namespace().unwrap(),
-                    name: old_vrs.metadata().name().unwrap(),
-                    owner_ref: vd.controller_owner_ref(),
-                    obj: old_vrs.clone().marshal()
-                });
-                let state_prime = VDeploymentReconcileState {
-                    reconcile_step: VDeploymentReconcileStep::AfterScaleDownOldVRS,
-                    old_vrs_list: old_vrs_list,
-                    new_vrs: state.new_vrs,
-                };
-                return (state_prime, Some(Request::KRequest(req)))
+                return scale_down_old_vrs(state.new_vrs, state.old_vrs_list, &vd);
             } else {
                 return (done_state(state), None)
             }
@@ -346,6 +226,98 @@ pub fn done_state(state: VDeploymentReconcileState) -> (state_prime: VDeployment
         reconcile_step: VDeploymentReconcileStep::Done,
         ..state
     }
+}
+
+// wrapper functions to avoid duplication
+
+// create new vrs
+pub fn create_new_vrs(old_vrs_list: Vec<VReplicaSet>, vd: &VDeployment) -> (res: (VDeploymentReconcileState, Option<Request<VoidEReq>>))
+requires
+    vd@.well_formed(),
+ensures
+    res.1@.is_Some() && model_reconciler::create_new_vrs(old_vrs_list.deep_view(), vd@).1.is_Some(),
+    (res.0@, res.1.deep_view()) == model_reconciler::create_new_vrs(old_vrs_list.deep_view(), vd@),
+{
+    let new_vrs = make_replica_set(vd);
+    let req = KubeAPIRequest::CreateRequest(KubeCreateRequest {
+        api_resource: VReplicaSet::api_resource(),
+        namespace: vd.metadata().namespace().unwrap(),
+        obj: new_vrs.clone().marshal(),
+    });
+    let state_prime = VDeploymentReconcileState {
+        reconcile_step: VDeploymentReconcileStep::AfterCreateNewVRS,
+        new_vrs: Some(new_vrs),
+        old_vrs_list: old_vrs_list,
+    };
+    return (state_prime, Some(Request::KRequest(req)))
+}
+
+// scale new vrs to desired replicas
+pub fn scale_new_vrs(mut new_vrs: VReplicaSet, old_vrs_list: Vec<VReplicaSet>, vd: &VDeployment) -> (res: (VDeploymentReconcileState, Option<Request<VoidEReq>>))
+requires
+    vd@.well_formed(),
+    new_vrs@.well_formed(),
+ensures
+    res.1@.is_Some() && model_reconciler::scale_new_vrs(new_vrs@, old_vrs_list.deep_view(), vd@).1.is_Some(),
+    (res.0@, res.1.deep_view()) == model_reconciler::scale_new_vrs(new_vrs@, old_vrs_list.deep_view(), vd@),
+{
+    let mut new_spec = new_vrs.spec();
+    new_spec.set_replicas(vd.spec().replicas().unwrap_or(1));
+    new_vrs.set_spec(new_spec);
+    let req = KubeAPIRequest::GetThenUpdateRequest(KubeGetThenUpdateRequest {
+        api_resource: VReplicaSet::api_resource(),
+        namespace: vd.metadata().namespace().unwrap(),
+        name: new_vrs.metadata().name().unwrap(),
+        owner_ref: vd.controller_owner_ref(),
+        obj: new_vrs.clone().marshal()
+    });
+    let state_prime = VDeploymentReconcileState {
+        reconcile_step: VDeploymentReconcileStep::AfterScaleNewVRS,
+        new_vrs: Some(new_vrs),
+        old_vrs_list: old_vrs_list,
+    };
+    return (state_prime, Some(Request::KRequest(req)))
+}
+
+// scale down old vrs to 0 replicas
+pub fn scale_down_old_vrs(new_vrs: Option<VReplicaSet>, mut old_vrs_list: Vec<VReplicaSet>, vd: &VDeployment) -> (res: (VDeploymentReconcileState, Option<Request<VoidEReq>>))
+requires
+    vd@.well_formed(),
+    old_vrs_list@.len() > 0,
+    old_vrs_list.deep_view()[old_vrs_list.len() - 1].well_formed(),
+ensures
+    (res.0@, res.1.deep_view()) == model_reconciler::scale_down_old_vrs(new_vrs.deep_view(), old_vrs_list.deep_view(), vd@),
+{
+    let tmp = old_vrs_list.clone();
+    let mut old_vrs = old_vrs_list[old_vrs_list.len() - 1].clone();
+    old_vrs_list.pop();
+    // somehow it's necessary
+    assert(old_vrs_list.deep_view() == model_reconciler::scale_down_old_vrs(new_vrs.deep_view(), tmp.deep_view(), vd@).0.old_vrs_list);
+    let mut new_spec = old_vrs.spec();
+    new_spec.set_replicas(0);
+    old_vrs.set_spec(new_spec);
+    let req = KubeAPIRequest::GetThenUpdateRequest(KubeGetThenUpdateRequest {
+        api_resource: VReplicaSet::api_resource(),
+        namespace: vd.metadata().namespace().unwrap(),
+        name: old_vrs.metadata().name().unwrap(),
+        owner_ref: vd.controller_owner_ref(),
+        obj: old_vrs.clone().marshal()
+    });
+    let state_prime = VDeploymentReconcileState {
+        reconcile_step: VDeploymentReconcileStep::AfterScaleDownOldVRS,
+        old_vrs_list: old_vrs_list,
+        new_vrs: new_vrs,
+    };
+    return (state_prime, Some(Request::KRequest(req)))
+}
+
+fn match_replicas(vd: &VDeployment, vrs: &VReplicaSet) -> (res: bool)
+requires
+    vd@.well_formed(),
+    vrs@.well_formed(),
+ensures res == model_util::match_replicas(vd@, vrs@),
+{
+    vrs.spec().replicas().unwrap_or(1) == vd.spec().replicas().unwrap_or(1)
 }
 
 fn objects_to_vrs_list(objs: Vec<DynamicObject>) -> (vrs_list_or_none: Option<Vec<VReplicaSet>>)
@@ -429,7 +401,7 @@ ensures
     Some(vrs_list)
 }
 
-fn filter_vrs_list(vrs_list: Vec<VReplicaSet>, vd: &VDeployment) -> (filtered_vrs_list: Vec<VReplicaSet>)
+fn filter_vrs_list(vd: &VDeployment, vrs_list: Vec<VReplicaSet>) -> (filtered_vrs_list: Vec<VReplicaSet>)
 requires
     vd@.well_formed(),
 ensures

--- a/src/controllers/vdeployment_controller/trusted/step.rs
+++ b/src/controllers/vdeployment_controller/trusted/step.rs
@@ -7,6 +7,7 @@ pub enum VDeploymentReconcileStep {
     AfterListVRS,
     AfterCreateNewVRS,
     AfterScaleNewVRS,
+    AfterEnsureNewVRS,
     AfterScaleDownOldVRS,
     Done,
     Error,
@@ -39,18 +40,19 @@ impl View for VDeploymentReconcileStep {
             VDeploymentReconcileStep::AfterCreateNewVRS => VDeploymentReconcileStepView::AfterCreateNewVRS,
             VDeploymentReconcileStep::AfterScaleNewVRS => VDeploymentReconcileStepView::AfterScaleNewVRS,
             VDeploymentReconcileStep::AfterScaleDownOldVRS => VDeploymentReconcileStepView::AfterScaleDownOldVRS,
+            VDeploymentReconcileStep::AfterEnsureNewVRS => VDeploymentReconcileStepView::AfterEnsureNewVRS,
             VDeploymentReconcileStep::Done => VDeploymentReconcileStepView::Done,
             VDeploymentReconcileStep::Error => VDeploymentReconcileStepView::Error,
         }
     }
 }
 
-#[is_variant]
 pub enum VDeploymentReconcileStepView {
     Init,
     AfterListVRS,
     AfterCreateNewVRS,
     AfterScaleNewVRS,
+    AfterEnsureNewVRS,
     AfterScaleDownOldVRS,
     Done,
     Error,

--- a/src/controllers/vdeployment_controller/trusted/util.rs
+++ b/src/controllers/vdeployment_controller/trusted/util.rs
@@ -52,4 +52,8 @@ pub open spec fn match_template_without_hash(vd: VDeploymentView, vrs: VReplicaS
     }
 }
 
+pub open spec fn match_replicas(vd: VDeploymentView, vrs: VReplicaSetView) -> bool {
+    vd.spec.replicas.unwrap_or(1) == vrs.spec.replicas.unwrap_or(1 as int)
+}
+
 }


### PR DESCRIPTION
- Add barrier state of `AfterEnsureNewVRS`
- Add wrappers back as the flakiness is resolved
- remove deprecated `#[is_variant]`