### PR TITLE
Make `tla_exists_proved_by_witness` private

### DIFF
--- a/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
@@ -168,10 +168,7 @@ ensures
                     .satisfied_by(ex) by {
                 let s_marshalled = ex.head().ongoing_reconciles(controller_id)[vd.object_ref()].local_state;
                 let witness_n = VDeploymentReconcileState::unmarshal(s_marshalled).unwrap().old_vrs_list.len();
-                tla_exists_proved_by_witness(
-                    ex, |n| lift_state(lift_local(controller_id, vd, scale_down_old_vrs_rank_n(n))),
-                    witness_n
-                );
+                assert((|n| lift_state(lift_local(controller_id, vd, scale_down_old_vrs_rank_n(n))))(witness_n).satisfied_by(ex));
             }
         assert(spec.entails(p.leads_to(lift_state(reconcile_idle)))) by {
             // p ~> p(n)

--- a/src/temporal_logic/rules.rs
+++ b/src/temporal_logic/rules.rs
@@ -70,8 +70,7 @@ proof fn tla_exists_unfold<T, A>(ex: Execution<T>, a_to_p: spec_fn(A) -> TempPre
     ensures exists |a| #[trigger] a_to_p(a).satisfied_by(ex),
 {}
 
-// TODO: add a lemma to prove by witness and elimiate the reasoning over execution
-pub proof fn tla_exists_proved_by_witness<T, A>(ex: Execution<T>, a_to_p: spec_fn(A) -> TempPred<T>, witness_a: A)
+proof fn tla_exists_proved_by_witness<T, A>(ex: Execution<T>, a_to_p: spec_fn(A) -> TempPred<T>, witness_a: A)
     requires a_to_p(witness_a).satisfied_by(ex),
     ensures tla_exists(a_to_p).satisfied_by(ex)
 {}


### PR DESCRIPTION
Remove all usage of `tla_exists_proved_by_witness` and make it private.

After #662 is merged this can be rebased and merged to main.