### PR TITLE
Fix VDeployment controller bug: Fields are not updates at `AfterListVRS` step

### DIFF
--- a/src/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/controllers/vdeployment_controller/exec/reconciler.rs
@@ -145,7 +145,12 @@ pub fn reconcile_core(vd: &VDeployment, resp_o: Option<Response<VoidEResp>>, sta
                 // scale new vrs to desired replicas
                 return scale_new_vrs(new_vrs, old_vrs_list, &vd);
             }
-            return (new_vrs_ensured_state(state), None);
+            let state = VDeploymentReconcileState {
+                reconcile_step: VDeploymentReconcileStep::AfterEnsureNewVRS,
+                new_vrs: Some(new_vrs),
+                old_vrs_list: old_vrs_list,
+            };
+            return (state, None);
         },
         VDeploymentReconcileStep::AfterCreateNewVRS => {
             if !(is_some_k_create_resp!(resp_o) && extract_some_k_create_resp_as_ref!(resp_o).is_ok()) {

--- a/src/controllers/vdeployment_controller/model/reconciler.rs
+++ b/src/controllers/vdeployment_controller/model/reconciler.rs
@@ -95,7 +95,12 @@ pub open spec fn reconcile_core(vd: VDeploymentView, resp_o: Option<ResponseView
                             // scale new vrs to desired replicas
                             scale_new_vrs(new_vrs, old_vrs_list, vd)
                         } else {
-                            (new_vrs_ensured_state(state), None)
+                            let state = VDeploymentReconcileState {
+                                reconcile_step: VDeploymentReconcileStepView::AfterEnsureNewVRS,
+                                new_vrs: Some(new_vrs),
+                                old_vrs_list: old_vrs_list,
+                            };
+                            (state, None)
                         }
                     }
                 }


### PR DESCRIPTION
As discovered by @codyjrivera at `AfterListVRS` step the previous state doesn't have `new_vrs` and `old_vrs_list` available, and I forgot to update these 2 fields using information in list response.

This PR fixes the bug.