### PR TITLE
Use old_vrs_index to record current progress, keep all old vrs in cache

### DIFF
--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -665,7 +665,7 @@ ensures
                         assert(new_vrs_or_none is None);
                         // try comment out the next line
                         assert(vrls_prime.new_vrs == Some(make_replica_set(vd)));
-                        assert(vrls_prime == create_new_vrs(old_vrs_list, vd).0);
+                        assert(vrls_prime == create_new_vrs(vrls, vd).0);
                     }
                 }
             },

--- a/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/terminate.rs
@@ -75,7 +75,7 @@ ensures
     temp_pred_equality(lift_state(lift_local(controller_id, vd, at_step_or![Done])), lift_state(reconcile_done));
     entails_implies_leads_to(spec, lift_state(reconcile_idle), lift_state(reconcile_idle));
     // 2, AfterScaleDownOldVRS ~> reconcile_idle.
-    // 2.1, AfterScaleDownOldVRS && state.old_vrs_list.len() == 0 ~> reconcile_idle.
+    // 2.1, AfterScaleDownOldVRS && state.old_vrs_index == 0 ~> reconcile_idle.
     // Done ~> idle && Error ~> idle => Done \/ Error ~> idle
     or_leads_to_combine_and_equality!(spec,
         lift_state(lift_local(controller_id, vd, at_step_or![Error, Done])),
@@ -84,7 +84,7 @@ ensures
         lift_state(reconcile_idle)
     );
     let zero = 0 as nat;
-    // AfterScaleDownOldVRS && state.old_vrs_list.len() == 0 ~> Done \/ Error ~> idle
+    // AfterScaleDownOldVRS && state.old_vrs_index == 0 ~> Done \/ Error ~> idle
     lemma_from_pending_req_in_flight_or_resp_in_flight_at_step_to_at_step_and_pred(
         spec, vd, controller_id, AfterScaleDownOldVRS, old_vrs_list_len(zero)
     );
@@ -167,7 +167,7 @@ ensures
             implies tla_exists(|n| lift_state(lift_local(controller_id, vd, scale_down_old_vrs_rank_n(n))))
                     .satisfied_by(ex) by {
                 let s_marshalled = ex.head().ongoing_reconciles(controller_id)[vd.object_ref()].local_state;
-                let witness_n = VDeploymentReconcileState::unmarshal(s_marshalled).unwrap().old_vrs_list.len();
+                let witness_n = VDeploymentReconcileState::unmarshal(s_marshalled).unwrap().old_vrs_index;
                 assert((|n| lift_state(lift_local(controller_id, vd, scale_down_old_vrs_rank_n(n))))(witness_n).satisfied_by(ex));
             }
         assert(spec.entails(p.leads_to(lift_state(reconcile_idle)))) by {

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -271,7 +271,7 @@ pub open spec fn pending_get_then_update_req_in_flight_with_replicas(
 pub open spec fn local_state_is_consistent_with_etcd(vd: VDeploymentView, controller_id: int) -> StatePred<ClusterState> {
     |s: ClusterState| {
         let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
-        &&& forall |i| 0 <= i < vds.old_vrs_list.len() ==> {
+        &&& forall |i| 0 <= i < vds.old_vrs_index ==> {
             // the get-then-update request can succeed
             &&& #[trigger] valid_owned_object(vds.old_vrs_list[i], vd)
             // obj in etcd exists and is owned by vd
@@ -337,15 +337,12 @@ pub open spec fn local_state_is(new_vrs_replicas: Option<int>, old_vrs_list_len:
             }
             None => vds.new_vrs is None
         }
-        &&& vds.old_vrs_list.len() == old_vrs_list_len
+        &&& vds.old_vrs_index == old_vrs_list_len
     }
 }
 
 pub open spec fn old_vrs_list_len(n: nat) -> spec_fn(VDeploymentReconcileState) -> bool {
-    |vds: VDeploymentReconcileState| {
-        let old_vrs_list = vds.old_vrs_list;
-        &&& old_vrs_list.len() == n
-    }
+    |vds: VDeploymentReconcileState| vds.old_vrs_index == n
 }
 
 pub open spec fn vd_rely_condition(vd: VDeploymentView, cluster: Cluster, controller_id: int) -> StatePred<ClusterState> {


### PR DESCRIPTION
This PR updates VDeployment controller reconciler to use old_vrs_index to record current progress just as VRS controller does