### PR TITLE
Insert invariants into top-level proof

### DIFF
--- a/src/controllers/vdeployment_controller/proof/helper_invariants/proof.rs
+++ b/src/controllers/vdeployment_controller/proof/helper_invariants/proof.rs
@@ -384,10 +384,10 @@ pub proof fn lemma_always_vd_reconcile_request_only_interferes_with_itself(
 
 #[verifier(spinoff_prover)]
 pub proof fn lemma_eventually_always_no_pending_interfering_update_request(
-    spec: TempPred<ClusterState>, 
+    spec: TempPred<ClusterState>,
+    vd: VDeploymentView,
     cluster: Cluster, 
-    controller_id: int,
-    vd: VDeploymentView
+    controller_id: int
 )
     requires
         spec.entails(always(lift_action(cluster.next()))),

--- a/src/controllers/vdeployment_controller/proof/liveness/proof.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/proof.rs
@@ -12,6 +12,7 @@ use crate::vdeployment_controller::{
         step::*
     },
 };
+use crate::vreplicaset_controller::trusted::spec_types::*;
 use vstd::prelude::*;
 
 verus! {
@@ -23,6 +24,8 @@ proof fn eventually_stable_reconciliation_holds(spec: TempPred<ClusterState>, cl
         spec.entails(next_with_wf(cluster, controller_id)),
         // The vd type is installed in the cluster.
         cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+        // The vrs type is installed in the cluster.
+        cluster.type_is_installed_in_cluster::<VReplicaSetView>(),
         // The vd controller runs in the cluster.
         cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
         // No other controllers interfere with the vd controller.
@@ -74,6 +77,8 @@ proof fn eventually_stable_reconciliation_holds_per_cr(spec: TempPred<ClusterSta
         spec.entails(next_with_wf(cluster, controller_id)),
         // The vd type is installed in the cluster.
         cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+        // The vrs type is installed in the cluster.
+        cluster.type_is_installed_in_cluster::<VReplicaSetView>(),
         // The vd controller runs in the cluster.
         cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
         // No other controllers interfere with the vd controller.
@@ -92,8 +97,9 @@ proof fn eventually_stable_reconciliation_holds_per_cr(spec: TempPred<ClusterSta
         stable_spec, cluster, controller_id
     );
     lemma_true_leads_to_always_current_state_matches(stable_spec, vd, cluster, controller_id);
-    reveal_with_fuel(spec_before_phase_n, 6);
+    reveal_with_fuel(spec_before_phase_n, 7);
 
+    spec_before_phase_n_entails_true_leads_to_current_state_matches(6, stable_spec, vd, cluster, controller_id);
     spec_before_phase_n_entails_true_leads_to_current_state_matches(5, stable_spec, vd, cluster, controller_id);
     spec_before_phase_n_entails_true_leads_to_current_state_matches(4, stable_spec, vd, cluster, controller_id);
     spec_before_phase_n_entails_true_leads_to_current_state_matches(3, stable_spec, vd, cluster, controller_id);
@@ -128,7 +134,7 @@ proof fn eventually_stable_reconciliation_holds_per_cr(spec: TempPred<ClusterSta
 
 proof fn spec_before_phase_n_entails_true_leads_to_current_state_matches(i: nat, spec: TempPred<ClusterState>, vd: VDeploymentView, cluster: Cluster, controller_id: int)
     requires
-        1 <= i <= 5,
+        1 <= i <= 6,
         valid(stable(spec.and(spec_before_phase_n(i, vd, cluster, controller_id)))),
         spec.and(spec_before_phase_n(i + 1, vd, cluster, controller_id)).entails(true_pred().leads_to(always(lift_state(current_state_matches(vd))))),
         cluster.type_is_installed_in_cluster::<VDeploymentView>(),
@@ -137,7 +143,7 @@ proof fn spec_before_phase_n_entails_true_leads_to_current_state_matches(i: nat,
             ==> spec.entails(always(lift_state(#[trigger] vd_rely(other_id)))),
     ensures spec.and(spec_before_phase_n(i, vd, cluster, controller_id)).entails(true_pred().leads_to(always(lift_state(current_state_matches(vd))))),
 {
-    reveal_with_fuel(spec_before_phase_n, 6);
+    reveal_with_fuel(spec_before_phase_n, 7);
     temp_pred_equality(
         spec.and(spec_before_phase_n(i + 1, vd, cluster, controller_id)),
         spec.and(spec_before_phase_n(i, vd, cluster, controller_id))


### PR DESCRIPTION
This pull request weaves the invariants written and proved in earlier PRs into the top-level proof structure.

It also generalizes Cathy's termination argument to apply to an arbitrary `VDeployment` controller.