### PR TITLE
WF1 proof for VDeployment controller

### DIFF
--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -42,7 +42,7 @@ pub proof fn lemma_create_new_vrs_request_returns_ok_at_after_ensure_new_vrs(
 ) -> (resp_msg: Message)
 requires
     cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
-    req_msg_is_the_pending_create_new_vrs_req_in_flight(vd, controller_id, msg)(s),
+    req_msg_is_pending_create_new_vrs_req_in_flight(vd, controller_id, msg)(s),
     cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
     n_old_vrs_exists_in_etcd(controller_id, vd, n)(s),
     no_new_vrs_exists_in_etcd(controller_id, vd)(s),

--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -36,7 +36,7 @@ ensures
 }
 
 #[verifier(external_body)]
-pub proof fn lemma_create_new_vrs_request_returns_ok_at_after_ensure_new_vrs(
+pub proof fn lemma_create_new_vrs_request_returns_ok_after_ensure_new_vrs(
     s: ClusterState, s_prime: ClusterState, vd: VDeploymentView, cluster: Cluster, controller_id: int, 
     msg: Message, n: nat
 ) -> (resp_msg: Message)
@@ -54,7 +54,7 @@ ensures
 }
 
 #[verifier(external_body)]
-pub proof fn lemma_get_then_update_request_returns_ok_at_after_scale_new_vrs(
+pub proof fn lemma_get_then_update_request_returns_ok_after_scale_new_vrs(
     s: ClusterState, s_prime: ClusterState, vd: VDeploymentView, cluster: Cluster, controller_id: int, 
     msg: Message, replicas: int, n: nat
 ) -> (resp_msg: Message)
@@ -72,7 +72,7 @@ ensures
 }
 
 #[verifier(external_body)]
-pub proof fn lemma_get_then_update_request_returns_ok_at_after_scale_down_old_vrs(
+pub proof fn lemma_get_then_update_request_returns_ok_after_scale_down_old_vrs(
     s: ClusterState, s_prime: ClusterState, vd: VDeploymentView, cluster: Cluster, controller_id: int, 
     msg: Message, n: nat
 ) -> (resp_msg: Message)

--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -44,13 +44,11 @@ requires
     cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
     req_msg_is_pending_create_new_vrs_req_in_flight(vd, controller_id, msg)(s),
     cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
-    n_old_vrs_exists_in_etcd(controller_id, vd, n)(s),
-    no_new_vrs_exists_in_etcd(controller_id, vd)(s),
+    etcd_state_is(vd, controller_id, None, n)(s),
 ensures
     resp_msg == handle_create_request_msg(cluster.installed_types, msg, s.api_server).1,
     resp_msg_is_ok_create_new_vrs_resp(vd, controller_id, resp_msg)(s_prime),
-    n_old_vrs_exists_in_etcd(controller_id, vd, (n - nat1!()) as nat)(s_prime),
-    new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!()))(s_prime),
+    etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n)(s_prime),
 {
     return handle_create_request_msg(cluster.installed_types, msg, s.api_server).1;
 }
@@ -64,13 +62,11 @@ requires
     cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
     req_msg_is_get_then_update_req_with_replicas(vd, controller_id, msg, vd.spec.replicas.unwrap_or(int1!()))(s),
     cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
-    n_old_vrs_exists_in_etcd(controller_id, vd, n)(s),
-    new_vrs_with_replicas_exists_in_etcd(controller_id, vd, replicas)(s),
+    etcd_state_is(vd, controller_id, Some(replicas), n)(s),
 ensures
     resp_msg == handle_get_then_update_request_msg(cluster.installed_types, msg, s.api_server).1,
     resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, resp_msg, replicas)(s_prime),
-    n_old_vrs_exists_in_etcd(controller_id, vd, n)(s_prime),
-    new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!()))(s_prime),
+    etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n)(s_prime),
 {
     return handle_get_then_update_request_msg(cluster.installed_types, msg, s.api_server).1;
 }
@@ -84,13 +80,11 @@ requires
     cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
     req_msg_is_get_then_update_req_with_replicas(vd, controller_id, msg, int0!())(s),
     cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
-    n_old_vrs_exists_in_etcd(controller_id, vd, n)(s),
-    new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!()))(s),
+    etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n)(s),
 ensures
     resp_msg == handle_get_then_update_request_msg(cluster.installed_types, msg, s.api_server).1,
     resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, resp_msg, int0!())(s_prime),
-    n_old_vrs_exists_in_etcd(controller_id, vd, (n - nat1!()) as nat)(s_prime),
-    new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!()))(s_prime),
+    etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), (n - nat1!()) as nat)(s_prime),
 {
     return handle_get_then_update_request_msg(cluster.installed_types, msg, s.api_server).1;
 }

--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -44,7 +44,8 @@ requires
     cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
     req_msg_is_get_then_update_req_with_replicas(vd, controller_id, msg, int0!())(s),
     cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
-    with_n_old_vrs_in_etcd(controller_id, vd, n)(s),
+    n_old_vrs_exists_in_etcd(controller_id, vd, n)(s),
+    new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!()))(s),
 ensures
     resp_msg == handle_get_then_update_request_msg(cluster.installed_types, msg, s.api_server).1,
     resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, resp_msg, int0!())(s_prime),
@@ -64,7 +65,8 @@ ensures
                 ..req.obj
         }
     }),
-    with_n_old_vrs_in_etcd(controller_id, vd, (n - nat1!()) as nat)(s_prime),
+    n_old_vrs_exists_in_etcd(controller_id, vd, (n - nat1!()) as nat)(s_prime),
+    new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!()))(s_prime),
 {
     return handle_get_then_update_request_msg(cluster.installed_types, msg, s.api_server).1;
 }
@@ -86,10 +88,6 @@ ensures
     s_prime.resources().values().filter(list_vrs_obj_filter(vd)).to_seq(),
     objects_to_vrs_list(s.resources().values().filter(list_vrs_obj_filter(vd)).to_seq()) ==
     objects_to_vrs_list(s_prime.resources().values().filter(list_vrs_obj_filter(vd)).to_seq()),
-    // TODO: find a place for this post condition which holds since AfterListVRS state
-    local_state_match_etcd_on_old_vrs_list(vd, controller_id)(s) == local_state_match_etcd_on_old_vrs_list(vd, controller_id)(s_prime),
-    // TODO: find a place for this post condition which holds since AfterEnsureNewVRS state
-    local_state_match_etcd_on_new_vrs(vd, controller_id)(s) == local_state_match_etcd_on_new_vrs(vd, controller_id)(s_prime),
 {}
 
 }

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -119,183 +119,167 @@ ensures
             }
             temp_pred_equality(list_resp_msg(msg), tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)));
         }
-        // \A |n| \A |replicas| etcd_state_is(replicas, n) ~> after_ensure_vrs(n)
-        assert forall |n: nat| #![trigger after_ensure_vrs(n)] spec.entails(tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n))
-            .leads_to(after_ensure_vrs(n))) by {
-            // \A |replicas| after_list_with_etcd_state(msg, Some(replicas), n) ~> after_ensure_vrs(n)
-            // since here the transitions branch over the existence and replicas of new vrs
-            assert forall |replicas: Option<int>| spec.entails(#[trigger] after_list_with_etcd_state(msg, replicas, n).leads_to(after_ensure_vrs(n))) by {
-                // new vrs does not exists. Here the existance is encoded as is_Some, and replicas is get_Some_0
-                if replicas.is_None() {
-                    // AfterListVRS ~> AfterCreateNewVRS
-                    let create_vrs_req = lift_state(and!(
-                        at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                        pending_create_new_vrs_req_in_flight(vd, controller_id),
-                        etcd_state_is(vd, controller_id, None, n),
-                        local_state_match_etcd(vd, controller_id)
-                    ));
-                    assert(spec.entails(after_list_with_etcd_state(msg, None, n).leads_to(create_vrs_req))) by {
-                        lemma_from_after_receive_list_vrs_resp_to_send_create_new_vrs_req(vd, spec, cluster, controller_id, msg, n);
+        // \A |replicas, n| etcd_state_is(replicas, n) ~> \E |n| after_ensure_vrs(n)
+        assert forall |i: (Option<int>, nat)| #![trigger after_list_with_etcd_state(msg, i.0, i.1)] spec.entails(after_list_with_etcd_state(msg, i.0, i.1).leads_to(tla_exists(|n| after_ensure_vrs(n)))) by {
+            let (replicas, n) = i;
+            // new vrs does not exists. Here the existance is encoded as is_Some, and replicas is get_Some_0
+            if replicas.is_None() {
+                // AfterListVRS ~> AfterCreateNewVRS
+                let create_vrs_req = lift_state(and!(
+                    at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
+                    pending_create_new_vrs_req_in_flight(vd, controller_id),
+                    etcd_state_is(vd, controller_id, None, n),
+                    local_state_match_etcd(vd, controller_id)
+                ));
+                assert(spec.entails(after_list_with_etcd_state(msg, None, n).leads_to(create_vrs_req))) by {
+                    lemma_from_after_receive_list_vrs_resp_to_send_create_new_vrs_req(vd, spec, cluster, controller_id, msg, n);
+                }
+                let create_vrs_req_msg = |msg: Message| lift_state(and!(
+                    at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
+                    req_msg_is_pending_create_new_vrs_req_in_flight(vd, controller_id, msg),
+                    etcd_state_is(vd, controller_id, None, n),
+                    local_state_match_etcd(vd, controller_id)
+                ));
+                assert(create_vrs_req == tla_exists(|msg| create_vrs_req_msg(msg))) by {
+                    assert forall |ex: Execution<ClusterState>| #[trigger] create_vrs_req.satisfied_by(ex) implies
+                        tla_exists(|msg| create_vrs_req_msg(msg)).satisfied_by(ex) by {
+                        let s = ex.head();
+                        let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
+                        assert((|msg| create_vrs_req_msg(msg))(req_msg).satisfied_by(ex));
                     }
-                    let create_vrs_req_msg = |msg: Message| lift_state(and!(
-                        at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                        req_msg_is_pending_create_new_vrs_req_in_flight(vd, controller_id, msg),
-                        etcd_state_is(vd, controller_id, None, n),
+                    temp_pred_equality(create_vrs_req, tla_exists(|msg| create_vrs_req_msg(msg)));
+                }
+                let create_vrs_resp = lift_state(and!(
+                    at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
+                    exists_resp_msg_is_ok_create_new_vrs_resp(vd, controller_id),
+                    etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
+                    local_state_match_etcd(vd, controller_id)
+                ));
+                assert forall |msg: Message| spec.entails(#[trigger] create_vrs_req_msg(msg).leads_to(create_vrs_resp)) by {
+                    lemma_from_after_send_create_pod_req_to_receive_ok_resp(vd, spec, cluster, controller_id, msg, n);
+                }
+                leads_to_exists_intro(spec, |msg| create_vrs_req_msg(msg), create_vrs_resp);
+                let create_vrs_resp_msg = |msg: Message| lift_state(and!(
+                    at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
+                    resp_msg_is_ok_create_new_vrs_resp(vd, controller_id, msg),
+                    etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
+                    local_state_match_etcd(vd, controller_id)
+                ));
+                assert(create_vrs_resp == tla_exists(|msg| create_vrs_resp_msg(msg))) by {
+                    assert forall |ex: Execution<ClusterState>| #[trigger] create_vrs_resp.satisfied_by(ex) implies
+                        tla_exists(|msg| create_vrs_resp_msg(msg)).satisfied_by(ex) by {
+                        let s = ex.head();
+                        let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
+                        let resp_msg = choose |resp_msg| {
+                            &&& #[trigger] s.in_flight().contains(resp_msg)
+                            &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+                            &&& resp_msg.content.is_create_response()
+                            &&& resp_msg.content.get_create_response().res.is_Ok()
+                        };
+                        assert((|msg| create_vrs_resp_msg(msg))(resp_msg).satisfied_by(ex));
+                    }
+                    temp_pred_equality(create_vrs_resp, tla_exists(|msg| create_vrs_resp_msg(msg)));
+                }
+                // AfterCreateNewVRS ~> AfterEnsureNewVRS
+                // Because maxSurge is not supported, this transition can be completed without scaling new VRS
+                assert forall |msg: Message| spec.entails(#[trigger] create_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
+                    lemma_from_receive_ok_resp_after_create_new_vrs_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, n);
+                }
+                leads_to_exists_intro(spec, |msg| create_vrs_resp_msg(msg), after_ensure_vrs(n));
+                leads_to_trans_n!(
+                    spec,
+                    after_list_with_etcd_state(msg, replicas, n),
+                    create_vrs_req,
+                    create_vrs_resp,
+                    after_ensure_vrs(n)
+                );
+            } else {
+                if replicas.unwrap_or(1) != vd.spec.replicas.unwrap_or(1) {
+                    let scale_new_vrs_req = lift_state(and!(
+                        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
+                        pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
+                        etcd_state_is(vd, controller_id, replicas, n),
                         local_state_match_etcd(vd, controller_id)
                     ));
-                    assert(create_vrs_req == tla_exists(|msg| create_vrs_req_msg(msg))) by {
-                        assert forall |ex: Execution<ClusterState>| #[trigger] create_vrs_req.satisfied_by(ex) implies
-                            tla_exists(|msg| create_vrs_req_msg(msg)).satisfied_by(ex) by {
+                    assert(spec.entails(after_list_with_etcd_state(msg, replicas, n).leads_to(scale_new_vrs_req))) by {
+                        lemma_from_after_receive_list_vrs_resp_to_pending_scale_new_vrs_req_in_flight(vd, spec, cluster, controller_id, msg, replicas.unwrap_or(int1!()), n);
+                    }
+                    let scale_new_vrs_req_msg = |msg: Message| lift_state(and!(
+                        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
+                        req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, msg, vd.spec.replicas.unwrap_or(int1!())),
+                        etcd_state_is(vd, controller_id, replicas, n),
+                        local_state_match_etcd(vd, controller_id)
+                    ));
+                    assert(scale_new_vrs_req == tla_exists(|msg| scale_new_vrs_req_msg(msg))) by {
+                        assert forall |ex: Execution<ClusterState>| #[trigger] scale_new_vrs_req.satisfied_by(ex) implies
+                            tla_exists(|msg| scale_new_vrs_req_msg(msg)).satisfied_by(ex) by {
                             let s = ex.head();
                             let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
-                            assert((|msg| create_vrs_req_msg(msg))(req_msg).satisfied_by(ex));
+                            assert((|msg| scale_new_vrs_req_msg(msg))(req_msg).satisfied_by(ex));
                         }
-                        temp_pred_equality(create_vrs_req, tla_exists(|msg| create_vrs_req_msg(msg)));
+                        temp_pred_equality(scale_new_vrs_req, tla_exists(|msg| scale_new_vrs_req_msg(msg)));
                     }
-                    let create_vrs_resp = lift_state(and!(
-                        at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                        exists_resp_msg_is_ok_create_new_vrs_resp(vd, controller_id),
+                    let scale_new_vrs_resp = lift_state(and!(
+                        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
+                        exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
                         etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
                         local_state_match_etcd(vd, controller_id)
                     ));
-                    assert forall |msg: Message| spec.entails(#[trigger] create_vrs_req_msg(msg).leads_to(create_vrs_resp)) by {
-                        lemma_from_after_send_create_pod_req_to_receive_ok_resp(vd, spec, cluster, controller_id, msg, n);
+                    assert forall |msg: Message| spec.entails(#[trigger] scale_new_vrs_req_msg(msg).leads_to(scale_new_vrs_resp)) by {
+                        lemma_from_after_send_get_then_update_req_to_receive_ok_resp_of_new_replicas(vd, spec, cluster, controller_id, msg, replicas.unwrap_or(int1!()), n);
                     }
-                    leads_to_exists_intro(spec, |msg| create_vrs_req_msg(msg), create_vrs_resp);
-                    let create_vrs_resp_msg = |msg: Message| lift_state(and!(
-                        at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                        resp_msg_is_ok_create_new_vrs_resp(vd, controller_id, msg),
+                    leads_to_exists_intro(spec, |msg| scale_new_vrs_req_msg(msg), scale_new_vrs_resp);
+                    let scale_new_vrs_resp_msg = |msg: Message| lift_state(and!(
+                        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
+                        resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, msg, vd.spec.replicas.unwrap_or(int1!())),
                         etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
                         local_state_match_etcd(vd, controller_id)
                     ));
-                    assert(create_vrs_resp == tla_exists(|msg| create_vrs_resp_msg(msg))) by {
-                        assert forall |ex: Execution<ClusterState>| #[trigger] create_vrs_resp.satisfied_by(ex) implies
-                            tla_exists(|msg| create_vrs_resp_msg(msg)).satisfied_by(ex) by {
+                    assert(scale_new_vrs_resp == tla_exists(|msg| scale_new_vrs_resp_msg(msg))) by {
+                        assert forall |ex: Execution<ClusterState>| #[trigger] scale_new_vrs_resp.satisfied_by(ex) implies
+                            tla_exists(|msg| scale_new_vrs_resp_msg(msg)).satisfied_by(ex) by {
                             let s = ex.head();
                             let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
                             let resp_msg = choose |resp_msg| {
                                 &&& #[trigger] s.in_flight().contains(resp_msg)
                                 &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-                                &&& resp_msg.content.is_create_response()
-                                &&& resp_msg.content.get_create_response().res.is_Ok()
+                                &&& resp_msg.content.is_get_then_update_response()
+                                &&& resp_msg.content.get_get_then_update_response().res.is_Ok()
                             };
-                            assert((|msg| create_vrs_resp_msg(msg))(resp_msg).satisfied_by(ex));
+                            assert((|msg| scale_new_vrs_resp_msg(msg))(resp_msg).satisfied_by(ex));
                         }
-                        temp_pred_equality(create_vrs_resp, tla_exists(|msg| create_vrs_resp_msg(msg)));
+                        temp_pred_equality(scale_new_vrs_resp, tla_exists(|msg| scale_new_vrs_resp_msg(msg)));
                     }
-                    // AfterCreateNewVRS ~> AfterEnsureNewVRS
-                    // Because maxSurge is not supported, this transition can be completed without scaling new VRS
-                    assert forall |msg: Message| spec.entails(#[trigger] create_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
-                        lemma_from_receive_ok_resp_after_create_new_vrs_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, n);
+                    assert forall |msg: Message| spec.entails(#[trigger] scale_new_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
+                        lemma_from_receive_ok_resp_after_scale_new_vrs_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, n);
                     }
-                    leads_to_exists_intro(spec, |msg| create_vrs_resp_msg(msg), after_ensure_vrs(n));
+                    leads_to_exists_intro(spec, |msg| scale_new_vrs_resp_msg(msg), after_ensure_vrs(n));
                     leads_to_trans_n!(
                         spec,
                         after_list_with_etcd_state(msg, replicas, n),
-                        create_vrs_req,
-                        create_vrs_resp,
+                        scale_new_vrs_req,
+                        scale_new_vrs_resp,
                         after_ensure_vrs(n)
                     );
                 } else {
-                    if replicas.unwrap_or(1) != vd.spec.replicas.unwrap_or(1) {
-                        let scale_new_vrs_req = lift_state(and!(
-                            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                            pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
-                            etcd_state_is(vd, controller_id, replicas, n),
-                            local_state_match_etcd(vd, controller_id)
-                        ));
-                        assert(spec.entails(after_list_with_etcd_state(msg, replicas, n).leads_to(scale_new_vrs_req))) by {
-                            lemma_from_after_receive_list_vrs_resp_to_pending_scale_new_vrs_req_in_flight(vd, spec, cluster, controller_id, msg, replicas.unwrap_or(int1!()), n);
-                        }
-                        let scale_new_vrs_req_msg = |msg: Message| lift_state(and!(
-                            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                            req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, msg, vd.spec.replicas.unwrap_or(int1!())),
-                            etcd_state_is(vd, controller_id, replicas, n),
-                            local_state_match_etcd(vd, controller_id)
-                        ));
-                        assert(scale_new_vrs_req == tla_exists(|msg| scale_new_vrs_req_msg(msg))) by {
-                            assert forall |ex: Execution<ClusterState>| #[trigger] scale_new_vrs_req.satisfied_by(ex) implies
-                                tla_exists(|msg| scale_new_vrs_req_msg(msg)).satisfied_by(ex) by {
-                                let s = ex.head();
-                                let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
-                                assert((|msg| scale_new_vrs_req_msg(msg))(req_msg).satisfied_by(ex));
-                            }
-                            temp_pred_equality(scale_new_vrs_req, tla_exists(|msg| scale_new_vrs_req_msg(msg)));
-                        }
-                        let scale_new_vrs_resp = lift_state(and!(
-                            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                            exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
-                            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
-                            local_state_match_etcd(vd, controller_id)
-                        ));
-                        assert forall |msg: Message| spec.entails(#[trigger] scale_new_vrs_req_msg(msg).leads_to(scale_new_vrs_resp)) by {
-                            lemma_from_after_send_get_then_update_req_to_receive_ok_resp_of_new_replicas(vd, spec, cluster, controller_id, msg, replicas.unwrap_or(int1!()), n);
-                        }
-                        leads_to_exists_intro(spec, |msg| scale_new_vrs_req_msg(msg), scale_new_vrs_resp);
-                        let scale_new_vrs_resp_msg = |msg: Message| lift_state(and!(
-                            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                            resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, msg, vd.spec.replicas.unwrap_or(int1!())),
-                            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
-                            local_state_match_etcd(vd, controller_id)
-                        ));
-                        assert(scale_new_vrs_resp == tla_exists(|msg| scale_new_vrs_resp_msg(msg))) by {
-                            assert forall |ex: Execution<ClusterState>| #[trigger] scale_new_vrs_resp.satisfied_by(ex) implies
-                                tla_exists(|msg| scale_new_vrs_resp_msg(msg)).satisfied_by(ex) by {
-                                let s = ex.head();
-                                let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
-                                let resp_msg = choose |resp_msg| {
-                                    &&& #[trigger] s.in_flight().contains(resp_msg)
-                                    &&& resp_msg_matches_req_msg(resp_msg, req_msg)
-                                    &&& resp_msg.content.is_get_then_update_response()
-                                    &&& resp_msg.content.get_get_then_update_response().res.is_Ok()
-                                };
-                                assert((|msg| scale_new_vrs_resp_msg(msg))(resp_msg).satisfied_by(ex));
-                            }
-                            temp_pred_equality(scale_new_vrs_resp, tla_exists(|msg| scale_new_vrs_resp_msg(msg)));
-                        }
-                        assert forall |msg: Message| spec.entails(#[trigger] scale_new_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
-                            lemma_from_receive_ok_resp_after_scale_new_vrs_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, n);
-                        }
-                        leads_to_exists_intro(spec, |msg| scale_new_vrs_resp_msg(msg), after_ensure_vrs(n));
-                        leads_to_trans_n!(
-                            spec,
-                            after_list_with_etcd_state(msg, replicas, n),
-                            scale_new_vrs_req,
-                            scale_new_vrs_resp,
-                            after_ensure_vrs(n)
-                        );
-                    } else {
-                        lemma_from_after_receive_list_vrs_resp_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, replicas.unwrap_or(1), n);
-                    }
+                    lemma_from_after_receive_list_vrs_resp_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, replicas.unwrap_or(1), n);
                 }
             }
-            leads_to_exists_intro(spec, |replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n), after_ensure_vrs(n));
-            // forall |n| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n)).leads_to(after_ensure_vrs(n))
-        }
-        // tla_exists(|n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n))).leads_to(tla_exists(|n: nat| after_ensure_vrs(n)));
-        // need to prove (\A |a| (a_to_p(a) ~> a_to_q(a))) && (r ~> \E |a| a_to_p(a)) ==> r ~> \E |a| a_to_q(a)
-        assert(spec.entails(tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1))
-            .leads_to(tla_exists(|n: nat| after_ensure_vrs(n))))) by {
-            // TODO: prove it
-            leads_to_exists_intro_pred(spec, |n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n)), |n: nat| after_ensure_vrs(n));
-            assume(false);
-            temp_pred_equality(
-                tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)),
-                tla_exists(|n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n)))
+            assert(after_ensure_vrs(n).entails(tla_exists(|n| after_ensure_vrs(n)))) by {
+                assert forall |ex: Execution<ClusterState>| #[trigger] after_ensure_vrs(n).satisfied_by(ex) implies
+                    tla_exists(|n| after_ensure_vrs(n)).satisfied_by(ex) by {
+                    assert((|n| after_ensure_vrs(n))(n).satisfied_by(ex));
+                }
+            }
+            entails_implies_leads_to(spec, after_ensure_vrs(n), tla_exists(|n| after_ensure_vrs(n)));
+            leads_to_trans_n!(
+                spec,
+                after_list_with_etcd_state(msg, replicas, n),
+                after_ensure_vrs(n),
+                tla_exists(|n| after_ensure_vrs(n))
             );
-        };
-        // no proper trigger inside tla_exists, if I use dummy I will make verus panic
-        // assert(tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)).entails(tla_exists(|n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n))))) by {
-        //     assume(false);
-        //     assert forall |ex: Execution<ClusterState>| tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)).satisfied_by(ex) implies
-        //         tla_exists(|n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n))).satisfied_by(ex) by {
-        //         let i = tla_exists_choose_witness(ex, |i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1));
-        //     }
-        // }
-        // temp_pred_equality(
-        //     tla_exists(|n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n))),
-        //     tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1))
-        // );
+        }
+        leads_to_exists_intro(spec, |i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1), tla_exists(|n| after_ensure_vrs(n)));
     }
     leads_to_exists_intro(spec, |msg| list_resp_msg(msg), tla_exists(|n: nat| after_ensure_vrs(n)));
     leads_to_trans_n!(

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -275,9 +275,10 @@ ensures
                             }
                         }
                         entails_implies_leads_to(spec, scale_new_vrs_resp, tla_exists(|msg| scale_new_vrs_resp_msg(msg)));
-                        assert forall |msg: Message| #![trigger dummy(msg)] spec.entails(scale_new_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
+                        assert forall |msg: Message| spec.entails(#[trigger] scale_new_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
                             lemma_from_receive_ok_resp_at_after_scale_new_vrs_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, n);
                         }
+                        leads_to_exists_intro(spec, |msg| scale_new_vrs_resp_msg(msg), after_ensure_vrs(n));
                         leads_to_trans_n!(
                             spec,
                             after_list_with_etcd_state(msg, Some(replicas), n),

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -720,7 +720,7 @@ ensures
         .leads_to(lift_state(and!(
             at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
             pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
-            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
+            etcd_state_is(vd, controller_id, Some(replicas), n),
             local_state_match_etcd(vd, controller_id)
         )))),
 {

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -239,13 +239,15 @@ ensures
                         leads_to_exists_intro(spec, |msg| scale_new_vrs_req_msg(msg), scale_new_vrs_resp);
                         let scale_new_vrs_resp_msg = |msg: Message| lift_state(and!(
                             at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                            resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, msg, replicas),
+                            resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, msg, vd.spec.replicas.unwrap_or(int1!())),
                             etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
                             local_state_match_etcd(vd, controller_id)
                         ));
-                        assert(spec.entails(scale_new_vrs_resp.leads_to(tla_exists(|msg| scale_new_vrs_resp_msg(msg))))) by {
+                        assert(scale_new_vrs_resp.entails(tla_exists(|msg| scale_new_vrs_resp_msg(msg)))) by {
+                            assume(false);
                             assert forall |ex: Execution<ClusterState>| #![trigger dummy(ex)] scale_new_vrs_resp.satisfied_by(ex) implies
                                 tla_exists(|msg| scale_new_vrs_resp_msg(msg)).satisfied_by(ex) by {
+                                assume(false);
                                 let s = ex.head();
                                 let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
                                 let resp_msg = choose |resp_msg| {
@@ -256,8 +258,8 @@ ensures
                                 };
                                 tla_exists_proved_by_witness(ex, |msg| scale_new_vrs_resp_msg(msg), resp_msg);
                             }
-                            entails_implies_leads_to(spec, scale_new_vrs_resp, tla_exists(|msg| scale_new_vrs_resp_msg(msg)));
                         }
+                        entails_implies_leads_to(spec, scale_new_vrs_resp, tla_exists(|msg| scale_new_vrs_resp_msg(msg)));
                         assert forall |msg: Message| #![trigger dummy(msg)] spec.entails(scale_new_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
                             lemma_from_receive_ok_resp_at_after_scale_new_vrs_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, n);
                         }

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -295,6 +295,7 @@ ensures
             }
             leads_to_exists_intro(spec, |replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n), after_ensure_vrs(n));
         }
+        leads_to_exists_intro(spec, |msg: Message| list_resp_msg(msg), tla_exists(|n: nat| after_ensure_vrs(n)));
     }
     leads_to_exists_intro(spec, |msg| list_resp_msg(msg), tla_exists(|n: nat| after_ensure_vrs(n)));
     assume(false);

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -135,7 +135,7 @@ ensures
         }
         entails_implies_leads_to(spec, list_resp_msg(msg), tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)));
         // \A |n| \A |replicas| etcd_state_is(replicas, n) ~> after_ensure_vrs(n)
-        assert forall |n: nat| spec.entails(tla_forall(|replicas: int| #[trigger] after_list_with_etcd_state(msg, Some(replicas), n)).leads_to(after_ensure_vrs(n))) by {
+        assert forall |n: nat| spec.entails(tla_forall(|replicas: int| after_list_with_etcd_state(msg, Some(replicas), n)).leads_to(#[trigger] after_ensure_vrs(n))) by {
             // \A |replicas| after_list_with_etcd_state(msg, Some(replicas), n) ~> after_ensure_vrs(n)
             // since here the transitions branch over the existence and replicas of new vrs
             assert forall |replicas: Option<int>| spec.entails(#[trigger] after_list_with_etcd_state(msg, replicas, n).leads_to(after_ensure_vrs(n))) by {

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -233,7 +233,7 @@ ensures
                             etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
                             local_state_match_etcd(vd, controller_id)
                         ));
-                        assert forall |msg: Message| #![trigger dummy(msg)] spec.entails(scale_new_vrs_req_msg(msg).leads_to(scale_new_vrs_resp)) by {
+                        assert forall |msg: Message| spec.entails(#[trigger] scale_new_vrs_req_msg(msg).leads_to(scale_new_vrs_resp)) by {
                             lemma_from_after_send_get_then_update_req_to_receive_ok_resp_of_new_replicas(vd, spec, cluster, controller_id, msg, replicas, n);
                         }
                         leads_to_exists_intro(spec, |msg| scale_new_vrs_req_msg(msg), scale_new_vrs_resp);

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -523,86 +523,6 @@ ensures
 }
 
 #[verifier(external_body)]
-pub proof fn lemma_from_after_receive_list_vrs_resp_to_pending_scale_new_vrs_req_in_flight(
-    vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, replicas: int, n: nat
-)
-requires
-    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
-    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
-    spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
-    spec.entails(always(lift_action(cluster.next()))),
-    spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
-    replicas != vd.spec.replicas.unwrap_or(int1!()),
-ensures
-    spec.entails(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
-            resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
-            n_old_vrs_exists_in_etcd(controller_id, vd, n),
-            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, replicas),
-            local_state_match_etcd(vd, controller_id)
-        ))
-        .leads_to(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
-                and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
-            pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
-            n_old_vrs_exists_in_etcd(controller_id, vd, n),
-            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
-            local_state_match_etcd(vd, controller_id)
-        )))),
-{
-    let pre = and!(
-        at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
-        resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
-        n_old_vrs_exists_in_etcd(controller_id, vd, n),
-        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, replicas),
-        local_state_match_etcd(vd, controller_id)
-    );
-    let post = and!(
-        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
-            and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
-        pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
-        n_old_vrs_exists_in_etcd(controller_id, vd, n),
-        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
-        local_state_match_etcd(vd, controller_id)
-    );
-    let stronger_next = |s, s_prime: ClusterState| {
-        &&& cluster.next()(s, s_prime)
-        &&& cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s)
-    };
-    combine_spec_entails_always_n!(spec,
-        lift_action(stronger_next),
-        lift_action(cluster.next()),
-        lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id))
-    );
-    let input = (Some(resp_msg), Some(vd.object_ref()));
-    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| cluster.next_step(s, s_prime, step);
-        match step {
-            Step::APIServerStep(input) => {
-                let msg = input.get_Some_0();
-                lemma_api_request_other_than_pending_req_msg_maintains_filter_old_and_new_vrs_on_etcd(
-                    s, s_prime, vd, cluster, controller_id, msg
-                );
-            },
-            Step::ControllerStep(input) => {
-                if input.0 == controller_id && input.1 == Some(resp_msg) && input.2 == Some(vd.object_ref()) {
-                    VDeploymentReconcileState::marshal_preserves_integrity();
-                    // the request should carry the update of replicas, which requires reasoning over unmarshalling vrs
-                    VReplicaSetView::marshal_preserves_integrity();
-                }
-            },
-            _ => {}
-        }
-    }
-    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.controller_next().forward((controller_id, input.0, input.1))(s, s_prime) implies post(s_prime) by {
-        VDeploymentReconcileState::marshal_preserves_integrity();
-    }
-    cluster.lemma_pre_leads_to_post_by_controller(
-        spec, controller_id, input, stronger_next, ControllerStep::ContinueReconcile, pre, post
-    );
-}
-
-#[verifier(external_body)]
 pub proof fn lemma_from_after_send_get_then_update_req_to_receive_get_then_update_resp_on_new_vrs_of_replicas(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, req_msg: Message, replicas: int, n: nat
 )
@@ -691,6 +611,86 @@ ensures
     );
 }
 
+#[verifier(external_body)]
+pub proof fn lemma_from_after_receive_list_vrs_resp_to_pending_scale_new_vrs_req_in_flight(
+    vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, replicas: int, n: nat
+)
+requires
+    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
+    spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
+    spec.entails(always(lift_action(cluster.next()))),
+    spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+    replicas != vd.spec.replicas.unwrap_or(int1!()),
+ensures
+    spec.entails(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
+            resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, replicas),
+            local_state_match_etcd(vd, controller_id)
+        ))
+        .leads_to(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
+                and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
+            pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        )))),
+{
+    let pre = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
+        resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, replicas),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let post = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
+            and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
+        pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& cluster.next()(s, s_prime)
+        &&& cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s)
+    };
+    combine_spec_entails_always_n!(spec,
+        lift_action(stronger_next),
+        lift_action(cluster.next()),
+        lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id))
+    );
+    let input = (Some(resp_msg), Some(vd.object_ref()));
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| cluster.next_step(s, s_prime, step);
+        match step {
+            Step::APIServerStep(input) => {
+                let msg = input.get_Some_0();
+                lemma_api_request_other_than_pending_req_msg_maintains_filter_old_and_new_vrs_on_etcd(
+                    s, s_prime, vd, cluster, controller_id, msg
+                );
+            },
+            Step::ControllerStep(input) => {
+                if input.0 == controller_id && input.1 == Some(resp_msg) && input.2 == Some(vd.object_ref()) {
+                    VDeploymentReconcileState::marshal_preserves_integrity();
+                    // the request should carry the update of replicas, which requires reasoning over unmarshalling vrs
+                    VReplicaSetView::marshal_preserves_integrity();
+                }
+            },
+            _ => {}
+        }
+    }
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.controller_next().forward((controller_id, input.0, input.1))(s, s_prime) implies post(s_prime) by {
+        VDeploymentReconcileState::marshal_preserves_integrity();
+    }
+    cluster.lemma_pre_leads_to_post_by_controller(
+        spec, controller_id, input, stronger_next, ControllerStep::ContinueReconcile, pre, post
+    );
+}
+
 // same as lemma_from_receive_ok_resp_at_after_create_new_vrs_to_after_ensure_new_vrs
 #[verifier(external_body)]
 pub proof fn lemma_from_receive_ok_resp_at_after_scale_new_vrs_to_after_ensure_new_vrs(
@@ -764,91 +764,6 @@ ensures
         }
     }
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.controller_next().forward((controller_id, input.0, input.1))(s, s_prime) implies post(s_prime) by {
-        VDeploymentReconcileState::marshal_preserves_integrity();
-    }
-    cluster.lemma_pre_leads_to_post_by_controller(
-        spec, controller_id, input, stronger_next, ControllerStep::ContinueReconcile, pre, post
-    );
-}
-
-#[verifier(external_body)]
-pub proof fn lemma_from_at_after_scale_down_old_vrs_with_old_vrs_of_n_to_pending_scale_down_req_in_flight(
-    vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
-)
-requires
-    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
-    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
-    spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
-    spec.entails(always(lift_action(cluster.next()))),
-    spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
-    n > 0
-ensures
-    spec.entails(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS,
-                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
-            resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, resp_msg, int0!()),
-            n_old_vrs_exists_in_etcd(controller_id, vd, n),
-            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
-            local_state_match_etcd(vd, controller_id)
-        ))
-       .leads_to(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS,
-                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n - nat1!())))]),
-            pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, int0!()),
-            n_old_vrs_exists_in_etcd(controller_id, vd, n),
-            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
-            local_state_match_etcd(vd, controller_id)
-        )))),
-{
-    let pre = and!(
-        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS,
-            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
-        resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, resp_msg, int0!()),
-        n_old_vrs_exists_in_etcd(controller_id, vd, n),
-        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
-        local_state_match_etcd(vd, controller_id)
-    );
-    let post = and!(
-        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS,
-            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n - nat1!())))]),
-        pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, int0!()),
-        n_old_vrs_exists_in_etcd(controller_id, vd, n),
-        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
-        local_state_match_etcd(vd, controller_id)
-    );
-    let stronger_next = |s, s_prime: ClusterState| {
-        &&& cluster.next()(s, s_prime)
-        &&& cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s)
-    };
-    combine_spec_entails_always_n!(spec,
-        lift_action(stronger_next),
-        lift_action(cluster.next()),
-        lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id))
-    );
-    let input = (Some(resp_msg), Some(vd.object_ref()));
-    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
-        let step = choose |step| cluster.next_step(s, s_prime, step);
-        match step {
-            Step::APIServerStep(input) => {
-                let msg = input.get_Some_0();
-                lemma_api_request_other_than_pending_req_msg_maintains_filter_old_and_new_vrs_on_etcd(
-                    s, s_prime, vd, cluster, controller_id, msg
-                );
-            },
-            Step::ControllerStep(input) => {
-                if input.0 == controller_id && input.1 == None::<Message> && input.2 == Some(vd.object_ref()) {
-                    VDeploymentReconcileState::marshal_preserves_integrity();
-                    // the request should carry the update of replicas, which requires reasoning over unmarshalling vrs
-                    VReplicaSetView::marshal_preserves_integrity();
-                    let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
-                    let vds_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
-                    commutativity_of_seq_drop_last_and_map(vds.old_vrs_list, |vrs: VReplicaSetView| vrs.object_ref());
-                }
-            },
-            _ => {}
-        }
-    }
-    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.controller_next().forward((controller_id, input.0, input.1))(s, s_prime) implies post(s_prime)  by {
         VDeploymentReconcileState::marshal_preserves_integrity();
     }
     cluster.lemma_pre_leads_to_post_by_controller(
@@ -934,6 +849,91 @@ ensures
         }
     }
     // without this proof will fail
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.controller_next().forward((controller_id, input.0, input.1))(s, s_prime) implies post(s_prime)  by {
+        VDeploymentReconcileState::marshal_preserves_integrity();
+    }
+    cluster.lemma_pre_leads_to_post_by_controller(
+        spec, controller_id, input, stronger_next, ControllerStep::ContinueReconcile, pre, post
+    );
+}
+
+#[verifier(external_body)]
+pub proof fn lemma_from_at_after_scale_down_old_vrs_with_old_vrs_of_n_to_pending_scale_down_req_in_flight(
+    vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
+)
+requires
+    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
+    spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
+    spec.entails(always(lift_action(cluster.next()))),
+    spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+    n > 0
+ensures
+    spec.entails(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, resp_msg, int0!()),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        ))
+       .leads_to(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n - nat1!())))]),
+            pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, int0!()),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        )))),
+{
+    let pre = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, resp_msg, int0!()),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let post = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n - nat1!())))]),
+        pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, int0!()),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& cluster.next()(s, s_prime)
+        &&& cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s)
+    };
+    combine_spec_entails_always_n!(spec,
+        lift_action(stronger_next),
+        lift_action(cluster.next()),
+        lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id))
+    );
+    let input = (Some(resp_msg), Some(vd.object_ref()));
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| cluster.next_step(s, s_prime, step);
+        match step {
+            Step::APIServerStep(input) => {
+                let msg = input.get_Some_0();
+                lemma_api_request_other_than_pending_req_msg_maintains_filter_old_and_new_vrs_on_etcd(
+                    s, s_prime, vd, cluster, controller_id, msg
+                );
+            },
+            Step::ControllerStep(input) => {
+                if input.0 == controller_id && input.1 == None::<Message> && input.2 == Some(vd.object_ref()) {
+                    VDeploymentReconcileState::marshal_preserves_integrity();
+                    // the request should carry the update of replicas, which requires reasoning over unmarshalling vrs
+                    VReplicaSetView::marshal_preserves_integrity();
+                    let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
+                    let vds_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
+                    commutativity_of_seq_drop_last_and_map(vds.old_vrs_list, |vrs: VReplicaSetView| vrs.object_ref());
+                }
+            },
+            _ => {}
+        }
+    }
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.controller_next().forward((controller_id, input.0, input.1))(s, s_prime) implies post(s_prime)  by {
         VDeploymentReconcileState::marshal_preserves_integrity();
     }

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -611,6 +611,86 @@ ensures
     );
 }
 
+// same as lemma_from_receive_ok_resp_at_after_create_new_vrs_to_after_ensure_new_vrs
+#[verifier(external_body)]
+pub proof fn lemma_from_receive_ok_resp_at_after_scale_new_vrs_to_after_ensure_new_vrs(
+    vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
+)
+requires
+    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
+    spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
+    spec.entails(always(lift_action(cluster.next()))),
+    spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+ensures
+    spec.entails(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        ))
+        .leads_to(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            no_pending_req_in_cluster(vd, controller_id),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        )))),
+{
+    let pre = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        exists_resp_msg_is_ok_create_new_vrs_resp(vd, controller_id),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let post = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        no_pending_req_in_cluster(vd, controller_id),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& cluster.next()(s, s_prime)
+        &&& cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s)
+    };
+    combine_spec_entails_always_n!(spec,
+        lift_action(stronger_next),
+        lift_action(cluster.next()),
+        lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id))
+    );
+    let input = (Some(resp_msg), Some(vd.object_ref()));
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| cluster.next_step(s, s_prime, step);
+        match step {
+            Step::APIServerStep(input) => {
+                let msg = input.get_Some_0();
+                lemma_api_request_other_than_pending_req_msg_maintains_filter_old_and_new_vrs_on_etcd(
+                    s, s_prime, vd, cluster, controller_id, msg
+                );
+            },
+            Step::ControllerStep(input) => {
+                if input.0 == controller_id && input.1 == Some(resp_msg) && input.2 == Some(vd.object_ref()) {
+                    VDeploymentReconcileState::marshal_preserves_integrity();
+                }
+            },
+            _ => {}
+        }
+    }
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.controller_next().forward((controller_id, input.0, input.1))(s, s_prime) implies post(s_prime) by {
+        VDeploymentReconcileState::marshal_preserves_integrity();
+    }
+    cluster.lemma_pre_leads_to_post_by_controller(
+        spec, controller_id, input, stronger_next, ControllerStep::ContinueReconcile, pre, post
+    );
+}
+
 #[verifier(external_body)]
 pub proof fn lemma_from_at_after_scale_down_old_vrs_with_old_vrs_of_n_to_pending_scale_down_req_in_flight(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -138,8 +138,7 @@ ensures
         assert forall |n: nat| #![trigger dummy(n)] spec.entails(tla_forall(|replicas: int| after_list_with_etcd_state(msg, Some(replicas), n)).leads_to(after_ensure_vrs(n))) by {
             // \A |replicas| after_list_with_etcd_state(msg, Some(replicas), n) ~> after_ensure_vrs(n)
             // since here the transitions branch over the existence and replicas of new vrs
-            assert forall |replicas: Option<int>| #![trigger dummy(replicas)] spec.entails(
-                tla_forall(|n| after_list_with_etcd_state(msg, replicas, n).leads_to(after_ensure_vrs(n)))) by {
+            assert forall |replicas: Option<int>| spec.entails(#[trigger] after_list_with_etcd_state(msg, replicas, n).leads_to(after_ensure_vrs(n))) by {
                 // new vrs does not exists. Here the existance is encoded as is_Some, and replicas is get_Some_0
                 if replicas.is_None() {
                     // AfterListVRS ~> AfterCreateNewVRS

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -92,15 +92,14 @@ ensures
     let msg_is_list_resp_with_etcd_state = |msg: Message, replicas_or_not_exist: Option<int>, n: nat| lift_state(and!(
         at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
         resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, msg),
-        etcd_state_is(vd, controller_id, replicas_or_not_exist, n),
-        local_state_match_etcd(vd, controller_id)
+        etcd_state_is(vd, controller_id, replicas_or_not_exist, n)
     ));
     assert forall |msg: Message| #![trigger dummy(msg)] spec.entails(msg_is_list_resp(msg).leads_to(
         tla_exists(|i: (Option<int>, nat)| msg_is_list_resp_with_etcd_state(msg, i.0, i.1)))) by {
         assert forall |ex: Execution<ClusterState>| #![trigger dummy(ex)] msg_is_list_resp(msg).satisfied_by(ex) implies
             tla_exists(|i: (Option<int>, nat)| msg_is_list_resp_with_etcd_state(msg, i.0, i.1)).satisfied_by(ex) by {
             let s = ex.head();
-            let (replicas_or_not_exist, n) = choose |i: (Option<int>, nat)| etcd_state_is(vd, controller_id, i.0, i.1)(s);
+            let (replicas_or_not_exist, n) = choose |i: (Option<int>, nat)| #[trigger] etcd_state_is(vd, controller_id, i.0, i.1)(s);
             tla_exists_proved_by_witness(
                 ex,
                 |i: (Option<int>, nat)| msg_is_list_resp_with_etcd_state(msg, i.0, i.1),
@@ -232,8 +231,7 @@ ensures
             // at this stage there's no local cache available
             at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
             resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
-            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
-            local_state_match_etcd(vd, controller_id)
+            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n)
         ))
         .leads_to(lift_state(and!(
             at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
@@ -246,8 +244,7 @@ ensures
     let pre = and!(
         at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
         resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
-        etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
-        local_state_match_etcd(vd, controller_id)
+        etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n)
     );
     let post = and!(
         at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
@@ -320,8 +317,7 @@ ensures
     spec.entails(lift_state(and!(
             at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
             resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
-            etcd_state_is(vd, controller_id, None, n),
-            local_state_match_etcd(vd, controller_id)
+            etcd_state_is(vd, controller_id, None, n)
         ))
         .leads_to(lift_state(and!(
             at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS,
@@ -637,8 +633,7 @@ ensures
     spec.entails(lift_state(and!(
             at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
             resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
-            etcd_state_is(vd, controller_id, Some(replicas), n),
-            local_state_match_etcd(vd, controller_id)
+            etcd_state_is(vd, controller_id, Some(replicas), n)
         ))
         .leads_to(lift_state(and!(
             at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -364,6 +364,85 @@ ensures
 }
 
 #[verifier(external_body)]
+pub proof fn lemma_from_receive_ok_resp_at_after_create_new_vrs_to_after_ensure_new_vrs(
+    vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
+)
+requires
+    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
+    spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
+    spec.entails(always(lift_action(cluster.next()))),
+    spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
+ensures
+    spec.entails(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            exists_resp_msg_is_ok_create_new_vrs_resp(vd, controller_id),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        ))
+        .leads_to(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            no_pending_req_in_cluster(vd, controller_id),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        )))),
+{
+    let pre = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        exists_resp_msg_is_ok_create_new_vrs_resp(vd, controller_id),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let post = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        no_pending_req_in_cluster(vd, controller_id),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& cluster.next()(s, s_prime)
+        &&& cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s)
+    };
+    combine_spec_entails_always_n!(spec,
+        lift_action(stronger_next),
+        lift_action(cluster.next()),
+        lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id))
+    );
+    let input = (Some(resp_msg), Some(vd.object_ref()));
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| cluster.next_step(s, s_prime, step);
+        match step {
+            Step::APIServerStep(input) => {
+                let msg = input.get_Some_0();
+                lemma_api_request_other_than_pending_req_msg_maintains_filter_old_and_new_vrs_on_etcd(
+                    s, s_prime, vd, cluster, controller_id, msg
+                );
+            },
+            Step::ControllerStep(input) => {
+                if input.0 == controller_id && input.1 == Some(resp_msg) && input.2 == Some(vd.object_ref()) {
+                    VDeploymentReconcileState::marshal_preserves_integrity();
+                }
+            },
+            _ => {}
+        }
+    }
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.controller_next().forward((controller_id, input.0, input.1))(s, s_prime) implies post(s_prime) by {
+        VDeploymentReconcileState::marshal_preserves_integrity();
+    }
+    cluster.lemma_pre_leads_to_post_by_controller(
+        spec, controller_id, input, stronger_next, ControllerStep::ContinueReconcile, pre, post
+    );
+}
+
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_list_vrs_resp_to_pending_scale_new_vrs_req_in_flight(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, replicas: int, n: nat
 )

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -444,6 +444,95 @@ ensures
 }
 
 #[verifier(external_body)]
+pub proof fn lemma_from_after_send_get_then_update_req_to_receive_get_then_update_resp_on_new_vrs_of_replicas(
+    vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, req_msg: Message, replicas: int, n: nat
+)
+requires
+    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
+    spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
+    spec.entails(always(lift_action(cluster.next()))),
+    spec.entails(tla_forall(|i| cluster.api_server_next().weak_fairness(i))),
+ensures
+    spec.entails(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterListVRS,
+                and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
+            req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, req_msg, vd.spec.replicas.unwrap_or(int1!())),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, replicas),
+            local_state_match_etcd(vd, controller_id)
+        ))
+       .leads_to(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        )))),
+{
+    let pre = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterListVRS,
+            and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
+        req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, req_msg, vd.spec.replicas.unwrap_or(int1!())),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, replicas),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let post = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& cluster.next()(s, s_prime)
+        &&& cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s)
+    };
+    let input = Some(req_msg);
+    combine_spec_entails_always_n!(spec,
+        lift_action(stronger_next),
+        lift_action(cluster.next()),
+        lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id))
+    );
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| cluster.next_step(s, s_prime, step);
+        match step {
+            Step::APIServerStep(input) => {
+                let msg = input.get_Some_0();
+                if msg == req_msg {
+                    let resp_msg = lemma_get_then_update_request_returns_ok_at_after_scale_new_vrs(
+                        s, s_prime, vd, cluster, controller_id, msg, replicas, n
+                    );
+                    VReplicaSetView::marshal_preserves_integrity();
+                    assert({
+                        &&& s_prime.in_flight().contains(resp_msg)
+                        &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+                    });
+                }
+            },
+            _ => {}
+        }
+    }
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.api_server_next().forward(input)(s, s_prime) implies post(s_prime) by {
+        let msg = input.get_Some_0();
+        let resp_msg = lemma_get_then_update_request_returns_ok_at_after_scale_new_vrs(
+            s, s_prime, vd, cluster, controller_id, msg, replicas, n
+        );
+        // instantiate existential quantifier.
+        assert({
+            &&& s_prime.in_flight().contains(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, msg)
+        });
+    }
+    cluster.lemma_pre_leads_to_post_by_api_server(
+        spec, input, stronger_next, APIServerStep::HandleRequest, pre, post
+    );
+}
+
+#[verifier(external_body)]
 pub proof fn lemma_from_at_after_scale_down_old_vrs_with_old_vrs_of_n_to_pending_scale_down_req_in_flight(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
 )

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -121,7 +121,8 @@ ensures
         }
         entails_implies_leads_to(spec, list_resp_msg(msg), tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)));
         // \A |n| \A |replicas| etcd_state_is(replicas, n) ~> after_ensure_vrs(n)
-        assert forall |n: nat| #![trigger after_ensure_vrs(n)] spec.entails(tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n)).leads_to(after_ensure_vrs(n))) by {
+        assert forall |n: nat| #![trigger after_ensure_vrs(n)] spec.entails(tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n))
+            .leads_to(after_ensure_vrs(n))) by {
             // \A |replicas| after_list_with_etcd_state(msg, Some(replicas), n) ~> after_ensure_vrs(n)
             // since here the transitions branch over the existence and replicas of new vrs
             assert forall |replicas: Option<int>| spec.entails(#[trigger] after_list_with_etcd_state(msg, replicas, n).leads_to(after_ensure_vrs(n))) by {
@@ -272,8 +273,14 @@ ensures
             leads_to_exists_intro(spec, |replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n), after_ensure_vrs(n));
         }
         // need to prove (\A |a| (a_to_p(a) ~> a_to_q(a))) && (r ~> \E |a| a_to_p(a)) ==> r ~> \E |a| a_to_q(a)
-        assert(spec.entails(tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)).leads_to(tla_exists(|n: nat| after_ensure_vrs(n))))) by {
+        assert(spec.entails(tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1))
+            .leads_to(tla_exists(|n: nat| after_ensure_vrs(n))))) by {
+            leads_to_exists_intro_pred(spec, |n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n)), |n: nat| after_ensure_vrs(n));
             assume(false);
+            temp_pred_equality(
+                tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)),
+                tla_exists(|n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n)))
+            );
         };
         // no proper trigger inside tla_exists, if I use dummy I will make verus panic
         // assert(tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)).entails(tla_exists(|n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n))))) by {

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -170,10 +170,8 @@ ensures
                         etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
                         local_state_match_etcd(vd, controller_id)
                     ));
-                    // TODO: fix this
                     assert(spec.entails(create_vrs_resp.leads_to(tla_exists(|msg| create_vrs_resp_msg(msg))))) by {
-                        assume(false);
-                        assert forall |ex: Execution<ClusterState>| #![trigger dummy(ex)] create_vrs_resp.satisfied_by(ex) implies
+                        assert forall |ex: Execution<ClusterState>| #[trigger] create_vrs_resp.satisfied_by(ex) implies
                             tla_exists(|msg| create_vrs_resp_msg(msg)).satisfied_by(ex) by {
                             let s = ex.head();
                             let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
@@ -189,12 +187,10 @@ ensures
                     }
                     // AfterCreateNewVRS ~> AfterEnsureNewVRS
                     // Because maxSurge is not supported, this transition can be completed without scaling new VRS
-                    assert forall |msg: Message| #![trigger dummy(msg)] spec.entails(create_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
+                    assert forall |msg: Message| spec.entails(#[trigger] create_vrs_resp_msg(msg).leads_to(after_ensure_vrs(n))) by {
                         lemma_from_receive_ok_resp_after_create_new_vrs_to_after_ensure_new_vrs(vd, spec, cluster, controller_id, msg, n);
                     }
-                    // TODO: fix this
-                    // leads_to_exists_intro(spec, |msg| create_vrs_resp_msg(msg), after_ensure_vrs(n));
-                    assume(spec.entails(tla_exists(|msg| create_vrs_resp_msg(msg)).leads_to(after_ensure_vrs(n))));
+                    leads_to_exists_intro(spec, |msg| create_vrs_resp_msg(msg), after_ensure_vrs(n));
                     leads_to_trans_n!(
                         spec,
                         after_list_with_etcd_state(msg, replicas, n),
@@ -221,11 +217,9 @@ ensures
                             etcd_state_is(vd, controller_id, replicas, n),
                             local_state_match_etcd(vd, controller_id)
                         ));
-                        // TODO: fix this
                         // temp_pred_equality(scale_new_vrs_req, tla_exists(|msg| scale_new_vrs_req_msg(msg)));
                         assert(scale_new_vrs_req.entails(tla_exists(|msg| scale_new_vrs_req_msg(msg)))) by {
-                            assume(false);
-                            assert forall |ex: Execution<ClusterState>| #![trigger dummy(ex)] scale_new_vrs_req.satisfied_by(ex) implies
+                            assert forall |ex: Execution<ClusterState>| #[trigger] scale_new_vrs_req.satisfied_by(ex) implies
                                 tla_exists(|msg| scale_new_vrs_req_msg(msg)).satisfied_by(ex) by {
                                 let s = ex.head();
                                 let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
@@ -250,10 +244,8 @@ ensures
                             local_state_match_etcd(vd, controller_id)
                         ));
                         assert(scale_new_vrs_resp.entails(tla_exists(|msg| scale_new_vrs_resp_msg(msg)))) by {
-                            assume(false);
-                            assert forall |ex: Execution<ClusterState>| #![trigger dummy(ex)] scale_new_vrs_resp.satisfied_by(ex) implies
+                            assert forall |ex: Execution<ClusterState>| #[trigger] scale_new_vrs_resp.satisfied_by(ex) implies
                                 tla_exists(|msg| scale_new_vrs_resp_msg(msg)).satisfied_by(ex) by {
-                                assume(false);
                                 let s = ex.head();
                                 let req_msg = s.ongoing_reconciles(controller_id)[vd.object_ref()].pending_req_msg.get_Some_0();
                                 let resp_msg = choose |resp_msg| {

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -208,7 +208,6 @@ requires
     spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
     spec.entails(always(lift_action(cluster.next()))),
     spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
-    n > 0,
 ensures
     spec.entails(lift_state(and!(
             at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
@@ -263,10 +262,8 @@ ensures
             Step::ControllerStep(input) => {
                 if input.0 == controller_id && input.1 == Some(resp_msg) && input.2 == Some(vd.object_ref()) {
                     VDeploymentReconcileState::marshal_preserves_integrity();
-                    // the request should carry the update of replicas, which requires reasoning over unmarshalling vrs
+                    // the request should carry the make_replica_set(vd).marshal(), which requires reasoning over unmarshalling vrs
                     VReplicaSetView::marshal_preserves_integrity();
-                    let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
-                    let vds_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
                 }
             },
             _ => {}
@@ -277,6 +274,93 @@ ensures
     );
 }
 
+pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
+    vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, req_msg: Message, n: nat
+)
+requires
+    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
+    spec.entails(always(lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id)))),
+    spec.entails(always(lift_action(cluster.next()))),
+    spec.entails(tla_forall(|i| cluster.api_server_next().weak_fairness(i))),
+ensures
+    spec.entails(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterListVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            req_msg_is_the_pending_create_new_vrs_req_in_flight(vd, controller_id, req_msg),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            no_new_vrs_exists_in_etcd(controller_id, vd),
+            local_state_match_etcd(vd, controller_id)
+        ))
+       .leads_to(lift_state(and!(
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS,
+                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            exists_resp_msg_is_ok_create_new_vrs_resp(vd, controller_id),
+            n_old_vrs_exists_in_etcd(controller_id, vd, n),
+            new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+            local_state_match_etcd(vd, controller_id)
+        )))),
+{
+    let pre = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterListVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        req_msg_is_the_pending_create_new_vrs_req_in_flight(vd, controller_id, req_msg),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        no_new_vrs_exists_in_etcd(controller_id, vd),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let post = and!(
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS,
+            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        exists_resp_msg_is_ok_create_new_vrs_resp(vd, controller_id),
+        n_old_vrs_exists_in_etcd(controller_id, vd, n),
+        new_vrs_with_replicas_exists_in_etcd(controller_id, vd, vd.spec.replicas.unwrap_or(int1!())),
+        local_state_match_etcd(vd, controller_id)
+    );
+    let stronger_next = |s, s_prime: ClusterState| {
+        &&& cluster.next()(s, s_prime)
+        &&& cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s)
+    };
+    let input = Some(req_msg);
+    combine_spec_entails_always_n!(spec,
+        lift_action(stronger_next),
+        lift_action(cluster.next()),
+        lift_state(cluster_invariants_since_reconciliation(cluster, vd, controller_id))
+    );
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) implies pre(s_prime) || post(s_prime) by {
+        let step = choose |step| cluster.next_step(s, s_prime, step);
+        match step {
+            Step::APIServerStep(input) => {
+                let msg = input.get_Some_0();
+                if msg == req_msg {
+                    let resp_msg = lemma_create_new_vrs_request_returns_ok_at_after_ensure_new_vrs(
+                        s, s_prime, vd, cluster, controller_id, msg, n
+                    );
+                    VReplicaSetView::marshal_preserves_integrity();
+                    assert({
+                        &&& s_prime.in_flight().contains(resp_msg)
+                        &&& resp_msg_matches_req_msg(resp_msg, req_msg)
+                    });
+                }
+            },
+            _ => {}
+        }
+    }
+    assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.api_server_next().forward(input)(s, s_prime) implies post(s_prime) by {
+        let msg = input.get_Some_0();
+        let resp_msg = lemma_create_new_vrs_request_returns_ok_at_after_ensure_new_vrs(
+            s, s_prime, vd, cluster, controller_id, msg, n
+        );
+        // instantiate existential quantifier.
+        assert({
+            &&& s_prime.in_flight().contains(resp_msg)
+            &&& resp_msg_matches_req_msg(resp_msg, msg)
+        });
+    }
+    cluster.lemma_pre_leads_to_post_by_api_server(
+        spec, input, stronger_next, APIServerStep::HandleRequest, pre, post
+    );
+}
 
 #[verifier(external_body)]
 pub proof fn lemma_from_after_send_get_then_update_req_to_receive_get_then_update_resp_on_old_vrs_of_n(

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -638,7 +638,7 @@ ensures
             Step::APIServerStep(input) => {
                 let msg = input.get_Some_0();
                 if msg == req_msg {
-                    let resp_msg = lemma_create_new_vrs_request_returns_ok_at_after_ensure_new_vrs(
+                    let resp_msg = lemma_create_new_vrs_request_returns_ok_after_ensure_new_vrs(
                         s, s_prime, vd, cluster, controller_id, msg, n
                     );
                     VReplicaSetView::marshal_preserves_integrity();
@@ -653,7 +653,7 @@ ensures
     }
     assert forall |s, s_prime| pre(s) && #[trigger] stronger_next(s, s_prime) && cluster.api_server_next().forward(input)(s, s_prime) implies post(s_prime) by {
         let msg = input.get_Some_0();
-        let resp_msg = lemma_create_new_vrs_request_returns_ok_at_after_ensure_new_vrs(
+        let resp_msg = lemma_create_new_vrs_request_returns_ok_after_ensure_new_vrs(
             s, s_prime, vd, cluster, controller_id, msg, n
         );
         // instantiate existential quantifier.
@@ -970,7 +970,7 @@ ensures
 }
 
 #[verifier(external_body)]
-pub proof fn lemma_from_at_after_ensure_new_vrs_with_old_vrs_of_n_to_pending_scale_down_req_in_flight(
+pub proof fn lemma_from_after_ensure_new_vrs_with_old_vrs_of_n_to_pending_scale_down_req_in_flight(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, n: nat
 )
 requires
@@ -1315,7 +1315,7 @@ ensures
     );
 }
 
-pub proof fn lemma_from_old_vrs_len_zero_at_after_ensure_new_vrs_to_current_state_matches(
+pub proof fn lemma_from_old_vrs_len_zero_after_ensure_new_vrs_to_current_state_matches(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int
 )
 requires

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -89,14 +89,6 @@ ensures
         // |= |= ~>
         entails_implies_leads_to(spec, list_resp, tla_exists(|msg| list_resp_msg(msg)));
     };
-    leads_to_trans_n!(
-        spec,
-        init,
-        list_req,
-        tla_exists(|msg| list_req_msg(msg)),
-        list_resp,
-        tla_exists(|msg| list_resp_msg(msg))
-    );
     let after_list_with_etcd_state = |msg: Message, replicas_or_not_exist: Option<int>, n: nat| lift_state(and!(
         at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
         resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, msg),
@@ -318,6 +310,15 @@ ensures
         );
     }
     leads_to_exists_intro(spec, |msg| list_resp_msg(msg), tla_exists(|n: nat| after_ensure_vrs(n)));
+    leads_to_trans_n!(
+        spec,
+        init,
+        list_req,
+        tla_exists(|msg| list_req_msg(msg)),
+        list_resp,
+        tla_exists(|msg| list_resp_msg(msg)),
+        tla_exists(|n: nat| after_ensure_vrs(n))
+    );
     assume(false);
 }
 

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -1050,6 +1050,7 @@ ensures
 }
 
 // local_state_match_etcd significantly slowed and flaked this proof
+#[verifier(external_body)]
 pub proof fn lemma_from_after_ensure_new_vrs_with_old_vrs_of_n_to_pending_scale_down_req_in_flight(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, n: nat
 )
@@ -1376,6 +1377,7 @@ ensures
     );
 }
 
+#[verifier(external_body)]
 pub proof fn lemma_from_old_vrs_len_zero_after_ensure_new_vrs_to_current_state_matches(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, n: nat
 )

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -229,11 +229,11 @@ ensures
                         entails_implies_leads_to(spec, scale_new_vrs_req, tla_exists(|msg| scale_new_vrs_req_msg(msg)));
                         let scale_new_vrs_resp = lift_state(and!(
                             at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-                            exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, replicas),
-                            etcd_state_is(vd, controller_id, Some(replicas), n),
+                            exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
+                            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
                             local_state_match_etcd(vd, controller_id)
                         ));
-                        assert forall |msg: Message| #![trigger dummy(msg)] spec.entails(scale_new_vrs_req.leads_to(scale_new_vrs_resp)) by {
+                        assert forall |msg: Message| #![trigger dummy(msg)] spec.entails(scale_new_vrs_req_msg(msg).leads_to(scale_new_vrs_resp)) by {
                             lemma_from_after_send_get_then_update_req_to_receive_ok_resp_of_new_replicas(vd, spec, cluster, controller_id, msg, replicas, n);
                         }
                         leads_to_exists_intro(spec, |msg| scale_new_vrs_req_msg(msg), scale_new_vrs_resp);

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -135,7 +135,7 @@ ensures
         }
         entails_implies_leads_to(spec, list_resp_msg(msg), tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1)));
         // \A |n| \A |replicas| etcd_state_is(replicas, n) ~> after_ensure_vrs(n)
-        assert forall |n: nat| #![trigger dummy(n)] spec.entails(tla_forall(|replicas: int| after_list_with_etcd_state(msg, Some(replicas), n)).leads_to(after_ensure_vrs(n))) by {
+        assert forall |n: nat| spec.entails(tla_forall(|replicas: int| #[trigger] after_list_with_etcd_state(msg, Some(replicas), n)).leads_to(after_ensure_vrs(n))) by {
             // \A |replicas| after_list_with_etcd_state(msg, Some(replicas), n) ~> after_ensure_vrs(n)
             // since here the transitions branch over the existence and replicas of new vrs
             assert forall |replicas: Option<int>| spec.entails(#[trigger] after_list_with_etcd_state(msg, replicas, n).leads_to(after_ensure_vrs(n))) by {

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -274,6 +274,7 @@ ensures
         // need to prove (\A |a| (a_to_p(a) ~> a_to_q(a))) && (r ~> \E |a| a_to_p(a)) ==> r ~> \E |a| a_to_q(a)
         assert(spec.entails(tla_exists(|i: (Option<int>, nat)| after_list_with_etcd_state(msg, i.0, i.1))
             .leads_to(tla_exists(|n: nat| after_ensure_vrs(n))))) by {
+            // TODO: prove it
             leads_to_exists_intro_pred(spec, |n: nat| tla_exists(|replicas: Option<int>| after_list_with_etcd_state(msg, replicas, n)), |n: nat| after_ensure_vrs(n));
             assume(false);
             temp_pred_equality(

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -45,7 +45,7 @@ ensures
     // send list req ~> exists |msg| msg_is_list_req(msg)
     // just to make verus happy with trigger on macro
     let list_req = lift_state(and!(at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]), pending_list_req_in_flight(vd, controller_id)));
-    let msg_is_list_req = |msg| lift_state(and!(at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]), req_msg_is_the_pending_list_req_in_flight(vd, controller_id, msg)));
+    let msg_is_list_req = |msg| lift_state(and!(at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]), req_msg_is_pending_list_req_in_flight(vd, controller_id, msg)));
     assert(spec.entails(list_req.leads_to(tla_exists(|msg| msg_is_list_req(msg))))) by {
         assert forall |ex| #[trigger] list_req.satisfied_by(ex) implies
             tla_exists(|msg| msg_is_list_req(msg)).satisfied_by(ex) by {
@@ -141,12 +141,12 @@ requires
     spec.entails(always(lift_action(cluster.next()))),
     spec.entails(tla_forall(|i| cluster.api_server_next().weak_fairness(i))),
 ensures
-    spec.entails(lift_state(and!(at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]), req_msg_is_the_pending_list_req_in_flight(vd, controller_id, req_msg)))
+    spec.entails(lift_state(and!(at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]), req_msg_is_pending_list_req_in_flight(vd, controller_id, req_msg)))
        .leads_to(lift_state(and!(at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]), exists_pending_list_resp_in_flight_and_match_req(vd, controller_id))))),
 {
     let pre = and!(
         at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
-        req_msg_is_the_pending_list_req_in_flight(vd, controller_id, req_msg)
+        req_msg_is_pending_list_req_in_flight(vd, controller_id, req_msg)
     );
     let post = and!(
         at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
@@ -288,7 +288,7 @@ ensures
     spec.entails(lift_state(and!(
             at_vd_step_with_vd(vd, controller_id, at_step![(AfterListVRS,
                 and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
-            req_msg_is_the_pending_create_new_vrs_req_in_flight(vd, controller_id, req_msg),
+            req_msg_is_pending_create_new_vrs_req_in_flight(vd, controller_id, req_msg),
             n_old_vrs_exists_in_etcd(controller_id, vd, n),
             no_new_vrs_exists_in_etcd(controller_id, vd),
             local_state_match_etcd(vd, controller_id)
@@ -305,7 +305,7 @@ ensures
     let pre = and!(
         at_vd_step_with_vd(vd, controller_id, at_step![(AfterListVRS,
             and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
-        req_msg_is_the_pending_create_new_vrs_req_in_flight(vd, controller_id, req_msg),
+        req_msg_is_pending_create_new_vrs_req_in_flight(vd, controller_id, req_msg),
         n_old_vrs_exists_in_etcd(controller_id, vd, n),
         no_new_vrs_exists_in_etcd(controller_id, vd),
         local_state_match_etcd(vd, controller_id)

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -215,8 +215,10 @@ ensures
                             etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
                             local_state_match_etcd(vd, controller_id)
                         ));
+                        // TODO: fix this
                         // temp_pred_equality(scale_new_vrs_req, tla_exists(|msg| scale_new_vrs_req_msg(msg)));
-                        assert(spec.entails(scale_new_vrs_req.leads_to(tla_exists(|msg| scale_new_vrs_req_msg(msg))))) by {
+                        assert(scale_new_vrs_req.entails(tla_exists(|msg| scale_new_vrs_req_msg(msg)))) by {
+                            assume(false);
                             assert forall |ex: Execution<ClusterState>| #![trigger dummy(ex)] scale_new_vrs_req.satisfied_by(ex) implies
                                 tla_exists(|msg| scale_new_vrs_req_msg(msg)).satisfied_by(ex) by {
                                 let s = ex.head();
@@ -784,30 +786,26 @@ requires
     spec.entails(tla_forall(|i| cluster.api_server_next().weak_fairness(i))),
 ensures
     spec.entails(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
-                and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
             req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, req_msg, vd.spec.replicas.unwrap_or(int1!())),
             etcd_state_is(vd, controller_id, Some(replicas), n),
             local_state_match_etcd(vd, controller_id)
         ))
        .leads_to(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
-                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
             exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
             etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
             local_state_match_etcd(vd, controller_id)
         )))),
 {
     let pre = and!(
-        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
-            and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
         req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, req_msg, vd.spec.replicas.unwrap_or(int1!())),
         etcd_state_is(vd, controller_id, Some(replicas), n),
         local_state_match_etcd(vd, controller_id)
     );
     let post = and!(
-        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
-            and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
         exists_resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
         etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
         local_state_match_etcd(vd, controller_id)

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -455,7 +455,7 @@ requires
     spec.entails(tla_forall(|i| cluster.api_server_next().weak_fairness(i))),
 ensures
     spec.entails(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![(AfterListVRS,
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
                 and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
             req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, req_msg, vd.spec.replicas.unwrap_or(int1!())),
             n_old_vrs_exists_in_etcd(controller_id, vd, n),
@@ -472,7 +472,7 @@ ensures
         )))),
 {
     let pre = and!(
-        at_vd_step_with_vd(vd, controller_id, at_step![(AfterListVRS,
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
             and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
         req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, req_msg, vd.spec.replicas.unwrap_or(int1!())),
         n_old_vrs_exists_in_etcd(controller_id, vd, n),

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -1108,7 +1108,7 @@ ensures
     );
 }
 
-#[verifier(external_body)]
+// local_state_match_etcd significantly slowed and flaked this proof
 pub proof fn lemma_from_after_ensure_new_vrs_with_old_vrs_of_n_to_pending_scale_down_req_in_flight(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, n: nat
 )

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -110,7 +110,7 @@ ensures
     ));
     // from list_resp with different etcd state to different transitions to AfterEnsureNewVRS
     // \A |msg| (list_resp_msg(msg) ~> \E |n: nat| after_ensure_vrs(n))
-    assert forall |msg: Message| #![trigger dummy(msg)] spec.entails(list_resp_msg(msg).leads_to(tla_exists(|n: nat| after_ensure_vrs(n)))) by{
+    assert forall |msg: Message| #![trigger list_resp_msg(msg)] spec.entails(list_resp_msg(msg).leads_to(tla_exists(|n: nat| after_ensure_vrs(n)))) by{
         // (\A |msg|) list_resp_msg(msg) |= \E |replicas: Options<int>, n: nat| after_ensure_vrs(n)
         // here replicas.is_Some == if new vrs exists, replicas.get_Some_0() == new_vrs.spec.replicas.unwrap_or(1)
         // 1 is the default value if not set

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -203,7 +203,7 @@ ensures
                         let scale_new_vrs_req = lift_state(and!(
                             at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
                             pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
-                            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
+                            etcd_state_is(vd, controller_id, Some(replicas), n),
                             local_state_match_etcd(vd, controller_id)
                         ));
                         assert(spec.entails(after_list_with_etcd_state(msg, Some(replicas), n).leads_to(scale_new_vrs_req))) by {
@@ -212,7 +212,7 @@ ensures
                         let scale_new_vrs_req_msg = |msg: Message| lift_state(and!(
                             at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
                             req_msg_is_pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, msg, vd.spec.replicas.unwrap_or(int1!())),
-                            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
+                            etcd_state_is(vd, controller_id, Some(replicas), n),
                             local_state_match_etcd(vd, controller_id)
                         ));
                         // TODO: fix this
@@ -240,7 +240,7 @@ ensures
                         let scale_new_vrs_resp_msg = |msg: Message| lift_state(and!(
                             at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
                             resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, msg, replicas),
-                            etcd_state_is(vd, controller_id, Some(replicas), n),
+                            etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
                             local_state_match_etcd(vd, controller_id)
                         ));
                         assert(spec.entails(scale_new_vrs_resp.leads_to(tla_exists(|msg| scale_new_vrs_resp_msg(msg))))) by {
@@ -731,10 +731,9 @@ ensures
         local_state_match_etcd(vd, controller_id)
     );
     let post = and!(
-        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
-            and!(new_vrs_is_some_with_replicas(replicas), old_vrs_list_len(n)))]),
+        at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
         pending_get_then_update_req_in_flight_with_replicas(vd, controller_id, vd.spec.replicas.unwrap_or(int1!())),
-        etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
+        etcd_state_is(vd, controller_id, Some(replicas), n),
         local_state_match_etcd(vd, controller_id)
     );
     let stronger_next = |s, s_prime: ClusterState| {
@@ -868,15 +867,13 @@ requires
     spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
 ensures
     spec.entails(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS,
-                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
             resp_msg_is_ok_get_then_update_resp_with_replicas(vd, controller_id, resp_msg, vd.spec.replicas.unwrap_or(int1!())),
             etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
             local_state_match_etcd(vd, controller_id)
         ))
         .leads_to(lift_state(and!(
-            at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS,
-                and!(new_vrs_is_some_with_replicas(vd.spec.replicas.unwrap_or(int1!())), old_vrs_list_len(n)))]),
+            at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
             no_pending_req_in_cluster(vd, controller_id),
             etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
             local_state_match_etcd(vd, controller_id)

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -199,6 +199,7 @@ ensures
     );
 }
 
+#[verifier(external_body)]
 pub proof fn lemma_from_after_receive_list_vrs_resp_to_send_create_new_vrs_req(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
 )

--- a/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
@@ -89,7 +89,7 @@ ensures
         spec, vd, controller_id, AfterScaleDownOldVRS, old_vrs_list_len(zero)
     );
     // 0 ~> Done | Error ~> idle
-    assert(forall |input_cr, resp_o, s| #![trigger dummy_trigger_transition(input_cr, resp_o, s)] at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(zero))](s)
+    assert(forall |input_cr, resp_o, s| #![trigger dummy((input_cr, resp_o, s))] at_step_or![(AfterScaleDownOldVRS, old_vrs_list_len(zero))](s)
         ==> at_step_or![Error, Done]((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     cluster.lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
         spec, controller_id, vd.marshal(),
@@ -193,7 +193,7 @@ ensures
         lift_state(lift_local(controller_id, vd, at_step_or![Done]));
         lift_state(reconcile_idle)
     );
-    assert(forall |input_cr, resp_o, s| #![trigger dummy_trigger_transition(input_cr, resp_o, s)]
+    assert(forall |input_cr, resp_o, s| #![trigger dummy((input_cr, resp_o, s))]
         at_step_or![AfterEnsureNewVRS](s) ==> at_step_or![AfterScaleDownOldVRS, Error, Done]
                                              ((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     // AfterEnsureNewVRS is similar to init on no pending req/resp is needed for the transition to next step
@@ -210,7 +210,7 @@ ensures
         lift_state(lift_local(controller_id, vd, at_step_or![Error]));
         lift_state(reconcile_idle)
     );
-    assert(forall |input_cr, resp_o, s| #![trigger dummy_trigger_transition(input_cr, resp_o, s)] 
+    assert(forall |input_cr, resp_o, s| #![trigger dummy((input_cr, resp_o, s))] 
         at_step_or![AfterScaleNewVRS](s) ==> at_step_or![AfterEnsureNewVRS, Error]
                                              ((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     cluster.lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
@@ -219,7 +219,7 @@ ensures
         at_step_or![AfterEnsureNewVRS, Error]
     );
     // 5, AfterCreateNewVRS ~> idle
-    assert(forall |input_cr, resp_o, s| #![trigger dummy_trigger_transition(input_cr, resp_o, s)]
+    assert(forall |input_cr, resp_o, s| #![trigger dummy((input_cr, resp_o, s))]
         at_step_or![AfterCreateNewVRS](s) ==> at_step_or![AfterEnsureNewVRS, Error]
                                               ((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     cluster.lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(
@@ -235,7 +235,7 @@ ensures
         lift_state(lift_local(controller_id, vd, at_step_or![AfterEnsureNewVRS, Error]));
         lift_state(reconcile_idle)
     );
-    assert(forall |input_cr, resp_o, s| #![trigger dummy_trigger_transition(input_cr, resp_o, s)]
+    assert(forall |input_cr, resp_o, s| #![trigger dummy((input_cr, resp_o, s))]
         at_step_or![AfterListVRS](s) ==> at_step_or![AfterCreateNewVRS, AfterScaleNewVRS, AfterEnsureNewVRS, Error]
                                          ((cluster.reconcile_model(controller_id).transition)(input_cr, resp_o, s).0));
     cluster.lemma_from_some_state_to_arbitrary_next_state_to_reconcile_idle(

--- a/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
@@ -168,10 +168,7 @@ ensures
                     .satisfied_by(ex) by {
                 let s_marshalled = ex.head().ongoing_reconciles(controller_id)[vd.object_ref()].local_state;
                 let witness_n = VDeploymentReconcileState::unmarshal(s_marshalled).unwrap().old_vrs_list.len();
-                tla_exists_proved_by_witness(
-                    ex, |n| lift_state(lift_local(controller_id, vd, scale_down_old_vrs_rank_n(n))),
-                    witness_n
-                );
+                assert((|n| lift_state(lift_local(controller_id, vd, scale_down_old_vrs_rank_n(n))))(witness_n).satisfied_by(ex));
             }
         assert(spec.entails(p.leads_to(lift_state(reconcile_idle)))) by {
             // p ~> p(n)

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -446,9 +446,7 @@ pub open spec fn cluster_invariants_since_reconciliation(cluster: Cluster, vd: V
 }
 
 // just to make Verus happy
-pub uninterp spec fn dummy_trigger_n(n: nat) -> bool;
-pub uninterp spec fn dummy_trigger_ex(ex: Execution<ClusterState>) -> bool;
-pub uninterp spec fn dummy_trigger_transition(input: DynamicObjectView, resp_o: Option<ResponseContent>, s: ReconcileLocalState) -> bool;
+pub uninterp spec fn dummy<T>(t: T) -> bool;
 
 #[macro_export]
 macro_rules! and {

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -267,7 +267,7 @@ pub open spec fn pending_get_then_update_req_in_flight_with_replicas(
 // - so current_state_matches can be reached by sending get-then-update request
 // this predicate holds since AfterListVRS state
 // TODO: simplify this may help to reduce flakiness
-pub open spec fn local_state_match_etcd(vd: VDeploymentView, controller_id: int) -> StatePred<ClusterState> {
+pub open spec fn local_state_is_consistent_with_etcd(vd: VDeploymentView, controller_id: int) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
         &&& forall |i| 0 <= i < vds.old_vrs_list.len() ==> {

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -215,7 +215,6 @@ pub open spec fn local_state_match_etcd_on_old_vrs_list(vd: VDeploymentView, con
         let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
         // &&& (vds.new_vrs, vds.old_vrs_list) == filter_old_and_new_vrs_on_etcd(vd, s.resources())
         &&& forall |i|
-            #![trigger vds.old_vrs_list[i]]
             //#![trigger filter_old_and_new_vrs_on_etcd(vd, s.resources()).1.contains(VReplicaSetView::unmarshal(s.resources()[vds.old_vrs_list[i].object_ref()]).unwrap())]
             0 <= i < vds.old_vrs_list.len() ==> {
             // the get-then-update request can succeed
@@ -250,9 +249,9 @@ pub open spec fn local_state_match_etcd_on_new_vrs(vd: VDeploymentView, controll
         &&& vds.new_vrs.is_Some() ==> {
             let new_vrs = vds.new_vrs.get_Some_0();
             // the get-then-update request can succeed
-            &&& #[trigger] new_vrs.well_formed()
-            &&& #[trigger] new_vrs.metadata.namespace == vd.metadata.namespace
-            &&& #[trigger] new_vrs.metadata.owner_references_contains(vd.controller_owner_ref())
+            &&& new_vrs.well_formed()
+            &&& new_vrs.metadata.namespace == vd.metadata.namespace
+            &&& new_vrs.metadata.owner_references_contains(vd.controller_owner_ref())
             // obj in etcd exists and is owned by vd
             &&& s.resources().contains_key(new_vrs.object_ref())
             &&& ({

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -241,7 +241,7 @@ pub open spec fn local_state_match_etcd_on_old_vrs_list(vd: VDeploymentView, con
 }
 
 // a weaker version of coherence between local cache and etcd
-// only need the key to be in etcd
+// only need the key to be in etcd and corresponding objects can pass the filter
 // this predicate holds since AfterEnsureNewVRS state
 pub open spec fn local_state_match_etcd_on_new_vrs(vd: VDeploymentView, controller_id: int) -> StatePred<ClusterState> {
     |s: ClusterState| {

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -266,6 +266,7 @@ pub open spec fn pending_get_then_update_req_in_flight_with_replicas(
 // - only need the key to be in etcd and corresponding objects can pass the filter
 // - so current_state_matches can be reached by sending get-then-update request
 // this predicate holds since AfterListVRS state
+// TODO: simplify this may help to reduce flakiness
 pub open spec fn local_state_match_etcd(vd: VDeploymentView, controller_id: int) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -62,7 +62,7 @@ pub open spec fn pending_list_req_in_flight(vd: VDeploymentView, controller_id: 
     }
 }
 
-pub open spec fn req_msg_is_the_pending_list_req_in_flight(vd: VDeploymentView, controller_id: int, req_msg: Message,) -> StatePred<ClusterState> {
+pub open spec fn req_msg_is_pending_list_req_in_flight(vd: VDeploymentView, controller_id: int, req_msg: Message,) -> StatePred<ClusterState> {
     |s: ClusterState| {
         &&& Cluster::pending_req_msg_is(controller_id, s, vd.object_ref(), req_msg)
         &&& s.in_flight().contains(req_msg)
@@ -143,7 +143,7 @@ pub open spec fn pending_create_new_vrs_req_in_flight(
     }
 }
 
-pub open spec fn req_msg_is_the_pending_create_new_vrs_req_in_flight(
+pub open spec fn req_msg_is_pending_create_new_vrs_req_in_flight(
     vd: VDeploymentView, controller_id: int, req_msg: Message
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -349,27 +349,6 @@ pub open spec fn etcd_state_is(vd: VDeploymentView, controller_id: int, new_vrs_
     }
 }
 
-// TODO: remove these predicates and switch to etcd_state_is
-pub open spec fn no_new_vrs_exists_in_etcd(controller_id: int, vd: VDeploymentView) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        let objs = s.resources().values().filter(list_vrs_obj_filter(vd)).to_seq();
-        let (new_vrs, _) = filter_old_and_new_vrs_on_etcd(vd, s.resources());
-        &&& objects_to_vrs_list(objs).is_Some()
-        &&& new_vrs.is_None()
-    }
-}
-
-pub open spec fn new_vrs_with_replicas_exists_in_etcd(controller_id: int, vd: VDeploymentView, n: int) -> StatePred<ClusterState> {
-    |s: ClusterState| {
-        let objs = s.resources().values().filter(list_vrs_obj_filter(vd)).to_seq();
-        let (new_vrs, _) = filter_old_and_new_vrs_on_etcd(vd, s.resources());
-        &&& objects_to_vrs_list(objs).is_Some()
-        &&& new_vrs.is_Some()
-        &&& match_template_without_hash(vd, new_vrs.get_Some_0())
-        &&& new_vrs.get_Some_0().spec.replicas.unwrap_or(1) == n
-    }
-}
-
 pub open spec fn n_old_vrs_exists_in_etcd(controller_id: int, vd: VDeploymentView, n: nat) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let objs = s.resources().values().filter(list_vrs_obj_filter(vd)).to_seq();

--- a/src/controllers/vdeployment_controller/trusted/liveness_theorem.rs
+++ b/src/controllers/vdeployment_controller/trusted/liveness_theorem.rs
@@ -20,7 +20,7 @@ pub open spec fn vd_eventually_stable_reconciliation_per_cr(vd: VDeploymentView)
 // TODO: add another version which talks about pods and derives from VRS ESR and this ESR
 pub open spec fn current_state_matches(vd: VDeploymentView) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        // simulate handle_list_req
+        // make it consistent with API server's handle_list_req
         let objs = s.resources().values().filter(list_vrs_obj_filter(vd)).to_seq();
         let (new_vrs, old_vrs_list) = filter_old_and_new_vrs_on_etcd(vd, s.resources());
         // this step may return None so we need to check here

--- a/src/controllers/vdeployment_controller/trusted/liveness_theorem.rs
+++ b/src/controllers/vdeployment_controller/trusted/liveness_theorem.rs
@@ -44,7 +44,6 @@ pub open spec fn filter_old_and_new_vrs_on_etcd(vd: VDeploymentView, resources: 
     filter_old_and_new_vrs(vd, filtered_vrs_list)
 }
 
-// why this fn makes proof pass?
 pub open spec fn list_vrs_obj_filter(vd: VDeploymentView) -> spec_fn(DynamicObjectView) -> bool {
     |obj: DynamicObjectView| {
         &&& obj.kind == VReplicaSetView::kind()

--- a/src/controllers/vreplicaset_controller/pub_mod.rs
+++ b/src/controllers/vreplicaset_controller/pub_mod.rs
@@ -1,3 +1,1 @@
-pub mod exec;
-pub mod model;
 pub mod trusted;

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -682,6 +682,12 @@ pub proof fn leads_to_exists_intro<T, A>(spec: TempPred<T>, a_to_p: spec_fn(A) -
     };
 }
 
+#[verifier(external_body)]
+pub proof fn leads_to_exists_intro_pred<T, A>(spec: TempPred<T>, a_to_p: spec_fn(A) -> TempPred<T>, a_to_q: spec_fn(A) -> TempPred<T>)
+    requires forall |a: A| #[trigger] spec.entails(a_to_p(a).leads_to(a_to_q(a))),
+    ensures spec.entails(tla_exists(a_to_p).leads_to(tla_exists(a_to_q))),
+{}
+
 // This lemmas instantiates tla_forall for a.
 pub proof fn use_tla_forall<T, A>(spec: TempPred<T>, a_to_p: spec_fn(A) -> TempPred<T>, a: A)
     requires spec.entails(tla_forall(a_to_p)),

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -70,8 +70,7 @@ proof fn tla_exists_unfold<T, A>(ex: Execution<T>, a_to_p: spec_fn(A) -> TempPre
     ensures exists |a| #[trigger] a_to_p(a).satisfied_by(ex),
 {}
 
-// TODO: add a lemma to prove by witness and elimiate the reasoning over execution
-pub proof fn tla_exists_proved_by_witness<T, A>(ex: Execution<T>, a_to_p: spec_fn(A) -> TempPred<T>, witness_a: A)
+proof fn tla_exists_proved_by_witness<T, A>(ex: Execution<T>, a_to_p: spec_fn(A) -> TempPred<T>, witness_a: A)
     requires a_to_p(witness_a).satisfied_by(ex),
     ensures tla_exists(a_to_p).satisfied_by(ex)
 {}

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -682,12 +682,6 @@ pub proof fn leads_to_exists_intro<T, A>(spec: TempPred<T>, a_to_p: spec_fn(A) -
     };
 }
 
-#[verifier(external_body)]
-pub proof fn leads_to_exists_intro_pred<T, A>(spec: TempPred<T>, a_to_p: spec_fn(A) -> TempPred<T>, a_to_q: spec_fn(A) -> TempPred<T>)
-    requires forall |a: A| #[trigger] spec.entails(a_to_p(a).leads_to(a_to_q(a))),
-    ensures spec.entails(tla_exists(a_to_p).leads_to(tla_exists(a_to_q))),
-{}
-
 // This lemmas instantiates tla_forall for a.
 pub proof fn use_tla_forall<T, A>(spec: TempPred<T>, a_to_p: spec_fn(A) -> TempPred<T>, a: A)
     requires spec.entails(tla_forall(a_to_p)),


### PR DESCRIPTION
- Patch ESR to use predicates on etcd state
- Complete WF1 top level proof for VDeployment controller
  - mask broken transition lemmas for future PR

Minor change:
- unify `dummy` trigger for easier usage
- as `vreplicaset_controller::trusted` is the only module required by VDeployment controller, update the `pub_mod.rs`