### PR TITLE
Add requirements that `map` and `seq` should be finite

### DIFF
--- a/src/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/controllers/vdeployment_controller/exec/reconciler.rs
@@ -593,7 +593,6 @@ ensures
             assert(old_labels.dom().len() >= 0);
             assert(labels@ == old_labels.insert("pod-template-hash"@, pod_template_hash@));
             axiom_map_insert_domain(old_labels, "pod-template-hash"@, pod_template_hash@);
-            assume(old_labels.dom().finite());
             assert(labels@.dom() == old_labels.dom().insert("pod-template-hash"@));
             axiom_set_insert_len(old_labels.dom(), "pod-template-hash"@);
         }

--- a/src/controllers/vdeployment_controller/trusted/spec_types.rs
+++ b/src/controllers/vdeployment_controller/trusted/spec_types.rs
@@ -166,12 +166,14 @@ impl ResourceView for VDeploymentView {
         // selector exists, and its match_labels is not empty
         // TODO: revise it after supporting selector.match_expressions
         &&& self.spec.selector.match_labels is Some
-        &&& self.spec.selector.match_labels->0.finite()
+        // labels are finite
+        &&& self.spec.selector.match_labels->0.dom().finite()
         &&& self.spec.selector.match_labels->0.len() > 0
         // template and its metadata ane spec exists
         &&& self.spec.template.metadata is Some
         // can be derived from selector match labels
         &&& self.spec.template.metadata->0.labels is Some
+        &&& self.spec.template.metadata->0.labels->0.dom().finite()
         &&& self.spec.template.spec is Some
         // selector matches template's metadata's labels
         &&& self.spec.selector.matches(self.spec.template.metadata->0.labels->0)

--- a/src/controllers/vdeployment_controller/trusted/spec_types.rs
+++ b/src/controllers/vdeployment_controller/trusted/spec_types.rs
@@ -166,6 +166,7 @@ impl ResourceView for VDeploymentView {
         // selector exists, and its match_labels is not empty
         // TODO: revise it after supporting selector.match_expressions
         &&& self.spec.selector.match_labels is Some
+        &&& self.spec.selector.match_labels->0.finite()
         &&& self.spec.selector.match_labels->0.len() > 0
         // template and its metadata ane spec exists
         &&& self.spec.template.metadata is Some

--- a/src/controllers/vreplicaset_controller/trusted/spec_types.rs
+++ b/src/controllers/vreplicaset_controller/trusted/spec_types.rs
@@ -133,6 +133,7 @@ impl ResourceView for VReplicaSetView {
         // selector exists, and its match_labels is not empty
         // TODO: revise it after supporting selector.match_expressions
         &&& self.spec.selector.match_labels is Some
+        &&& self.spec.selector.match_labels->0.finite()
         &&& self.spec.selector.match_labels->0.len() > 0
         // template, and its metadata ane spec exists
         &&& self.spec.template is Some

--- a/src/controllers/vreplicaset_controller/trusted/spec_types.rs
+++ b/src/controllers/vreplicaset_controller/trusted/spec_types.rs
@@ -133,7 +133,8 @@ impl ResourceView for VReplicaSetView {
         // selector exists, and its match_labels is not empty
         // TODO: revise it after supporting selector.match_expressions
         &&& self.spec.selector.match_labels is Some
-        &&& self.spec.selector.match_labels->0.finite()
+        // labels are finite
+        &&& self.spec.selector.match_labels->0.dom().finite()
         &&& self.spec.selector.match_labels->0.len() > 0
         // template, and its metadata ane spec exists
         &&& self.spec.template is Some
@@ -142,6 +143,7 @@ impl ResourceView for VReplicaSetView {
         // kubernetes requires selector matches template's metadata's labels
         // and also requires selector to be non-empty, so it implicitly requires that the labels are non-empty
         &&& self.spec.template->0.metadata->0.labels is Some
+        &&& self.spec.template->0.metadata->0.labels->0.dom().finite()
         &&& self.spec.selector.matches(self.spec.template->0.metadata->0.labels->0)
     }
 

--- a/src/kubernetes_api_objects/exec/label_selector.rs
+++ b/src/kubernetes_api_objects/exec/label_selector.rs
@@ -52,7 +52,7 @@ impl LabelSelector {
     pub fn match_labels(&self) -> (match_labels: Option<StringMap>)
         ensures
             self@.match_labels is Some == match_labels is Some,
-            match_labels is Some ==> match_labels->0@ == self@.match_labels->0,
+            match_labels is Some ==> match_labels->0@ == self@.match_labels->0 && match_labels->0@.dom().finite(),
     {
         match &self.inner.match_labels {
             Some(ml) => Some(StringMap::from_rust_map(ml.clone())),

--- a/src/kubernetes_api_objects/exec/object_meta.rs
+++ b/src/kubernetes_api_objects/exec/object_meta.rs
@@ -71,7 +71,7 @@ impl ObjectMeta {
     pub fn labels(&self) -> (labels: Option<StringMap>)
         ensures
             self@.labels is Some == labels is Some,
-            labels is Some ==> labels->0@ == self@.labels->0,
+            labels is Some ==> labels->0@ == self@.labels->0 && labels->0@.dom().finite(),
     {
         match &self.inner.labels {
             Some(l) => Some(StringMap::from_rust_map(l.clone())),
@@ -83,7 +83,7 @@ impl ObjectMeta {
     pub fn annotations(&self) -> (annotations: Option<StringMap>)
         ensures
             self@.annotations is Some == annotations is Some,
-            annotations is Some ==> annotations->0@ == self@.annotations->0,
+            annotations is Some ==> annotations->0@ == self@.annotations->0 && annotations->0@.dom().finite(),
     {
         match &self.inner.annotations {
             Some(a) => Some(StringMap::from_rust_map(a.clone())),

--- a/src/kubernetes_api_objects/spec/object_meta.rs
+++ b/src/kubernetes_api_objects/spec/object_meta.rs
@@ -170,6 +170,10 @@ impl ObjectMetaView {
         &&& self.namespace is Some
         &&& self.resource_version is Some
         &&& self.uid is Some
+        &&& self.labels is Some ==> self.labels->0.finite()
+        &&& self.annotations is Some ==> self.annotations->0.finite()
+        &&& self.owner_references is Some ==> self.owner_references->0.finite()
+        &&& self.finalizers is Some ==> self.finalizers->0.finite()
     }
 }
 

--- a/src/kubernetes_api_objects/spec/object_meta.rs
+++ b/src/kubernetes_api_objects/spec/object_meta.rs
@@ -170,10 +170,9 @@ impl ObjectMetaView {
         &&& self.namespace is Some
         &&& self.resource_version is Some
         &&& self.uid is Some
-        &&& self.labels is Some ==> self.labels->0.finite()
-        &&& self.annotations is Some ==> self.annotations->0.finite()
-        &&& self.owner_references is Some ==> self.owner_references->0.finite()
-        &&& self.finalizers is Some ==> self.finalizers->0.finite()
+        // these fields are finite maps
+        &&& self.labels is Some ==> self.labels->0.dom().finite()
+        &&& self.annotations is Some ==> self.annotations->0.dom().finite()
     }
 }
 

--- a/src/kubernetes_api_objects/spec/object_meta.rs
+++ b/src/kubernetes_api_objects/spec/object_meta.rs
@@ -170,9 +170,6 @@ impl ObjectMetaView {
         &&& self.namespace is Some
         &&& self.resource_version is Some
         &&& self.uid is Some
-        // these fields are finite maps
-        &&& self.labels is Some ==> self.labels->0.dom().finite()
-        &&& self.annotations is Some ==> self.annotations->0.dom().finite()
     }
 }
 


### PR DESCRIPTION
Add finite requirement `.metadata.labels` and `.spec.selector.match_labels` for VDeployment and VReplicaSet CRs