### PR TITLE
Prove more VD invariants

### DIFF
--- a/src/controllers/vdeployment_controller/proof/guarantee.rs
+++ b/src/controllers/vdeployment_controller/proof/guarantee.rs
@@ -87,7 +87,7 @@ pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cl
                     if s.in_flight().contains(msg) {} // used to instantiate invariant's trigger.
                 }
             }
-            Step::ControllerStep((id, _, cr_key_opt)) => {
+            Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
                 let cr_key = cr_key_opt->0;
                 assert forall |msg| {
                     &&& invariant(s)
@@ -126,15 +126,15 @@ pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cl
                                 }
                             }
                             assert(req.owner_ref == triggering_cr.controller_owner_ref());
-                            let owners = req.obj.metadata.owner_references.get_Some_0();
+                            let owners = req.obj.metadata.owner_references->0;
                             let controller_owners = owners.filter(
-                                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                |o: OwnerReferenceView| o.controller is Some && o.controller->0
                             );
                             assert(controller_owners[0] == triggering_cr.controller_owner_ref());
                             assert(controller_owners.contains(triggering_cr.controller_owner_ref()));
                             seq_filter_contains_implies_seq_contains(
                                 owners,
-                                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0(),
+                                |o: OwnerReferenceView| o.controller is Some && o.controller->0,
                                 triggering_cr.controller_owner_ref(),
                             );
                             assert(req.obj.metadata.owner_references_contains(triggering_cr.controller_owner_ref()));

--- a/src/controllers/vdeployment_controller/proof/guarantee.rs
+++ b/src/controllers/vdeployment_controller/proof/guarantee.rs
@@ -7,7 +7,9 @@ use crate::vdeployment_controller::{
     proof::helper_invariants,
     trusted::{
         rely_guarantee::*,
-        spec_types::*, 
+        spec_types::*,
+        step::*,
+        util::*,
     },
 };
 use crate::vreplicaset_controller::trusted::spec_types::*;
@@ -16,9 +18,6 @@ use vstd::prelude::*;
 
 verus! {
 
-// TODO: finish proof; proof in progress.
-#[verifier(external_body)]
-#[verifier(rlimit(100))]
 pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int)
     requires
         spec.entails(lift_state(cluster.init())),
@@ -43,15 +42,19 @@ pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cl
         &&& cluster.next()(s, s_prime)
         &&& Cluster::there_is_the_controller_state(controller_id)(s)
         &&& helper_invariants::vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_vd(controller_id)(s)
+        &&& helper_invariants::vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_vd(controller_id)(s_prime)
         &&& Cluster::cr_states_are_unmarshallable::<VDeploymentReconcileState, VDeploymentView>(controller_id)(s)
         &&& Cluster::each_object_in_etcd_has_at_most_one_controller_owner()(s)
         &&& Cluster::each_object_in_etcd_is_weakly_well_formed()(s)
     };
 
+    always_to_always_later(spec, lift_state(helper_invariants::vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_vd(controller_id)));
+
     combine_spec_entails_always_n!(
         spec, lift_action(stronger_next), lift_action(cluster.next()),
         lift_state(Cluster::there_is_the_controller_state(controller_id)),
         lift_state(helper_invariants::vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_vd(controller_id)),
+        later(lift_state(helper_invariants::vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_vd(controller_id))),
         lift_state(Cluster::cr_states_are_unmarshallable::<VDeploymentReconcileState, VDeploymentView>(controller_id)),
         lift_state(Cluster::each_object_in_etcd_has_at_most_one_controller_owner()),
         lift_state(Cluster::each_object_in_etcd_is_weakly_well_formed())
@@ -101,57 +104,29 @@ pub proof fn guarantee_condition_holds(spec: TempPred<ClusterState>, cluster: Cl
                     if id == controller_id {
                         let new_msgs = s_prime.in_flight().sub(s.in_flight());
                         if new_msgs.contains(msg) && msg.content.is_get_then_update_request() {
-                            assert(s_prime.ongoing_reconciles(controller_id)[cr_key].pending_req_msg.unwrap() == msg);
                             let req = msg.content.get_get_then_update_request();
                             let state = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[cr_key].local_state).unwrap();
                             let triggering_cr = VDeploymentView::unmarshal(s.ongoing_reconciles(controller_id)[cr_key].triggering_cr).unwrap();    
 
-                            assert(req.owner_ref == triggering_cr.controller_owner_ref());
+                            if state.reconcile_step == VDeploymentReconcileStepView::AfterListVRS {
+                                let list_resp = resp_msg_opt.unwrap().content.get_list_response();
+                                let objs = list_resp.res.unwrap();
+                                let vrs_list_or_none = objects_to_vrs_list(objs);
+                                let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(triggering_cr, filter_vrs_list(triggering_cr, vrs_list_or_none->0));
 
-                            if state.new_vrs is Some && state.old_vrs_list.len() > 0 {
-                                let old_vrs = state.old_vrs_list.last();
-                                let updated_vrs = VReplicaSetView {
-                                    spec: VReplicaSetSpecView {
-                                        replicas: Some(0 as int),
-                                        ..old_vrs.spec
-                                    },
-                                    ..old_vrs
-                                };
-                                assert(req.obj == updated_vrs.marshal()
-                                    || req.obj == state.new_vrs.unwrap().marshal());
-                            } else if state.old_vrs_list.len() > 0 {
-                                let old_vrs = state.old_vrs_list.last();
-                                let updated_vrs = VReplicaSetView {
-                                    spec: VReplicaSetSpecView {
-                                        replicas: Some(0 as int),
-                                        ..old_vrs.spec
-                                    },
-                                    ..old_vrs
-                                };
-                                assert(req.obj == updated_vrs.marshal());
-                            } else if state.new_vrs is Some {
-                                assert(req.obj == state.new_vrs.unwrap().marshal());
+                                // idea: sidestep an explicit proof that the message we send is owned by triggering_cr
+                                // by applying the invariant `vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_vd`
+                                // to s_prime.
+                                if new_vrs is Some && !match_replicas(triggering_cr, new_vrs->0) {
+                                    let state_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[cr_key].local_state).unwrap();
+                                    // we need this to trigger the invariant on the post-state.
+                                    assert(s_prime.ongoing_reconciles(controller_id).contains_key(cr_key));
+                                }
                             }
+                            assert(req.owner_ref == triggering_cr.controller_owner_ref());
                             assert(req.obj.metadata.owner_references_contains(triggering_cr.controller_owner_ref()));
-                            assert(exists |vd: VDeploymentView| 
-                                req.owner_ref == #[trigger] vd.controller_owner_ref()
-                                && req.obj.metadata.owner_references_contains(vd.controller_owner_ref())
-                            );
                         }
                     }
-
-                    
-    //                  assert(match msg.content.get_APIRequest_0() {
-    //                 APIRequest::ListRequest(_) => true,
-    //                 APIRequest::CreateRequest(req) => vd_guarantee_create_req(req)(s_prime),
-    //                 APIRequest::GetThenUpdateRequest(req) => {
-    //     &&& req.obj.kind == VReplicaSetView::kind()
-    //     &&& exists |vd: VDeploymentView|
-    //         req.owner_ref == #[trigger] vd.controller_owner_ref()
-    //         && req.obj.metadata.owner_references_contains(vd.controller_owner_ref())
-    // },
-    //                 _ => false, 
-    //             });
                 }
             }
             _ => {

--- a/src/controllers/vdeployment_controller/proof/helper_invariants/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/helper_invariants/predicate.rs
@@ -216,9 +216,9 @@ pub open spec fn vd_reconcile_get_then_update_request_only_interferes_with_itsel
     vd: VDeploymentView
 ) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        let owners = req.obj.metadata.owner_references.get_Some_0();
+        let owners = req.obj.metadata.owner_references->0;
         let controller_owners = owners.filter(
-            |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+            |o: OwnerReferenceView| o.controller is Some && o.controller->0
         );
         &&& req.key().kind == VReplicaSetView::kind()
         &&& req.key().namespace == vd.metadata.namespace.unwrap()
@@ -226,7 +226,7 @@ pub open spec fn vd_reconcile_get_then_update_request_only_interferes_with_itsel
         &&& req.owner_ref.controller->0
         &&& req.owner_ref.kind == VDeploymentView::kind()
         &&& req.owner_ref.name == vd.object_ref().name
-        &&& req.obj.metadata.owner_references.is_Some()
+        &&& req.obj.metadata.owner_references is Some
         // We can't prove controller_owners == seq![vd.controller_owner_ref()]
         // directly since owner references carry a uid...
         &&& controller_owners.len() == 1
@@ -366,14 +366,14 @@ pub open spec fn vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_
                         &&& msg.content.get_list_response().res is Ok
                         &&& resp_objs.filter(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).is_err()).len() == 0 
                         &&& forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==> {
-                            let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                            let owners = resp_objs[i].metadata.owner_references->0;
                             let controller_owners = owners.filter(
-                                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                |o: OwnerReferenceView| o.controller is Some && o.controller->0
                             );
                             &&& resp_objs[i].metadata.namespace.is_some()
                             &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
                             &&& resp_objs[i].kind == VReplicaSetView::kind()
-                            &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                            &&& resp_objs[i].metadata.owner_references is Some ==> controller_owners.len() <= 1
                         }
                     }
                 }

--- a/src/controllers/vdeployment_controller/proof/helper_invariants/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/helper_invariants/predicate.rs
@@ -102,7 +102,8 @@ pub open spec fn no_other_pending_get_then_update_request_interferes_with_vd_rec
                 &&& req.owner_ref.controller->0
                 &&& req.owner_ref != vd.controller_owner_ref()
             })
-            // Prevents 2): where any message not from our specific vd updates 
+            // Prevents 2): where any message not from our specific vd (but in 
+            // the same namespace) updates 
             // vrs objects so they become owned by another VDeployment.
             &&& ((req.obj.metadata.owner_references is Some
                     && req.key().namespace == vd.object_ref().namespace) ==>
@@ -317,16 +318,25 @@ pub open spec fn vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_
                 let old_vrs_list = state.old_vrs_list;
                 &&& triggering_cr.object_ref() == key
                 &&& triggering_cr.metadata().well_formed_for_namespaced()
-                &&& forall |i| #![trigger old_vrs_list[i]] 0 <= i < old_vrs_list.len() ==>
-                    (
-                        old_vrs_list[i].object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
-                        && old_vrs_list[i].metadata.owner_references_contains(
-                            triggering_cr.controller_owner_ref()
-                        )
-                    )
-                &&& state.new_vrs is Some
-                    ==> (new_vrs.object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
-                        && new_vrs.metadata.owner_references_contains(triggering_cr.controller_owner_ref()))
+                &&& forall |i| #![trigger old_vrs_list[i]] 0 <= i < old_vrs_list.len() ==> {
+                    let owners = old_vrs_list[i].metadata.owner_references->0;
+                    let controller_owners = owners.filter(
+                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
+                    );
+                    &&& old_vrs_list[i].metadata.owner_references is Some
+                    &&& old_vrs_list[i].object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
+                    &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
+                }
+                &&& state.new_vrs is Some ==> {
+                    let new_vrs = state.new_vrs->0;
+                    let owners = new_vrs.metadata.owner_references->0;
+                    let controller_owners = owners.filter(
+                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
+                    );
+                    &&& new_vrs.metadata.owner_references is Some
+                    &&& new_vrs.object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
+                    &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
+                }
                 // Special case: a stronger property implying the above property
                 // after filtering holds on a list response to the
                 // appropriate request. 
@@ -351,12 +361,16 @@ pub open spec fn vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_
                         &&& msg.content.is_list_response()
                         &&& msg.content.get_list_response().res is Ok
                         &&& resp_objs.filter(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).is_err()).len() == 0 
-                        &&& forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==>
-                        (
-                            resp_objs[i].metadata.namespace.is_some()
-                            && resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
-                            && resp_objs[i].kind == VReplicaSetView::kind()
-                        )
+                        &&& forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==> {
+                            let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                            let controller_owners = owners.filter(
+                                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                            );
+                            &&& resp_objs[i].metadata.namespace.is_some()
+                            &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
+                            &&& resp_objs[i].kind == VReplicaSetView::kind()
+                            &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                        }
                     }
                 }
             }

--- a/src/controllers/vdeployment_controller/proof/helper_invariants/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/helper_invariants/predicate.rs
@@ -227,7 +227,11 @@ pub open spec fn vd_reconcile_get_then_update_request_only_interferes_with_itsel
         &&& req.owner_ref.kind == VDeploymentView::kind()
         &&& req.owner_ref.name == vd.object_ref().name
         &&& req.obj.metadata.owner_references.is_Some()
-        &&& controller_owners == seq![vd.controller_owner_ref()]
+        // We can't prove controller_owners == seq![vd.controller_owner_ref()]
+        // directly since owner references carry a uid...
+        &&& controller_owners.len() == 1
+        &&& controller_owners[0].name == vd.object_ref().name
+        &&& controller_owners[0].kind == VDeploymentView::kind()
     }
 }
 

--- a/src/controllers/vdeployment_controller/proof/helper_invariants/proof.rs
+++ b/src/controllers/vdeployment_controller/proof/helper_invariants/proof.rs
@@ -156,9 +156,9 @@ pub proof fn lemma_eventually_always_no_other_pending_request_interferes_with_vd
 
                             if msg.content.is_get_then_update_request() && vd.object_ref() != cr_key {
                                 let req = msg.content.get_get_then_update_request();
-                                let owners = req.obj.metadata.owner_references.get_Some_0();
+                                let owners = req.obj.metadata.owner_references->0;
                                 let controller_owners = owners.filter(
-                                    |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                    |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                 );
                                 assert(controller_owners.len() == 1);
                                 assert(controller_owners[0].name == vd_with_key.object_ref().name);
@@ -303,7 +303,7 @@ pub proof fn lemma_always_vd_reconcile_request_only_interferes_with_itself(
                 }
             }
             Step::ControllerStep((id, resp_msg_opt, cr_key_opt)) => {
-                let cr_key = cr_key_opt.get_Some_0();
+                let cr_key = cr_key_opt->0;
                 assert forall |msg| {
                     &&& invariant(s)
                     &&& stronger_next(s, s_prime)
@@ -330,21 +330,21 @@ pub proof fn lemma_always_vd_reconcile_request_only_interferes_with_itself(
                                 let list_resp = resp_msg_opt.unwrap().content.get_list_response();
                                 let objs = list_resp.res.unwrap();
                                 let vrs_list_or_none = objects_to_vrs_list(objs);
-                                let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(triggering_cr, filter_vrs_list(triggering_cr, vrs_list_or_none.get_Some_0()));
+                                let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(triggering_cr, filter_vrs_list(triggering_cr, vrs_list_or_none->0));
 
                                 // idea: sidestep an explicit proof that the message we send is owned by triggering_cr
                                 // by applying the invariant `vrs_objects_in_local_reconcile_state_are_controllerly_owned_by_vd`
                                 // to s_prime.
-                                if new_vrs.is_Some() && !match_replicas(triggering_cr, new_vrs.get_Some_0()) {
+                                if new_vrs is Some && !match_replicas(triggering_cr, new_vrs->0) {
                                     let state_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[cr_key].local_state).unwrap();
                                     // we need this to trigger the invariant on the post-state.
                                     assert(s_prime.ongoing_reconciles(controller_id).contains_key(cr_key));
                                 }
                             }
                             assert(req.owner_ref == triggering_cr.controller_owner_ref());
-                            let owners = req.obj.metadata.owner_references.get_Some_0();
+                            let owners = req.obj.metadata.owner_references->0;
                             let controller_owners = owners.filter(
-                                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                |o: OwnerReferenceView| o.controller is Some && o.controller->0
                             );
                             assert(controller_owners.len() == 1);
                             assert(controller_owners[0] == triggering_cr.controller_owner_ref());
@@ -352,7 +352,7 @@ pub proof fn lemma_always_vd_reconcile_request_only_interferes_with_itself(
                             assert(controller_owners.contains(triggering_cr.controller_owner_ref()));
                             seq_filter_contains_implies_seq_contains(
                                 owners,
-                                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0(),
+                                |o: OwnerReferenceView| o.controller is Some && o.controller->0,
                                 triggering_cr.controller_owner_ref(),
                             );
                             assert(req.obj.metadata.owner_references_contains(triggering_cr.controller_owner_ref()));
@@ -491,21 +491,21 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
         &&& triggering_cr.object_ref() == key
         &&& triggering_cr.metadata().well_formed_for_namespaced()
         &&& forall |i| #![trigger old_vrs_list[i]] 0 <= i < old_vrs_list.len() ==> {
-            let owners = old_vrs_list[i].metadata.owner_references.get_Some_0();
+            let owners = old_vrs_list[i].metadata.owner_references->0;
             let controller_owners = owners.filter(
-                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                |o: OwnerReferenceView| o.controller is Some && o.controller->0
             );
-            &&& old_vrs_list[i].metadata.owner_references.is_Some()
+            &&& old_vrs_list[i].metadata.owner_references is Some
             &&& old_vrs_list[i].object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
             &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
         }
-        &&& state.new_vrs.is_Some() ==> {
-            let new_vrs = state.new_vrs.get_Some_0();
-            let owners = new_vrs.metadata.owner_references.get_Some_0();
+        &&& state.new_vrs is Some ==> {
+            let new_vrs = state.new_vrs->0;
+            let owners = new_vrs.metadata.owner_references->0;
             let controller_owners = owners.filter(
-                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                |o: OwnerReferenceView| o.controller is Some && o.controller->0
             );
-            &&& new_vrs.metadata.owner_references.is_Some()
+            &&& new_vrs.metadata.owner_references is Some
             &&& new_vrs.object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
             &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
         }
@@ -513,8 +513,8 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
         // after filtering holds on a list response to the
         // appropriate request. 
         &&& state.reconcile_step == VDeploymentReconcileStepView::AfterListVRS ==> {
-            let req_msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
-            &&& s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.is_Some()
+            let req_msg = s.ongoing_reconciles(controller_id)[key].pending_req_msg->0;
+            &&& s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg is Some
             &&& req_msg.dst.is_APIServer()
             &&& req_msg.content.is_list_request()
             &&& req_msg.content.get_list_request() == ListRequest {
@@ -522,26 +522,26 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                 namespace: triggering_cr.metadata.namespace.unwrap(),
             }
             &&& forall |msg| {
-                let req_msg = s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.get_Some_0();
+                let req_msg = s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg->0;
                 &&& #[trigger] s.in_flight().contains(msg)
-                &&& s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.is_Some()
+                &&& s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg is Some
                 &&& msg.src.is_APIServer()
                 &&& resp_msg_matches_req_msg(msg, req_msg)
                 &&& is_ok_resp(msg.content.get_APIResponse_0())
             } ==> {
                 let resp_objs = msg.content.get_list_response().res.unwrap();
                 &&& msg.content.is_list_response()
-                &&& msg.content.get_list_response().res.is_Ok()
+                &&& msg.content.get_list_response().res is Ok
                 &&& resp_objs.filter(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).is_err()).len() == 0 
                 &&& forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==> {
-                    let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                    let owners = resp_objs[i].metadata.owner_references->0;
                     let controller_owners = owners.filter(
-                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                     );
                     &&& resp_objs[i].metadata.namespace.is_some()
                     &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
                     &&& resp_objs[i].kind == VReplicaSetView::kind()
-                    &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                    &&& resp_objs[i].metadata.owner_references is Some ==> controller_owners.len() <= 1
                 }
             }
         }
@@ -613,17 +613,17 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                 let step = choose |step| cluster.next_step(s, s_prime, step);
                 match step {
                     Step::ControllerStep((id, _, cr_key_opt)) => {
-                        let cr_key = cr_key_opt.get_Some_0();
+                        let cr_key = cr_key_opt->0;
                         if id == controller_id && cr_key == key {
                             let state = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[cr_key].local_state).unwrap();
                             let triggering_cr = VDeploymentView::unmarshal(s.ongoing_reconciles(controller_id)[cr_key].triggering_cr).unwrap();
 
                             let reconcile_step = state.reconcile_step;
-                            let cr_msg = step.get_ControllerStep_0().1.get_Some_0();
+                            let cr_msg = step.get_ControllerStep_0().1->0;
                             if reconcile_step == VDeploymentReconcileStepView::AfterListVRS
                                && is_ok_resp(cr_msg.content.get_APIResponse_0()) {
                                 let state = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[key].local_state).unwrap();
-                                let req_msg = s.ongoing_reconciles(controller_id)[cr_key].pending_req_msg.get_Some_0();
+                                let req_msg = s.ongoing_reconciles(controller_id)[cr_key].pending_req_msg->0;
                                 let objs = cr_msg.content.get_list_response().res.unwrap();
                                 let triggering_cr = VDeploymentView::unmarshal(s.ongoing_reconciles(controller_id)[cr_key].triggering_cr).unwrap();
                                 let vrs_list_or_none = objects_to_vrs_list(objs);
@@ -633,26 +633,26 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
 
 
                                 assert(cr_msg.content.is_list_response());
-                                assert(cr_msg.content.get_list_response().res.is_Ok());
-                                assert(vrs_list_or_none.is_Some());
+                                assert(cr_msg.content.get_list_response().res is Ok);
+                                assert(vrs_list_or_none is Some);
 
                                 assert forall |i| #![trigger filtered_vrs_list[i]] {
                                     0 <= i < filtered_vrs_list.len()
                                     && invariant_matrix(key, s)
                                     && stronger_next(s, s_prime)
                                 } implies {
-                                    let owners = filtered_vrs_list[i].metadata.owner_references.get_Some_0();
+                                    let owners = filtered_vrs_list[i].metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
-                                    &&& filtered_vrs_list[i].metadata.owner_references.is_Some()
+                                    &&& filtered_vrs_list[i].metadata.owner_references is Some
                                     &&& filtered_vrs_list[i].object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
                                     &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
                                 } by {
                                     assert({
-                                        let req_msg = s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.get_Some_0();
+                                        let req_msg = s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg->0;
                                         &&& s.in_flight().contains(cr_msg)
-                                        &&& s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.is_Some()
+                                        &&& s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg is Some
                                         &&& cr_msg.src.is_APIServer()
                                         &&& resp_msg_matches_req_msg(cr_msg, req_msg)});
                                     
@@ -660,7 +660,7 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                         vrs_list,
                                         |vrs: VReplicaSetView|
                                             vrs.metadata.owner_references_contains(triggering_cr.controller_owner_ref())
-                                            && vrs.metadata.deletion_timestamp.is_None()
+                                            && vrs.metadata.deletion_timestamp is None
                                             && vrs.well_formed(),
                                         filtered_vrs_list[i]
                                     );
@@ -685,13 +685,13 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                     assert(objs[idx1].metadata == vrs_list[idx1].metadata);
 
                                     // Show owner reference properties.
-                                    let owners = filtered_vrs_list[i].metadata.owner_references.get_Some_0();
+                                    let owners = filtered_vrs_list[i].metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
                                     assert(owners.contains(triggering_cr.controller_owner_ref()));
-                                    assert(triggering_cr.controller_owner_ref().controller.is_Some());
-                                    assert(triggering_cr.controller_owner_ref().controller.get_Some_0());
+                                    assert(triggering_cr.controller_owner_ref().controller is Some);
+                                    assert(triggering_cr.controller_owner_ref().controller->0);
                                     assert(controller_owners.contains(triggering_cr.controller_owner_ref()));
                                     assert(controller_owners.len() == 1);
                                     assert(controller_owners[0] == triggering_cr.controller_owner_ref());
@@ -705,11 +705,11 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                     && invariant_matrix(key, s)
                                     && stronger_next(s, s_prime)
                                     implies {
-                                    let owners = new_vrs_list[i].metadata.owner_references.get_Some_0();
+                                    let owners = new_vrs_list[i].metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
-                                    &&& new_vrs_list[i].metadata.owner_references.is_Some()
+                                    &&& new_vrs_list[i].metadata.owner_references is Some
                                     &&& new_vrs_list[i].object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
                                     &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
                                 } by {
@@ -723,27 +723,27 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
 
                                 let state_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[key].local_state).unwrap();
                                 if new_vrs_list.len() == 0 {
-                                    assert(new_vrs.is_None());
+                                    assert(new_vrs is None);
                                     assert(state_prime.new_vrs == Some(make_replica_set(triggering_cr)));
-                                    let owners = state_prime.new_vrs.get_Some_0().metadata.owner_references.get_Some_0();
+                                    let owners = state_prime.new_vrs->0.metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
                                     assert(owners == seq![triggering_cr.controller_owner_ref()]);
                                     assert(owners[0] == triggering_cr.controller_owner_ref());
                                     assert(owners.contains(triggering_cr.controller_owner_ref()));
-                                    assert(triggering_cr.controller_owner_ref().controller.is_Some());
-                                    assert(triggering_cr.controller_owner_ref().controller.get_Some_0());
+                                    assert(triggering_cr.controller_owner_ref().controller is Some);
+                                    assert(triggering_cr.controller_owner_ref().controller->0);
                                     assert(controller_owners.contains(triggering_cr.controller_owner_ref()));
                                     assert(controller_owners.len() == 1);
                                 }
 
-                                if new_vrs.is_Some() {
-                                    let owners = new_vrs_list[0].metadata.owner_references.get_Some_0();
+                                if new_vrs is Some {
+                                    let owners = new_vrs_list[0].metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
-                                    assert(new_vrs.get_Some_0() == new_vrs_list.first());
+                                    assert(new_vrs->0 == new_vrs_list.first());
                                     assert(new_vrs_list.first() == new_vrs_list[0]);
                                     assert(controller_owners == seq![triggering_cr.controller_owner_ref()]);
                                 }
@@ -753,11 +753,11 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                     && invariant_matrix(key, s)
                                     && stronger_next(s, s_prime)
                                     implies {
-                                    let owners = old_vrs_list[i].metadata.owner_references.get_Some_0();
+                                    let owners = old_vrs_list[i].metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
-                                    &&& old_vrs_list[i].metadata.owner_references.is_Some()
+                                    &&& old_vrs_list[i].metadata.owner_references is Some
                                     &&& old_vrs_list[i].object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
                                     &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
                                 } by {
@@ -765,8 +765,8 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                     seq_filter_contains_implies_seq_contains(
                                         filtered_vrs_list,
                                         |vrs: VReplicaSetView| {
-                                            &&& new_vrs.is_None() || vrs.metadata.uid != new_vrs.get_Some_0().metadata.uid
-                                            &&& vrs.spec.replicas.is_None() || vrs.spec.replicas.unwrap() > 0
+                                            &&& new_vrs is None || vrs.metadata.uid != new_vrs->0.metadata.uid
+                                            &&& vrs.spec.replicas is None || vrs.spec.replicas.unwrap() > 0
                                         },
                                         old_vrs_list[i]
                                     );
@@ -781,21 +781,21 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                     &&& triggering_cr.object_ref() == key
                                     &&& triggering_cr.metadata().well_formed_for_namespaced()
                                     &&& forall |i| #![trigger old_vrs_list[i]] 0 <= i < old_vrs_list.len() ==> {
-                                        let owners = old_vrs_list[i].metadata.owner_references.get_Some_0();
+                                        let owners = old_vrs_list[i].metadata.owner_references->0;
                                         let controller_owners = owners.filter(
-                                            |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                            |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                         );
-                                        &&& old_vrs_list[i].metadata.owner_references.is_Some()
+                                        &&& old_vrs_list[i].metadata.owner_references is Some
                                         &&& old_vrs_list[i].object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
                                         &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
                                     }
-                                    &&& state.new_vrs.is_Some() ==> {
-                                        let new_vrs = state.new_vrs.get_Some_0();
-                                        let owners = new_vrs.metadata.owner_references.get_Some_0();
+                                    &&& state.new_vrs is Some ==> {
+                                        let new_vrs = state.new_vrs->0;
+                                        let owners = new_vrs.metadata.owner_references->0;
                                         let controller_owners = owners.filter(
-                                            |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                            |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                         );
-                                        &&& new_vrs.metadata.owner_references.is_Some()
+                                        &&& new_vrs.metadata.owner_references is Some
                                         &&& new_vrs.object_ref().namespace == triggering_cr.metadata.namespace.unwrap()
                                         &&& controller_owners == seq![triggering_cr.controller_owner_ref()]
                                     }
@@ -803,8 +803,8 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                             }
 
                             // prove that the newly sent message has no response.
-                            if s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.is_Some() {
-                                let req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+                            if s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg is Some {
+                                let req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg->0;
                                 assert(forall |msg| #[trigger] s.in_flight().contains(msg) ==> msg.rpc_id != req_msg.rpc_id);
                                 assert(s_prime.in_flight().sub(s.in_flight()) == Multiset::singleton(req_msg));
                                 assert forall |msg| #[trigger] s_prime.in_flight().contains(msg)
@@ -822,11 +822,11 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                             let state = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[key].local_state).unwrap();
                             let triggering_cr = VDeploymentView::unmarshal(s_prime.ongoing_reconciles(controller_id)[key].triggering_cr).unwrap();
                             if state.reconcile_step == VDeploymentReconcileStepView::AfterListVRS {
-                                let req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+                                let req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg->0;
                                 assert forall |msg| {
-                                    let req_msg = s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.get_Some_0();
+                                    let req_msg = s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg->0;
                                     &&& #[trigger] s_prime.in_flight().contains(msg)
-                                    &&& s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.is_Some()
+                                    &&& s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg is Some
                                     &&& msg.src.is_APIServer()
                                     &&& resp_msg_matches_req_msg(msg, req_msg)
                                     &&& is_ok_resp(msg.content.get_APIResponse_0())
@@ -835,17 +835,17 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                 } implies {
                                     let resp_objs = msg.content.get_list_response().res.unwrap();
                                     &&& msg.content.is_list_response()
-                                    &&& msg.content.get_list_response().res.is_Ok()
+                                    &&& msg.content.get_list_response().res is Ok
                                     &&& resp_objs.filter(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).is_err()).len() == 0 
                                     &&& forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==>{
-                                        let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                                        let owners = resp_objs[i].metadata.owner_references->0;
                                         let controller_owners = owners.filter(
-                                            |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                            |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                         );
                                         &&& resp_objs[i].metadata.namespace.is_some()
                                         &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
                                         &&& resp_objs[i].kind == VReplicaSetView::kind()
-                                        &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                                        &&& resp_objs[i].metadata.owner_references is Some ==> controller_owners.len() <= 1
                                     }
                                 } by {
                                     assert(forall |msg| #[trigger] new_msgs.contains(msg) ==> !(#[trigger] msg.src.is_APIServer()));
@@ -862,12 +862,12 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                         let state = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[key].local_state).unwrap();
                         let new_msgs = s_prime.in_flight().sub(s.in_flight());
                         if state.reconcile_step == VDeploymentReconcileStepView::AfterListVRS {
-                            let req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+                            let req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg->0;
                             let triggering_cr = VDeploymentView::unmarshal(s.ongoing_reconciles(controller_id)[key].triggering_cr).unwrap();
                             assert forall |msg| {
-                                let req_msg = s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.get_Some_0();
+                                let req_msg = s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg->0;
                                 &&& #[trigger] s_prime.in_flight().contains(msg)
-                                &&& s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.is_Some()
+                                &&& s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg is Some
                                 &&& msg.src.is_APIServer()
                                 &&& resp_msg_matches_req_msg(msg, req_msg)
                                 &&& is_ok_resp(msg.content.get_APIResponse_0())
@@ -876,17 +876,17 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                             } implies {
                                 let resp_objs = msg.content.get_list_response().res.unwrap();
                                 &&& msg.content.is_list_response()
-                                &&& msg.content.get_list_response().res.is_Ok()
+                                &&& msg.content.get_list_response().res is Ok
                                 &&& resp_objs.filter(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).is_err()).len() == 0 
                                 &&& forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==> {
-                                    let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                                    let owners = resp_objs[i].metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
                                     &&& resp_objs[i].metadata.namespace.is_some()
                                     &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
                                     &&& resp_objs[i].kind == VReplicaSetView::kind()
-                                    &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                                    &&& resp_objs[i].metadata.owner_references is Some ==> controller_owners.len() <= 1
                                 }
                             } by {
                                 if (new_msgs.contains(msg)) {
@@ -919,14 +919,14 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                             && invariant_matrix(key, s)
                                             && stronger_next(s, s_prime)
                                         } implies {
-                                            let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                                            let owners = resp_objs[i].metadata.owner_references->0;
                                             let controller_owners = owners.filter(
-                                                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                                |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                             );
                                             &&& resp_objs[i].metadata.namespace.is_some()
                                             &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
                                             &&& resp_objs[i].kind == VReplicaSetView::kind()
-                                            &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                                            &&& resp_objs[i].metadata.owner_references is Some ==> controller_owners.len() <= 1
                                         } by {
                                             // Tricky reasoning about .to_seq
                                             let selector = |o: DynamicObjectView| {
@@ -947,7 +947,7 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                 } else {
                                     let msg_antecedent = {
                                         &&& s.in_flight().contains(msg)
-                                        &&& s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.is_Some()
+                                        &&& s.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg is Some
                                         &&& msg.src.is_APIServer()
                                         &&& resp_msg_matches_req_msg(msg, req_msg)
                                     };
@@ -955,18 +955,18 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                                         let resp_objs = msg.content.get_list_response().res.unwrap();
                                         assert({
                                             &&& msg.content.is_list_response()
-                                            &&& msg.content.get_list_response().res.is_Ok()
+                                            &&& msg.content.get_list_response().res is Ok
                                             &&& resp_objs.filter(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).is_err()).len() == 0
                                         });
                                         assert(forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==> {
-                                            let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                                            let owners = resp_objs[i].metadata.owner_references->0;
                                             let controller_owners = owners.filter(
-                                                |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                                |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                             );
                                             &&& resp_objs[i].metadata.namespace.is_some()
                                             &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
                                             &&& resp_objs[i].kind == VReplicaSetView::kind()
-                                            &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                                            &&& resp_objs[i].metadata.owner_references is Some ==> controller_owners.len() <= 1
                                         });
                                     }
                                 }
@@ -979,11 +979,11 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                         let state = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[key].local_state).unwrap();
                         let triggering_cr = VDeploymentView::unmarshal(s_prime.ongoing_reconciles(controller_id)[key].triggering_cr).unwrap();
                         if state.reconcile_step == VDeploymentReconcileStepView::AfterListVRS {
-                            let req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg.get_Some_0();
+                            let req_msg = s_prime.ongoing_reconciles(controller_id)[key].pending_req_msg->0;
                             assert forall |msg| {
-                                let req_msg = s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.get_Some_0();
+                                let req_msg = s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg->0;
                                 &&& #[trigger] s_prime.in_flight().contains(msg)
-                                &&& s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.is_Some()
+                                &&& s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg is Some
                                 &&& msg.src.is_APIServer()
                                 &&& resp_msg_matches_req_msg(msg, req_msg)
                                 &&& is_ok_resp(msg.content.get_APIResponse_0())
@@ -992,17 +992,17 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                             } implies {
                                 let resp_objs = msg.content.get_list_response().res.unwrap();
                                 &&& msg.content.is_list_response()
-                                &&& msg.content.get_list_response().res.is_Ok()
+                                &&& msg.content.get_list_response().res is Ok
                                 &&& resp_objs.filter(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).is_err()).len() == 0 
                                 &&& forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==> {
-                                    let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                                    let owners = resp_objs[i].metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
                                     &&& resp_objs[i].metadata.namespace.is_some()
                                     &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
                                     &&& resp_objs[i].kind == VReplicaSetView::kind()
-                                    &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                                    &&& resp_objs[i].metadata.owner_references is Some ==> controller_owners.len() <= 1
                                 }
                             } by {
                                 assert(forall |msg| #[trigger] new_msgs.contains(msg) ==> !(#[trigger] msg.src.is_APIServer()));
@@ -1017,28 +1017,28 @@ pub proof fn lemma_always_vrs_objects_in_local_reconcile_state_are_controllerly_
                         let triggering_cr = VDeploymentView::unmarshal(s_prime.ongoing_reconciles(controller_id)[key].triggering_cr).unwrap();
                         if state.reconcile_step == VDeploymentReconcileStepView::AfterListVRS {
                             assert forall |msg| {
-                                let req_msg = s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.get_Some_0();
+                                let req_msg = s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg->0;
                                 &&& invariant_matrix(key, s)
                                 &&& stronger_next(s, s_prime)
                                 &&& #[trigger] s_prime.in_flight().contains(msg)
-                                &&& s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg.is_Some()
+                                &&& s_prime.ongoing_reconciles(controller_id)[triggering_cr.object_ref()].pending_req_msg is Some
                                 &&& msg.src.is_APIServer()
                                 &&& resp_msg_matches_req_msg(msg, req_msg)
                                 &&& is_ok_resp(msg.content.get_APIResponse_0())
                             } implies {
                                 let resp_objs = msg.content.get_list_response().res.unwrap();
                                 &&& msg.content.is_list_response()
-                                &&& msg.content.get_list_response().res.is_Ok()
+                                &&& msg.content.get_list_response().res is Ok
                                 &&& resp_objs.filter(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).is_err()).len() == 0 
                                 &&& forall |i| #![trigger resp_objs[i]] 0 <= i < resp_objs.len() ==> {
-                                    let owners = resp_objs[i].metadata.owner_references.get_Some_0();
+                                    let owners = resp_objs[i].metadata.owner_references->0;
                                     let controller_owners = owners.filter(
-                                        |o: OwnerReferenceView| o.controller.is_Some() && o.controller.get_Some_0()
+                                        |o: OwnerReferenceView| o.controller is Some && o.controller->0
                                     );
                                     &&& resp_objs[i].metadata.namespace.is_some()
                                     &&& resp_objs[i].metadata.namespace.unwrap() == triggering_cr.metadata.namespace.unwrap()
                                     &&& resp_objs[i].kind == VReplicaSetView::kind()
-                                    &&& resp_objs[i].metadata.owner_references.is_Some() ==> controller_owners.len() <= 1
+                                    &&& resp_objs[i].metadata.owner_references is Some ==> controller_owners.len() <= 1
                                 }
                             } by {
                                 let resp_objs = msg.content.get_list_response().res.unwrap();

--- a/src/controllers/vdeployment_controller/proof/helper_lemmas.rs
+++ b/src/controllers/vdeployment_controller/proof/helper_lemmas.rs
@@ -8,8 +8,8 @@ use crate::kubernetes_cluster::spec::{
 use crate::temporal_logic::{defs::*, rules::*};
 use crate::vdeployment_controller::{
     model::{install::*, reconciler::*},
-    proof::predicate::*,
-    trusted::rely_guarantee::*,
+    proof::{helper_invariants, predicate::*},
+    trusted::{rely_guarantee::*, spec_types::*},
 };
 use crate::vstd_ext::{map_lib::*, seq_lib::*, set_lib::*};
 use vstd::{seq_lib::*, map_lib::*};
@@ -120,6 +120,70 @@ pub proof fn vd_rely_condition_equivalent_to_lifted_vd_rely_condition_action(
                 assert(always(lifted_vd_rely_condition_action(cluster, controller_id)).satisfied_by(ex));
                 assert(lifted_vd_rely_condition_action(cluster, controller_id).satisfied_by(ex.suffix(n)));
                 assert(lifted_vd_rely_condition_action(cluster, controller_id).satisfied_by(ex.suffix(n + 1)));
+            }
+        }
+    );
+}
+
+pub proof fn only_interferes_with_itself_equivalent_to_lifted_only_interferes_with_itself_action(
+    spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int,
+)
+    ensures
+        spec.entails(always(tla_forall(|vd: VDeploymentView| 
+            lift_state(helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)))))
+        <==>
+            spec.entails(always(lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id)))
+{
+    let lhs = 
+        spec.entails(always(tla_forall(|vd: VDeploymentView| 
+            lift_state(helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)))));
+    let rhs = spec.entails(always(lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id)));
+
+    assert_by(
+        lhs ==> rhs,
+        {
+            assert forall |ex: Execution<ClusterState>, n: nat, vd: VDeploymentView| #![auto]
+                lhs
+                && spec.satisfied_by(ex)
+                implies 
+                helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)(ex.suffix(n).head())
+                && helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)(ex.suffix(n).head_next()) by {
+                // Gradually unwrap the semantics of lhs
+                // until Verus can show the consequent.
+                let tla_forall_body = |vd: VDeploymentView| 
+                    lift_state(helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd));
+
+                assert(valid(spec.implies(always(tla_forall(tla_forall_body)))));
+                assert(spec.implies(always(tla_forall(tla_forall_body))).satisfied_by(ex));
+                assert(always(tla_forall(tla_forall_body)).satisfied_by(ex));
+
+                assert(tla_forall(tla_forall_body).satisfied_by(ex.suffix(n)));
+                assert(tla_forall(tla_forall_body).satisfied_by(ex.suffix(n + 1)));
+
+                assert(tla_forall_body(vd).satisfied_by(ex.suffix(n)));
+                assert(tla_forall_body(vd).satisfied_by(ex.suffix(n + 1)));
+            }
+        }
+    );
+    
+    assert_by(
+        rhs ==> lhs,
+        {
+            assert forall |ex: Execution<ClusterState>, n: nat, vd: VDeploymentView| #![auto]
+                rhs
+                && spec.satisfied_by(ex)
+                implies 
+                helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)(ex.suffix(n).head())
+                && helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)(ex.suffix(n).head_next()) by {
+                // Gradually unwrap the semantics of rhs
+                // until Verus can show the consequent.
+                assert(valid(spec.implies(always(lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id)))));
+                assert(spec.implies(always(lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id))).satisfied_by(ex));
+                assert(always(lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id)).satisfied_by(ex));
+                
+                assert(lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id).satisfied_by(ex.suffix(n)));
+                assert(lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id).satisfied_by(ex.suffix(n + 1)));
+
             }
         }
     );

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -3,6 +3,7 @@ use crate::kubernetes_api_objects::spec::prelude::*;
 use crate::vdeployment_controller::{
     trusted::{rely_guarantee::*, step::*, spec_types::*},
     model::{install::*, reconciler::*},
+    proof::helper_invariants,
 };
 use crate::kubernetes_cluster::spec::{
     controller::types::*,
@@ -558,6 +559,13 @@ pub open spec fn lifted_vd_rely_condition_action(cluster: Cluster, controller_id
             ==> #[trigger] vd_rely(other_id)(s))
         && (forall |other_id| cluster.controller_models.remove(controller_id).contains_key(other_id)
                 ==> #[trigger] vd_rely(other_id)(s_prime))
+    })
+}
+
+pub open spec fn lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id: int) -> TempPred<ClusterState> {
+    lift_action(|s, s_prime| {
+        (forall |vd: VDeploymentView| helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)(s))
+        && (forall |vd: VDeploymentView| helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)(s_prime))
     })
 }
 

--- a/src/controllers/vdeployment_controller/trusted/rely_guarantee.rs
+++ b/src/controllers/vdeployment_controller/trusted/rely_guarantee.rs
@@ -75,7 +75,7 @@ pub open spec fn vd_rely_get_then_update_req(req: GetThenUpdateRequest) -> State
 // similar to update requests, minus the condition on owner_references.
 pub open spec fn vd_rely_update_status_req(req: UpdateStatusRequest) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        req.obj.kind == VDeploymentView::kind() ==> 
+        req.obj.kind == VReplicaSetView::kind() ==> 
             req.obj.metadata.resource_version is Some
             && !{
                 let etcd_obj = s.resources()[req.key()];

--- a/src/kubernetes_cluster/proof/objects_in_store.rs
+++ b/src/kubernetes_cluster/proof/objects_in_store.rs
@@ -67,6 +67,7 @@ pub open spec fn each_builtin_object_in_etcd_is_well_formed(self) -> StatePred<C
     }
 }
 
+#[verifier(rlimit(100))]
 pub proof fn lemma_always_each_builtin_object_in_etcd_is_well_formed(self, spec: TempPred<ClusterState>)
     requires
         spec.entails(lift_state(self.init())),


### PR DESCRIPTION
Here I prove some additional invariants, including the boundary lemma `lemma_eventually_always_no_other_pending_request_interferes_with_vd_reconcile`. An invariant stating the garbage collector won't interfere with reconciliation remains unproven; this reasoning is complicated by the `GetThenUpdate` request that the `VDeployment` controller sends.