### PR TITLE
Update the reconciler to update new vrs upon response

### DIFF
--- a/src/controllers/vdeployment_controller/model/reconciler.rs
+++ b/src/controllers/vdeployment_controller/model/reconciler.rs
@@ -114,14 +114,29 @@ pub open spec fn reconcile_core(vd: VDeploymentView, resp_o: Option<ResponseView
             if !(is_some_k_create_resp_view!(resp_o) && extract_some_k_create_resp_view!(resp_o) is Ok) {
                 (error_state(state), None)
             } else {
-                (new_vrs_ensured_state(state), None)
+                let obj = extract_some_k_create_resp_view!(resp_o).unwrap();
+                if VReplicaSetView::unmarshal(obj) is Err{
+                    (error_state(state), None)
+                } else {
+                    let new_vrs = VReplicaSetView::unmarshal(obj).unwrap();
+                    let state_prime = VDeploymentReconcileState {
+                        reconcile_step: VDeploymentReconcileStepView::AfterEnsureNewVRS,
+                        new_vrs: Some(new_vrs),
+                        ..state
+                    };
+                    (state_prime, None)
+                }
             }
         },
         VDeploymentReconcileStepView::AfterScaleNewVRS => {
             if !(is_some_k_get_then_update_resp_view!(resp_o) && extract_some_k_get_then_update_resp_view!(resp_o) is Ok) {
                 (error_state(state), None)
             } else {
-                (new_vrs_ensured_state(state), None)
+                let state_prime = VDeploymentReconcileState {
+                    reconcile_step: VDeploymentReconcileStepView::AfterEnsureNewVRS,
+                    ..state
+                };
+                (state_prime, None)
             }
         },
         // a response-free barrier step
@@ -157,13 +172,6 @@ pub open spec fn reconcile_core(vd: VDeploymentView, resp_o: Option<ResponseView
         _ => {
             (state, None)
         }
-    }
-}
-
-pub open spec fn new_vrs_ensured_state(state: VDeploymentReconcileState) -> (state_prime: VDeploymentReconcileState) {
-    VDeploymentReconcileState {
-        reconcile_step: VDeploymentReconcileStepView::AfterEnsureNewVRS,
-        ..state
     }
 }
 
@@ -237,7 +245,6 @@ pub open spec fn create_new_vrs(state: VDeploymentReconcileState, vd: VDeploymen
     });
     let state_prime = VDeploymentReconcileState {
         reconcile_step: VDeploymentReconcileStepView::AfterCreateNewVRS,
-        new_vrs: Some(new_vrs),
         ..state
     };
     (state_prime, Some(RequestView::KRequest(req)))


### PR DESCRIPTION
This is required by coherence predicate:
```rust
VReplicaSetView::unmarshal(s.resources()[new_vrs.object_ref()])->Ok_0 == new_vrs
```
We can have a workaround to exclude `resource_version` and `uid`, but that requires more time to fix than this update on reconciler