### PR TITLE
Add timestamp check on VRS back to valid_owned_object

### DIFF
--- a/src/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/controllers/vdeployment_controller/exec/reconciler.rs
@@ -401,6 +401,7 @@ ensures
     res == model_util::valid_owned_object(vrs@, vd@),
 {
     vrs.metadata().name().is_some()
+    && !vrs.metadata().has_deletion_timestamp()
     && vrs.metadata().owner_references_contains(&vd.controller_owner_ref())
     && vrs.state_validation()
 }

--- a/src/controllers/vdeployment_controller/trusted/util.rs
+++ b/src/controllers/vdeployment_controller/trusted/util.rs
@@ -29,6 +29,7 @@ pub open spec fn valid_owned_object(vrs: VReplicaSetView, vd: VDeploymentView) -
     //     |
     // 419 |         && vrs.metadata().namespace().unwrap() == vd.metadata().namespace().unwrap() 
     // It's ok to go ahead without that because the namespace is ensured on API server side
+    &&& vrs.metadata.deletion_timestamp is None
     &&& vrs.metadata.owner_references_contains(vd.controller_owner_ref())
     &&& vrs.state_validation()
 }


### PR DESCRIPTION
The check on VRS's deletion timestamp is added back to `valid_owned_object`