### PR TITLE
Cosmetic changes with `deep_view`

### DIFF
--- a/src/controllers/vdeployment_controller/exec/reconciler.rs
+++ b/src/controllers/vdeployment_controller/exec/reconciler.rs
@@ -11,7 +11,7 @@ use crate::vdeployment_controller::trusted::{exec_types::*, step::*};
 use crate::vreplicaset_controller::trusted::{exec_types::*, spec_types::*};
 use crate::vstd_ext::{seq_lib::*, string_map::*, string_view::*};
 use deps_hack::tracing::{error, info};
-use vstd::{prelude::*, seq_lib::*, set::*, map::*};
+use vstd::{map::*, prelude::*, seq_lib::*, set::*};
 // for assert(objs.deep_view() == extract_some_k_list_resp_view!(resp_o.deep_view()).unwrap());
 use crate::reconciler::spec::io::*;
 
@@ -652,12 +652,12 @@ pub fn make_owner_references(vd: &VDeployment) -> (owner_references: Vec<OwnerRe
 requires
     vd@.well_formed(),
 ensures
-    owner_references@.map_values(|or: OwnerReference| or@) == model_reconciler::make_owner_references(vd@),
+    owner_references.deep_view() == model_reconciler::make_owner_references(vd@),
 {
     let mut owner_references = Vec::new();
     owner_references.push(vd.controller_owner_ref());
     proof {
-        assert(owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@) =~= model_reconciler::make_owner_references(vd@));
+        assert(owner_references.deep_view() =~= model_reconciler::make_owner_references(vd@));
     }
     owner_references
 }

--- a/src/controllers/vreplicaset_controller/exec/reconciler.rs
+++ b/src/controllers/vreplicaset_controller/exec/reconciler.rs
@@ -3,10 +3,10 @@
 use crate::kubernetes_api_objects::exec::prelude::*;
 use crate::kubernetes_api_objects::spec::prelude::*;
 use crate::reconciler::exec::{io::*, reconciler::*};
+use crate::reconciler::spec::io::*;
 use crate::vreplicaset_controller::model::reconciler as model_reconciler;
 use crate::vreplicaset_controller::trusted::{exec_types::*, step::*};
-use crate::vstd_ext::{string_map::StringMap, seq_lib::*};
-use crate::reconciler::spec::io::*;
+use crate::vstd_ext::{seq_lib::*, string_map::StringMap};
 use vstd::prelude::*;
 use vstd::seq_lib::*;
 
@@ -247,13 +247,13 @@ pub fn error_state(state: VReplicaSetReconcileState) -> (state_prime: VReplicaSe
 
 pub fn make_owner_references(v_replica_set: &VReplicaSet) -> (owner_references: Vec<OwnerReference>)
     requires v_replica_set@.well_formed(),
-    ensures owner_references@.map_values(|or: OwnerReference| or@) ==  model_reconciler::make_owner_references(v_replica_set@),
+    ensures owner_references.deep_view() ==  model_reconciler::make_owner_references(v_replica_set@),
 {
     let mut owner_references = Vec::new();
     owner_references.push(v_replica_set.controller_owner_ref());
     proof {
         assert_seqs_equal!(
-            owner_references@.map_values(|owner_ref: OwnerReference| owner_ref@),
+            owner_references.deep_view(),
             model_reconciler::make_owner_references(v_replica_set@)
         );
     }
@@ -277,7 +277,7 @@ fn objects_to_pods(objs: Vec<DynamicObject>) -> (pods_or_none: Option<Vec<Pod>>)
             );
         }
     }
-    
+
     for idx in 0..objs.len()
         invariant
             idx <= objs.len(),

--- a/src/kubernetes_api_objects/exec/affinity.rs
+++ b/src/kubernetes_api_objects/exec/affinity.rs
@@ -14,14 +14,11 @@ verus! {
 //
 // More detailed information: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.
 
-#[verifier(external_body)]
-pub struct Affinity {
-    inner: deps_hack::k8s_openapi::api::core::v1::Affinity,
-}
-
-impl Affinity {
-    pub uninterp spec fn view(&self) -> AffinityView;
-}
+implement_field_wrapper_type!(
+    Affinity,
+    deps_hack::k8s_openapi::api::core::v1::Affinity,
+    AffinityView
+);
 
 }
 

--- a/src/kubernetes_api_objects/exec/api_method.rs
+++ b/src/kubernetes_api_objects/exec/api_method.rs
@@ -96,7 +96,7 @@ pub struct KubeCreateRequest {
 impl KubeCreateRequest {
     #[verifier(external)]
     pub fn key(&self) -> std::string::String {
-        format!("{}/{}/{}", self.api_resource.as_kube_ref().kind, self.namespace, self.obj.kube_metadata_ref().name.as_ref().unwrap_or(&"".to_string()))
+        format!("{}/{}/{}", self.api_resource.as_kube_ref().kind, self.namespace, self.obj.as_kube_ref().metadata.name.as_ref().unwrap_or(&"".to_string()))
     }
 }
 

--- a/src/kubernetes_api_objects/exec/api_method.rs
+++ b/src/kubernetes_api_objects/exec/api_method.rs
@@ -338,7 +338,7 @@ impl View for KubeListResponse {
     type V = ListResponse;
     open spec fn view(&self) -> ListResponse {
         match self.res {
-            Ok(l) => ListResponse { res: Ok(l@.map_values(|o: DynamicObject| o@)) },
+            Ok(l) => ListResponse { res: Ok(l.deep_view()) },
             Err(e) => ListResponse { res: Err(e) },
         }
     }

--- a/src/kubernetes_api_objects/exec/api_resource.rs
+++ b/src/kubernetes_api_objects/exec/api_resource.rs
@@ -4,23 +4,21 @@ use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::api_resource::*;
 use vstd::prelude::*;
 
-verus! {
-
 // ApiResource is used for creating API handles for DynamicObject.
 //
 // This definition is a wrapper of ApiResource defined at
 // https://github.com/kube-rs/kube/blob/main/kube-core/src/discovery.rs.
 // It is supposed to be used in exec controller code.
 
+verus! {
+
 #[verifier(external_body)]
 pub struct ApiResource {
     inner: deps_hack::kube::api::ApiResource,
 }
 
-impl ApiResource {
-    pub uninterp spec fn view(&self) -> ApiResourceView;
 }
 
-}
-
+implement_view_trait!(ApiResource, ApiResourceView);
+implement_deep_view_trait!(ApiResource, ApiResourceView);
 implement_resource_wrapper_trait!(ApiResource, deps_hack::kube::api::ApiResource);

--- a/src/kubernetes_api_objects/exec/api_resource.rs
+++ b/src/kubernetes_api_objects/exec/api_resource.rs
@@ -4,21 +4,21 @@ use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::api_resource::*;
 use vstd::prelude::*;
 
+verus! {
+
 // ApiResource is used for creating API handles for DynamicObject.
 //
 // This definition is a wrapper of ApiResource defined at
 // https://github.com/kube-rs/kube/blob/main/kube-core/src/discovery.rs.
 // It is supposed to be used in exec controller code.
 
-verus! {
-
 #[verifier(external_body)]
 pub struct ApiResource {
     inner: deps_hack::kube::api::ApiResource,
 }
 
-}
-
 implement_view_trait!(ApiResource, ApiResourceView);
 implement_deep_view_trait!(ApiResource, ApiResourceView);
 implement_resource_wrapper_trait!(ApiResource, deps_hack::kube::api::ApiResource);
+
+}

--- a/src/kubernetes_api_objects/exec/config_map.rs
+++ b/src/kubernetes_api_objects/exec/config_map.rs
@@ -8,6 +8,8 @@ use crate::kubernetes_api_objects::spec::{config_map::*, resource::*};
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
+verus! {
+
 // ConfigMap is a type of API object used to store non-confidential data in key-value pairs.
 // A ConfigMap object can be used to set environment variables or configuration files
 // in a Volume mounted to a Pod.
@@ -24,14 +26,10 @@ implement_object_wrapper_type!(
     ConfigMapView
 );
 
-verus! {
-
 impl ConfigMap {
     #[verifier(external_body)]
     pub fn data(&self) -> (data: Option<StringMap>)
-        ensures
-            self@.data is Some == data is Some,
-            data is Some ==> data->0@ == self@.data->0,
+        ensures self@.data == data.deep_view()
     {
         match &self.inner.data {
             Some(d) => Some(StringMap::from_rust_map(d.clone())),

--- a/src/kubernetes_api_objects/exec/container.rs
+++ b/src/kubernetes_api_objects/exec/container.rs
@@ -5,32 +5,75 @@ use crate::kubernetes_api_objects::spec::container::*;
 use crate::vstd_ext::string_view::*;
 use vstd::prelude::*;
 
+implement_field_wrapper_type!(
+    Container,
+    deps_hack::k8s_openapi::api::core::v1::Container,
+    ContainerView
+);
+
+implement_field_wrapper_type!(
+    ContainerPort,
+    deps_hack::k8s_openapi::api::core::v1::ContainerPort,
+    ContainerPortView
+);
+
+implement_field_wrapper_type!(
+    VolumeMount,
+    deps_hack::k8s_openapi::api::core::v1::VolumeMount,
+    VolumeMountView
+);
+
+implement_field_wrapper_type!(
+    Probe,
+    deps_hack::k8s_openapi::api::core::v1::Probe,
+    ProbeView
+);
+
+implement_field_wrapper_type!(
+    ExecAction,
+    deps_hack::k8s_openapi::api::core::v1::ExecAction,
+    ExecActionView
+);
+
+implement_field_wrapper_type!(
+    TCPSocketAction,
+    deps_hack::k8s_openapi::api::core::v1::TCPSocketAction,
+    TCPSocketActionView
+);
+
+implement_field_wrapper_type!(
+    Lifecycle,
+    deps_hack::k8s_openapi::api::core::v1::Lifecycle,
+    LifecycleView
+);
+
+implement_field_wrapper_type!(
+    LifecycleHandler,
+    deps_hack::k8s_openapi::api::core::v1::LifecycleHandler,
+    LifecycleHandlerView
+);
+
+implement_field_wrapper_type!(
+    EnvVar,
+    deps_hack::k8s_openapi::api::core::v1::EnvVar,
+    EnvVarView
+);
+
+implement_field_wrapper_type!(
+    EnvVarSource,
+    deps_hack::k8s_openapi::api::core::v1::EnvVarSource,
+    EnvVarSourceView
+);
+
+implement_field_wrapper_type!(
+    SecurityContext,
+    deps_hack::k8s_openapi::api::core::v1::SecurityContext,
+    SecurityContextView
+);
+
 verus! {
 
-#[verifier(external_body)]
-pub struct Container {
-    inner: deps_hack::k8s_openapi::api::core::v1::Container,
-}
-
 impl Container {
-    pub uninterp spec fn view(&self) -> ContainerView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (container: Container)
-        ensures container@ == ContainerView::default(),
-    {
-        Container {
-            inner: deps_hack::k8s_openapi::api::core::v1::Container::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        Container { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_image(&mut self, image: String)
         ensures self@ == old(self)@.with_image(image@),
@@ -47,7 +90,7 @@ impl Container {
 
     #[verifier(external_body)]
     pub fn set_volume_mounts(&mut self, volume_mounts: Vec<VolumeMount>)
-        ensures self@ == old(self)@.with_volume_mounts(volume_mounts@.map_values(|mount: VolumeMount| mount@)),
+        ensures self@ == old(self)@.with_volume_mounts(volume_mounts.deep_view()),
     {
         self.inner.volume_mounts = Some(
             volume_mounts.into_iter().map(|mount: VolumeMount| mount.into_kube()).collect()
@@ -56,7 +99,7 @@ impl Container {
 
     #[verifier(external_body)]
     pub fn set_ports(&mut self, ports: Vec<ContainerPort>)
-        ensures self@ == old(self)@.with_ports(ports@.map_values(|port: ContainerPort| port@)),
+        ensures self@ == old(self)@.with_ports(ports.deep_view()),
     {
         self.inner.ports = Some(ports.into_iter().map(|port: ContainerPort| port.into_kube()).collect())
     }
@@ -91,7 +134,7 @@ impl Container {
 
     #[verifier(external_body)]
     pub fn set_command(&mut self, command: Vec<String>)
-        ensures self@ == old(self)@.with_command(command@.map_values(|c: String| c@)),
+        ensures self@ == old(self)@.with_command(command.deep_view()),
     {
         self.inner.command = Some(command)
     }
@@ -105,14 +148,14 @@ impl Container {
 
     #[verifier(external_body)]
     pub fn set_env(&mut self, env: Vec<EnvVar>)
-        ensures self@ == old(self)@.with_env(env@.map_values(|v: EnvVar| v@)),
+        ensures self@ == old(self)@.with_env(env.deep_view()),
     {
         self.inner.env = Some(env.into_iter().map(|e: EnvVar| e.into_kube()).collect())
     }
 
     #[verifier(external_body)]
     pub fn set_args(&mut self, args: Vec<String>)
-        ensures self@ == old(self)@.with_args(args@.map_values(|s: String| s@)),
+        ensures self@ == old(self)@.with_args(args.deep_view()),
     {
         self.inner.args = Some(args)
     }
@@ -125,21 +168,7 @@ impl Container {
     }
 }
 
-#[verifier(external_body)]
-pub struct ContainerPort {
-    inner: deps_hack::k8s_openapi::api::core::v1::ContainerPort,
-}
-
 impl ContainerPort {
-    pub uninterp spec fn view(&self) -> ContainerPortView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (container_port: ContainerPort)
-        ensures container_port@ == ContainerPortView::default(),
-    {
-        ContainerPort { inner: deps_hack::k8s_openapi::api::core::v1::ContainerPort::default() }
-    }
-
     pub fn new_with(name: String, port: i32) -> (container_port: ContainerPort)
         ensures container_port@ == ContainerPortView::default().with_name(name@).with_container_port(port as int),
     {
@@ -186,21 +215,7 @@ impl ContainerPort {
     }
 }
 
-#[verifier(external_body)]
-pub struct VolumeMount {
-    inner: deps_hack::k8s_openapi::api::core::v1::VolumeMount,
-}
-
 impl VolumeMount {
-    pub uninterp spec fn view(&self) -> VolumeMountView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (volume_mount: VolumeMount)
-        ensures volume_mount@ == VolumeMountView::default(),
-    {
-        VolumeMount { inner: deps_hack::k8s_openapi::api::core::v1::VolumeMount::default() }
-    }
-
     pub fn new_with(mount_path: String, name: String) -> (volume_mount: VolumeMount)
         ensures volume_mount@ == VolumeMountView::default().with_mount_path(mount_path@).with_name(name@),
     {
@@ -247,28 +262,7 @@ impl VolumeMount {
     }
 }
 
-#[verifier(external_body)]
-pub struct Probe {
-    inner: deps_hack::k8s_openapi::api::core::v1::Probe,
-}
-
 impl Probe {
-    pub uninterp spec fn view(&self) -> ProbeView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (probe: Probe)
-        ensures probe@ == ProbeView::default(),
-    {
-        Probe { inner: deps_hack::k8s_openapi::api::core::v1::Probe::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        Probe { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_exec(&mut self, exec: ExecAction)
         ensures self@ == old(self)@.with_exec(exec@),
@@ -319,58 +313,16 @@ impl Probe {
     }
 }
 
-#[verifier(external_body)]
-pub struct ExecAction {
-    inner: deps_hack::k8s_openapi::api::core::v1::ExecAction,
-}
-
 impl ExecAction {
-    pub uninterp spec fn view(&self) -> ExecActionView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (exec_action: ExecAction)
-        ensures exec_action@ == ExecActionView::default(),
-    {
-        ExecAction { inner: deps_hack::k8s_openapi::api::core::v1::ExecAction::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        ExecAction { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_command(&mut self, command: Vec<String>)
-        ensures self@ == old(self)@.with_command(command@.map_values(|s: String| s@)),
+        ensures self@ == old(self)@.with_command(command.deep_view()),
     {
         self.inner.command = Some(command);
     }
 }
 
-#[verifier(external_body)]
-pub struct TCPSocketAction {
-    inner: deps_hack::k8s_openapi::api::core::v1::TCPSocketAction,
-}
-
 impl TCPSocketAction {
-    pub uninterp spec fn view(&self) -> TCPSocketActionView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (tcp_socket_action: TCPSocketAction)
-        ensures tcp_socket_action@ == TCPSocketActionView::default(),
-    {
-        TCPSocketAction { inner: deps_hack::k8s_openapi::api::core::v1::TCPSocketAction::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        TCPSocketAction { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_host(&mut self, host: String)
         ensures self@ == old(self)@.with_host(host@),
@@ -386,28 +338,7 @@ impl TCPSocketAction {
     }
 }
 
-#[verifier(external_body)]
-pub struct Lifecycle {
-    inner: deps_hack::k8s_openapi::api::core::v1::Lifecycle,
-}
-
 impl Lifecycle {
-    pub uninterp spec fn view(&self) -> LifecycleView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (lifecycle: Lifecycle)
-        ensures lifecycle@ == LifecycleView::default(),
-    {
-        Lifecycle { inner: deps_hack::k8s_openapi::api::core::v1::Lifecycle::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        Lifecycle { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_pre_stop(&mut self, handler: LifecycleHandler)
         ensures self@ == old(self)@.with_pre_stop(handler@),
@@ -416,28 +347,7 @@ impl Lifecycle {
     }
 }
 
-#[verifier(external_body)]
-pub struct LifecycleHandler {
-    inner: deps_hack::k8s_openapi::api::core::v1::LifecycleHandler,
-}
-
 impl LifecycleHandler {
-    pub uninterp spec fn view(&self) -> LifecycleHandlerView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (lifecycle_handler: LifecycleHandler)
-        ensures lifecycle_handler@ == LifecycleHandlerView::default(),
-    {
-        LifecycleHandler { inner: deps_hack::k8s_openapi::api::core::v1::LifecycleHandler::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        LifecycleHandler { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_exec(&mut self, exec: ExecAction)
         ensures self@ == old(self)@.with_exec(exec@),
@@ -446,26 +356,7 @@ impl LifecycleHandler {
     }
 }
 
-#[verifier(external_body)]
-pub struct EnvVar {
-    inner: deps_hack::k8s_openapi::api::core::v1::EnvVar,
-}
-
 impl EnvVar {
-    pub uninterp spec fn view(&self) -> EnvVarView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (env_var: EnvVar)
-        ensures env_var@ == EnvVarView::default(),
-    {
-        EnvVar { inner: deps_hack::k8s_openapi::api::core::v1::EnvVar::default() }
-    }
-
-    #[verifier(external)]
-    pub fn clone(&self) -> (s: Self) {
-        EnvVar { inner: self.inner.clone() }
-    }
-
     pub fn new_with(name: String, value: Option<String>, value_from: Option<EnvVarSource>) -> (env_var: EnvVar)
         ensures
             env_var@ == (EnvVarView {
@@ -513,24 +404,7 @@ impl EnvVar {
     }
 }
 
-#[verifier(external_body)]
-pub struct EnvVarSource {
-    inner: deps_hack::k8s_openapi::api::core::v1::EnvVarSource,
-}
-
 impl EnvVarSource {
-    pub uninterp spec fn view(&self) -> EnvVarSourceView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (env_var_source: EnvVarSource)
-        ensures env_var_source@ == EnvVarSourceView::default(),
-    {
-        EnvVarSource { inner: deps_hack::k8s_openapi::api::core::v1::EnvVarSource::default() }
-    }
-
-    #[verifier(external)]
-    pub fn clone(&self) -> (s: Self) { EnvVarSource { inner: self.inner.clone() } }
-
     pub fn new_with_field_ref(field_ref: ObjectFieldSelector) -> (env_var_source: EnvVarSource)
         ensures env_var_source@ == EnvVarSourceView::default().with_field_ref(field_ref@)
     {
@@ -545,15 +419,6 @@ impl EnvVarSource {
     {
         self.inner.field_ref = Some(field_ref.into_kube());
     }
-}
-
-#[verifier(external_body)]
-pub struct SecurityContext {
-    inner: deps_hack::k8s_openapi::api::core::v1::SecurityContext,
-}
-
-impl SecurityContext {
-    pub uninterp spec fn view(&self) -> SecurityContextView;
 }
 
 }

--- a/src/kubernetes_api_objects/exec/container.rs
+++ b/src/kubernetes_api_objects/exec/container.rs
@@ -5,6 +5,8 @@ use crate::kubernetes_api_objects::spec::container::*;
 use crate::vstd_ext::string_view::*;
 use vstd::prelude::*;
 
+verus! {
+
 implement_field_wrapper_type!(
     Container,
     deps_hack::k8s_openapi::api::core::v1::Container,
@@ -70,8 +72,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::core::v1::SecurityContext,
     SecurityContextView
 );
-
-verus! {
 
 impl Container {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/daemon_set.rs
+++ b/src/kubernetes_api_objects/exec/daemon_set.rs
@@ -26,6 +26,18 @@ implement_object_wrapper_type!(
     DaemonSetView
 );
 
+implement_field_wrapper_type!(
+    DaemonSetSpec,
+    deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec,
+    DaemonSetSpecView
+);
+
+implement_field_wrapper_type!(
+    DaemonSetStatus,
+    deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus,
+    DaemonSetStatusView
+);
+
 verus! {
 
 impl DaemonSet {
@@ -46,28 +58,7 @@ impl DaemonSet {
     }
 }
 
-#[verifier(external_body)]
-pub struct DaemonSetSpec {
-    inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec,
-}
-
 impl DaemonSetSpec {
-    pub uninterp spec fn view(&self) -> DaemonSetSpecView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (daemon_set_spec: DaemonSetSpec)
-        ensures daemon_set_spec@ == DaemonSetSpecView::default(),
-    {
-        DaemonSetSpec { inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSetSpec::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        DaemonSetSpec { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_selector(&mut self, selector: LabelSelector)
         ensures self@ == old(self)@.with_selector(selector@),
@@ -97,14 +88,7 @@ impl DaemonSetSpec {
     }
 }
 
-#[verifier(external_body)]
-pub struct DaemonSetStatus {
-    inner: deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus,
-}
-
 impl DaemonSetStatus {
-    pub uninterp spec fn view(&self) -> DaemonSetStatusView;
-
     #[verifier(external_body)]
     pub fn number_ready(&self) -> (number_ready: i32)
         ensures self@.number_ready == number_ready as int,

--- a/src/kubernetes_api_objects/exec/daemon_set.rs
+++ b/src/kubernetes_api_objects/exec/daemon_set.rs
@@ -8,6 +8,8 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{daemon_set::*, resource::*};
 use vstd::prelude::*;
 
+verus! {
+
 // DaemonSet is a type of API object used for managing daemon applications,
 // mainly a group of Pods and PersistentVolumeClaims attached to the Pods.
 // A DaemonSet object allows different types of Volumes attached to the pods,
@@ -37,8 +39,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::apps::v1::DaemonSetStatus,
     DaemonSetStatusView
 );
-
-verus! {
 
 impl DaemonSet {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/dynamic.rs
+++ b/src/kubernetes_api_objects/exec/dynamic.rs
@@ -4,24 +4,20 @@ use crate::kubernetes_api_objects::exec::{object_meta::*, resource::*};
 use crate::kubernetes_api_objects::spec::dynamic::*;
 use vstd::prelude::*;
 
-verus! {
-
 // DynamicObject is mainly used to pass requests/response between reconcile_core and the shim layer.
 // We use DynamicObject in KubeAPIRequest and KubeAPIResponse so that they can carry the requests and responses
 // for all kinds of Kubernetes resource objects without exhaustive pattern matching.
+
+verus! {
 
 #[verifier(external_body)]
 pub struct DynamicObject {
     inner: deps_hack::kube::api::DynamicObject,
 }
 
+implement_view_trait!(DynamicObject, DynamicObjectView);
 implement_deep_view_trait!(DynamicObject, DynamicObjectView);
-
-impl View for DynamicObject {
-    type V = DynamicObjectView;
-
-    uninterp spec fn view(&self) -> DynamicObjectView;
-}
+implement_clone_trait!(DynamicObject);
 
 impl DynamicObject {
     #[verifier(external)]
@@ -35,13 +31,6 @@ impl DynamicObject {
     {
         ObjectMeta::from_kube(self.inner.metadata.clone())
     }
-}
-
-impl std::clone::Clone for DynamicObject {
-    #[verifier(external_body)]
-    fn clone(&self) -> (result: Self)
-        ensures result == self
-    { DynamicObject { inner: self.inner.clone() } }
 }
 
 #[verifier(external)]

--- a/src/kubernetes_api_objects/exec/dynamic.rs
+++ b/src/kubernetes_api_objects/exec/dynamic.rs
@@ -4,11 +4,11 @@ use crate::kubernetes_api_objects::exec::{object_meta::*, resource::*};
 use crate::kubernetes_api_objects::spec::dynamic::*;
 use vstd::prelude::*;
 
+verus! {
+
 // DynamicObject is mainly used to pass requests/response between reconcile_core and the shim layer.
 // We use DynamicObject in KubeAPIRequest and KubeAPIResponse so that they can carry the requests and responses
 // for all kinds of Kubernetes resource objects without exhaustive pattern matching.
-
-verus! {
 
 #[verifier(external_body)]
 pub struct DynamicObject {

--- a/src/kubernetes_api_objects/exec/dynamic.rs
+++ b/src/kubernetes_api_objects/exec/dynamic.rs
@@ -20,11 +20,6 @@ implement_deep_view_trait!(DynamicObject, DynamicObjectView);
 implement_clone_trait!(DynamicObject);
 
 impl DynamicObject {
-    #[verifier(external)]
-    pub fn kube_metadata_ref(&self) -> &deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
-        &self.inner.metadata
-    }
-
     #[verifier(external_body)]
     pub fn metadata(&self) -> (metadata: ObjectMeta)
         ensures metadata@ == self@.metadata,

--- a/src/kubernetes_api_objects/exec/object_meta.rs
+++ b/src/kubernetes_api_objects/exec/object_meta.rs
@@ -102,7 +102,7 @@ impl ObjectMeta {
     pub fn finalizers(&self) -> (finalizers: Option<Vec<String>>)
         ensures
             self@.finalizers is Some == finalizers is Some,
-            finalizers is Some ==> finalizers->0@.map_values(|s: String| s@) == self@.finalizers->0,
+            finalizers is Some ==> finalizers->0.deep_view() == self@.finalizers->0,
     {
         self.inner.finalizers.clone()
     }
@@ -111,7 +111,7 @@ impl ObjectMeta {
     pub fn owner_references(&self) -> (owner_references: Option<Vec<OwnerReference>>)
         ensures
             self@.owner_references is Some == owner_references is Some,
-            owner_references is Some ==> owner_references->0@.map_values(|o: OwnerReference| o@) == self@.owner_references->0,
+            owner_references is Some ==> owner_references->0.deep_view() == self@.owner_references->0,
     {
         match &self.inner.owner_references {
             Some(o) => Some(o.into_iter().map(|item| OwnerReference::from_kube(item.clone())).collect()),
@@ -274,14 +274,14 @@ impl ObjectMeta {
 
     #[verifier(external_body)]
     pub fn set_owner_references(&mut self, owner_references: Vec<OwnerReference>)
-        ensures self@ == old(self)@.with_owner_references(owner_references@.map_values(|o: OwnerReference| o@)),
+        ensures self@ == old(self)@.with_owner_references(owner_references.deep_view()),
     {
         self.inner.owner_references = Some(owner_references.into_iter().map(|o: OwnerReference| o.into_kube()).collect());
     }
 
     #[verifier(external_body)]
     pub fn set_finalizers(&mut self, finalizers: Vec<String>)
-        ensures self@ == old(self)@.with_finalizers(finalizers@.map_values(|s: String| s@)),
+        ensures self@ == old(self)@.with_finalizers(finalizers.deep_view()),
     {
         self.inner.finalizers = Some(finalizers);
     }

--- a/src/kubernetes_api_objects/exec/object_meta.rs
+++ b/src/kubernetes_api_objects/exec/object_meta.rs
@@ -16,30 +16,13 @@ verus! {
 //
 // More detailed information: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/.
 
-#[verifier(external_body)]
-pub struct ObjectMeta {
-    inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
-}
+implement_field_wrapper_type!(
+    ObjectMeta,
+    deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta,
+    ObjectMetaView
+);
 
 impl ObjectMeta {
-    pub uninterp spec fn view(&self) -> ObjectMetaView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (object_meta: ObjectMeta)
-        ensures object_meta@ == ObjectMetaView::default(),
-    {
-        ObjectMeta {
-            inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        ObjectMeta { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn name(&self) -> (name: Option<String>)
         ensures self@.name == name.deep_view()

--- a/src/kubernetes_api_objects/exec/object_meta.rs
+++ b/src/kubernetes_api_objects/exec/object_meta.rs
@@ -42,18 +42,14 @@ impl ObjectMeta {
 
     #[verifier(external_body)]
     pub fn name(&self) -> (name: Option<String>)
-        ensures
-            self@.name is Some == name is Some,
-            name is Some ==> name->0@ == self@.name->0,
+        ensures self@.name == name.deep_view()
     {
         self.inner.name.clone()
     }
 
     #[verifier(external_body)]
     pub fn namespace(&self) -> (namespace: Option<String>)
-        ensures
-            self@.namespace is Some == namespace is Some,
-            namespace is Some ==> namespace->0@ == self@.namespace->0,
+        ensures self@.namespace == namespace.deep_view()
     {
         self.inner.namespace.clone()
     }
@@ -67,9 +63,7 @@ impl ObjectMeta {
 
     #[verifier(external_body)]
     pub fn generate_name(&self) -> (generate_name: Option<String>)
-        ensures
-            self@.generate_name is Some == generate_name is Some,
-            generate_name is Some ==> generate_name->0@ == self@.generate_name->0,
+        ensures self@.generate_name == generate_name.deep_view()
     {
         self.inner.generate_name.clone()
     }
@@ -77,8 +71,8 @@ impl ObjectMeta {
     #[verifier(external_body)]
     pub fn labels(&self) -> (labels: Option<StringMap>)
         ensures
-            self@.labels is Some == labels is Some,
-            labels is Some ==> labels->0@ == self@.labels->0 && labels->0@.dom().finite(),
+            self@.labels == labels.deep_view(),
+            labels is Some ==> labels->0@.dom().finite(),
     {
         match &self.inner.labels {
             Some(l) => Some(StringMap::from_rust_map(l.clone())),
@@ -89,8 +83,8 @@ impl ObjectMeta {
     #[verifier(external_body)]
     pub fn annotations(&self) -> (annotations: Option<StringMap>)
         ensures
-            self@.annotations is Some == annotations is Some,
-            annotations is Some ==> annotations->0@ == self@.annotations->0 && annotations->0@.dom().finite(),
+            self@.annotations == annotations.deep_view(),
+            annotations is Some ==> annotations->0@.dom().finite(),
     {
         match &self.inner.annotations {
             Some(a) => Some(StringMap::from_rust_map(a.clone())),
@@ -100,18 +94,14 @@ impl ObjectMeta {
 
     #[verifier(external_body)]
     pub fn finalizers(&self) -> (finalizers: Option<Vec<String>>)
-        ensures
-            self@.finalizers is Some == finalizers is Some,
-            finalizers is Some ==> finalizers->0.deep_view() == self@.finalizers->0,
+        ensures self@.finalizers == finalizers.deep_view()
     {
         self.inner.finalizers.clone()
     }
 
     #[verifier(external_body)]
     pub fn owner_references(&self) -> (owner_references: Option<Vec<OwnerReference>>)
-        ensures
-            self@.owner_references is Some == owner_references is Some,
-            owner_references is Some ==> owner_references->0.deep_view() == self@.owner_references->0,
+        ensures self@.owner_references == owner_references.deep_view()
     {
         match &self.inner.owner_references {
             Some(o) => Some(o.into_iter().map(|item| OwnerReference::from_kube(item.clone())).collect()),
@@ -140,18 +130,17 @@ impl ObjectMeta {
     }
 
     #[verifier(external_body)]
-    pub fn resource_version(&self) -> (version: Option<String>)
+    pub fn resource_version(&self) -> (resource_version: Option<String>)
         ensures
-            self@.resource_version is Some == version is Some,
-            version is Some ==> version->0@ == int_to_string_view(self@.resource_version->0),
+            self@.resource_version is Some == resource_version is Some,
+            resource_version is Some ==> resource_version->0@ == int_to_string_view(self@.resource_version->0),
     {
         self.inner.resource_version.clone()
     }
 
     #[verifier(external_body)]
     pub fn has_some_resource_version(&self) -> (b: bool)
-        ensures
-            self@.resource_version is Some == b,
+        ensures self@.resource_version is Some == b
     {
         self.inner.resource_version.is_some()
     }
@@ -171,8 +160,7 @@ impl ObjectMeta {
 
     #[verifier(external_body)]
     pub fn has_some_uid(&self) -> (b: bool)
-        ensures
-            self@.uid is Some == b,
+        ensures self@.uid is Some == b,
     {
         self.inner.uid.is_some()
     }

--- a/src/kubernetes_api_objects/exec/owner_reference.rs
+++ b/src/kubernetes_api_objects/exec/owner_reference.rs
@@ -4,6 +4,8 @@ use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::owner_reference::*;
 use vstd::prelude::*;
 
+verus! {
+
 // OwnerReference contains enough information to let you identify an owning object.
 // An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
 //
@@ -17,8 +19,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference,
     OwnerReferenceView
 );
-
-verus! {
 
 impl OwnerReference {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/owner_reference.rs
+++ b/src/kubernetes_api_objects/exec/owner_reference.rs
@@ -23,9 +23,7 @@ verus! {
 impl OwnerReference {
     #[verifier(external_body)]
     pub fn controller(&self) -> (controller: Option<bool>)
-        ensures
-            self@.controller is Some == controller is Some,
-            controller is Some ==> controller->0 == self@.controller->0,
+        ensures self@.controller == controller.deep_view()
     {
         match &self.inner.controller {
             Some(c) => Some(*c),

--- a/src/kubernetes_api_objects/exec/owner_reference.rs
+++ b/src/kubernetes_api_objects/exec/owner_reference.rs
@@ -4,9 +4,6 @@ use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::owner_reference::*;
 use vstd::prelude::*;
 
-verus! {
-
-
 // OwnerReference contains enough information to let you identify an owning object.
 // An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
 //
@@ -15,21 +12,15 @@ verus! {
 // It is supposed to be used in exec controller code.
 //
 
-#[verifier(external_body)]
-pub struct OwnerReference {
-    inner: deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference,
-}
+implement_field_wrapper_type!(
+    OwnerReference,
+    deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference,
+    OwnerReferenceView
+);
+
+verus! {
 
 impl OwnerReference {
-    pub uninterp spec fn view(&self) -> OwnerReferenceView;
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        OwnerReference { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn controller(&self) -> (controller: Option<bool>)
         ensures
@@ -40,16 +31,6 @@ impl OwnerReference {
             Some(c) => Some(*c),
             None => None,
         }
-    }
-
-    #[verifier(external)]
-    pub fn as_kube_ref(&self) -> &deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
-        &self.inner
-    }
-
-    #[verifier(external)]
-    pub fn as_kube_mut_ref(&mut self) -> &mut deps_hack::k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
-        &mut self.inner
     }
 }
 

--- a/src/kubernetes_api_objects/exec/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/exec/persistent_volume_claim.rs
@@ -7,6 +7,8 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{persistent_volume_claim::*, resource::*};
 use vstd::prelude::*;
 
+verus! {
+
 // PersistentVolumeClaim is a type of API object representing a request for storage (typically used by a Pod).
 // PersistentVolumeClaim objects are often defined in StatefulSet objects as the Volumes mounted to the Pods.
 //
@@ -27,8 +29,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::core::v1::PersistentVolumeClaimSpec,
     PersistentVolumeClaimSpecView
 );
-
-verus! {
 
 impl PersistentVolumeClaim {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/persistent_volume_claim.rs
+++ b/src/kubernetes_api_objects/exec/persistent_volume_claim.rs
@@ -78,7 +78,7 @@ impl PersistentVolumeClaimSpec {
 
     #[verifier(external_body)]
     pub fn set_access_modes(&mut self, access_modes: Vec<String>)
-        ensures self@ == old(self)@.with_access_modes(access_modes@.map_values(|mode: String| mode@)),
+        ensures self@ == old(self)@.with_access_modes(access_modes.deep_view()),
     {
         self.inner.access_modes = Some(access_modes);
     }

--- a/src/kubernetes_api_objects/exec/pod.rs
+++ b/src/kubernetes_api_objects/exec/pod.rs
@@ -29,6 +29,18 @@ implement_field_wrapper_type!(
     PodSpecView
 );
 
+implement_field_wrapper_type!(
+    PodSecurityContext,
+    deps_hack::k8s_openapi::api::core::v1::PodSecurityContext,
+    PodSecurityContextView
+);
+
+implement_field_wrapper_type!(
+    LocalObjectReference,
+    deps_hack::k8s_openapi::api::core::v1::LocalObjectReference,
+    LocalObjectReferenceView
+);
+
 verus! {
 
 impl Pod {
@@ -60,21 +72,21 @@ impl PodSpec {
 
     #[verifier(external_body)]
     pub fn set_containers(&mut self, containers: Vec<Container>)
-        ensures self@ == old(self)@.with_containers(containers@.map_values(|container: Container| container@)),
+        ensures self@ == old(self)@.with_containers(containers.deep_view()),
     {
         self.inner.containers = containers.into_iter().map(|container: Container| container.into_kube()).collect()
     }
 
     #[verifier(external_body)]
     pub fn set_volumes(&mut self, volumes: Vec<Volume>)
-        ensures self@ == old(self)@.with_volumes(volumes@.map_values(|vol: Volume| vol@)),
+        ensures self@ == old(self)@.with_volumes(volumes.deep_view()),
     {
         self.inner.volumes = Some(volumes.into_iter().map(|vol: Volume| vol.into_kube()).collect())
     }
 
     #[verifier(external_body)]
     pub fn set_init_containers(&mut self, init_containers: Vec<Container>)
-        ensures self@ == old(self)@.with_init_containers(init_containers@.map_values(|container: Container| container@)),
+        ensures self@ == old(self)@.with_init_containers(init_containers.deep_view()),
     {
         self.inner.init_containers = Some(init_containers.into_iter().map(|container: Container| container.into_kube()).collect())
     }
@@ -88,7 +100,7 @@ impl PodSpec {
 
     #[verifier(external_body)]
     pub fn set_tolerations(&mut self, tolerations: Vec<Toleration>)
-        ensures self@ == old(self)@.with_tolerations(tolerations@.map_values(|toleration: Toleration| toleration@)),
+        ensures self@ == old(self)@.with_tolerations(tolerations.deep_view()),
     {
         self.inner.tolerations = Some(tolerations.into_iter().map(|toleration: Toleration| toleration.into_kube()).collect())
     }
@@ -151,32 +163,10 @@ impl PodSpec {
 
     #[verifier(external_body)]
     pub fn set_image_pull_secrets(&mut self, image_pull_secrets: Vec<LocalObjectReference>)
-        ensures self@ == old(self)@.with_image_pull_secrets(image_pull_secrets@.map_values(|r: LocalObjectReference| r@)),
+        ensures self@ == old(self)@.with_image_pull_secrets(image_pull_secrets.deep_view()),
     {
         self.inner.image_pull_secrets = Some(image_pull_secrets.into_iter().map(|r: LocalObjectReference| r.into_kube()).collect())
     }
-}
-
-#[verifier(external_body)]
-pub struct PodSecurityContext {
-    inner: deps_hack::k8s_openapi::api::core::v1::PodSecurityContext,
-}
-
-impl View for PodSecurityContext {
-    type V = PodSecurityContextView;
-
-    uninterp spec fn view(&self) -> PodSecurityContextView;
-}
-
-#[verifier(external_body)]
-pub struct LocalObjectReference {
-    inner: deps_hack::k8s_openapi::api::core::v1::LocalObjectReference,
-}
-
-impl View for LocalObjectReference {
-    type V = LocalObjectReferenceView;
-
-    uninterp spec fn view(&self) -> LocalObjectReferenceView;
 }
 
 }

--- a/src/kubernetes_api_objects/exec/pod.rs
+++ b/src/kubernetes_api_objects/exec/pod.rs
@@ -9,6 +9,8 @@ use crate::kubernetes_api_objects::spec::{pod::*, resource::*};
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
+verus! {
+
 // Pod is a type of API object used for grouping one or more containers that share storage and network resources.
 // This is the smallest deployable unit in Kubernetes.
 //
@@ -40,8 +42,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::core::v1::LocalObjectReference,
     LocalObjectReferenceView
 );
-
-verus! {
 
 impl Pod {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/preconditions.rs
+++ b/src/kubernetes_api_objects/exec/preconditions.rs
@@ -4,13 +4,13 @@ use crate::kubernetes_api_objects::exec::{object_meta::*, resource::*};
 use crate::kubernetes_api_objects::spec::preconditions::*;
 use vstd::prelude::*;
 
+verus! {
+
 implement_field_wrapper_type!(
     Preconditions,
     deps_hack::kube::api::Preconditions,
     PreconditionsView
 );
-
-verus! {
 
 impl Preconditions {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/preconditions.rs
+++ b/src/kubernetes_api_objects/exec/preconditions.rs
@@ -4,38 +4,15 @@ use crate::kubernetes_api_objects::exec::{object_meta::*, resource::*};
 use crate::kubernetes_api_objects::spec::preconditions::*;
 use vstd::prelude::*;
 
+implement_field_wrapper_type!(
+    Preconditions,
+    deps_hack::kube::api::Preconditions,
+    PreconditionsView
+);
+
 verus! {
 
-#[verifier(external_body)]
-pub struct Preconditions {
-    inner: deps_hack::kube::api::Preconditions,
-}
-
-impl View for Preconditions {
-    type V = PreconditionsView;
-
-    uninterp spec fn view(&self) -> PreconditionsView;
-}
-
-implement_deep_view_trait!(Preconditions, PreconditionsView);
-
-impl std::clone::Clone for Preconditions {
-    #[verifier(external_body)]
-    fn clone(&self) -> (result: Preconditions)
-        ensures result@ == self@
-    {
-        Preconditions { inner: self.inner.clone() }
-    }
-}
-
 impl Preconditions {
-    #[verifier(external_body)]
-    pub fn default() -> (preconditions: Preconditions)
-        ensures preconditions@ == PreconditionsView::default(),
-    {
-        Preconditions { inner: deps_hack::kube::api::Preconditions::default() }
-    }
-
     #[verifier(external_body)]
     pub fn set_uid_from_object_meta(&mut self, object_meta: ObjectMeta)
         ensures self@ == old(self)@.with_uid_from_object_meta(object_meta@),

--- a/src/kubernetes_api_objects/exec/resource.rs
+++ b/src/kubernetes_api_objects/exec/resource.rs
@@ -1,6 +1,5 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: MIT
-use vstd::prelude::*;
 
 #[macro_export]
 macro_rules! implement_field_wrapper_type {

--- a/src/kubernetes_api_objects/exec/resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/resource_requirements.rs
@@ -5,32 +5,15 @@ use crate::kubernetes_api_objects::spec::resource_requirements::*;
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
+implement_field_wrapper_type!(
+    ResourceRequirements,
+    deps_hack::k8s_openapi::api::core::v1::ResourceRequirements,
+    ResourceRequirementsView
+);
+
 verus! {
 
-#[verifier(external_body)]
-pub struct ResourceRequirements {
-    inner: deps_hack::k8s_openapi::api::core::v1::ResourceRequirements
-}
-
 impl ResourceRequirements {
-    pub uninterp spec fn view(&self) -> ResourceRequirementsView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (resource_requirements: ResourceRequirements)
-        ensures resource_requirements@ == ResourceRequirementsView::default(),
-    {
-        ResourceRequirements {
-            inner: deps_hack::k8s_openapi::api::core::v1::ResourceRequirements::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        ResourceRequirements { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_limits(&mut self, limits: StringMap)
         ensures self@ == old(self)@.with_limits(limits@),

--- a/src/kubernetes_api_objects/exec/resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/resource_requirements.rs
@@ -5,13 +5,13 @@ use crate::kubernetes_api_objects::spec::resource_requirements::*;
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
+verus! {
+
 implement_field_wrapper_type!(
     ResourceRequirements,
     deps_hack::k8s_openapi::api::core::v1::ResourceRequirements,
     ResourceRequirementsView
 );
-
-verus! {
 
 impl ResourceRequirements {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/role.rs
+++ b/src/kubernetes_api_objects/exec/role.rs
@@ -7,6 +7,8 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{resource::*, role::*};
 use vstd::prelude::*;
 
+verus! {
+
 // This definition is a wrapper of Role defined at
 // https://github.com/Arnavion/k8s-openapi/blob/v0.17.0/src/v1_26/api/rbac/v1/role.rs.
 // It is supposed to be used in exec controller code.
@@ -20,8 +22,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::rbac::v1::PolicyRule,
     PolicyRuleView
 );
-
-verus! {
 
 impl Role {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/role_binding.rs
+++ b/src/kubernetes_api_objects/exec/role_binding.rs
@@ -7,6 +7,8 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{resource::*, role_binding::*};
 use vstd::prelude::*;
 
+verus! {
+
 // This definition is a wrapper of RoleBinding defined at
 // https://github.com/Arnavion/k8s-openapi/blob/v0.17.0/src/v1_26/api/rbac/v1/role_binding.rs.
 // It is supposed to be used in exec controller code.
@@ -30,8 +32,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::rbac::v1::Subject,
     SubjectView
 );
-
-verus! {
 
 impl RoleBinding {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/secret.rs
+++ b/src/kubernetes_api_objects/exec/secret.rs
@@ -8,6 +8,8 @@ use crate::kubernetes_api_objects::spec::{resource::*, secret::*};
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
+verus! {
+
 // Secret is a type of API object used to store confidential data in key-value pairs.
 // A Secret object can be used to set environment variables or configuration files
 // in a Volume mounted to a Pod.
@@ -23,8 +25,6 @@ implement_object_wrapper_type!(
     deps_hack::k8s_openapi::api::core::v1::Secret,
     SecretView
 );
-
-verus! {
 
 impl Secret {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/secret.rs
+++ b/src/kubernetes_api_objects/exec/secret.rs
@@ -29,9 +29,7 @@ verus! {
 impl Secret {
     #[verifier(external_body)]
     pub fn data(&self) -> (data: Option<StringMap>)
-        ensures
-            self@.data is Some == data is Some,
-            data is Some ==> data->0@ == self@.data->0,
+        ensures self@.data == data.deep_view()
     {
         match &self.inner.data {
             Some(d) => {

--- a/src/kubernetes_api_objects/exec/service.rs
+++ b/src/kubernetes_api_objects/exec/service.rs
@@ -41,9 +41,7 @@ verus! {
 impl Service {
     #[verifier(external_body)]
     pub fn spec(&self) -> (spec: Option<ServiceSpec>)
-        ensures
-            self@.spec is Some == spec is Some,
-            spec is Some ==> spec->0@ == self@.spec->0,
+        ensures self@.spec == spec.deep_view()
     {
         match &self.inner.spec {
             Some(s) => Some(ServiceSpec::from_kube(s.clone())),
@@ -69,9 +67,7 @@ impl ServiceSpec {
 
     #[verifier(external_body)]
     pub fn ports(&self) -> (ports: Option<Vec<ServicePort>>)
-        ensures
-            self@.ports is Some == ports is Some,
-            ports is Some ==> ports->0.deep_view() == self@.ports->0,
+        ensures self@.ports == ports.deep_view()
     {
         match &self.inner.ports {
             Some(p) => Some(p.into_iter().map(|port: &deps_hack::k8s_openapi::api::core::v1::ServicePort| ServicePort::from_kube(port.clone())).collect()),
@@ -88,9 +84,7 @@ impl ServiceSpec {
 
     #[verifier(external_body)]
     pub fn selector(&self) -> (selector: Option<StringMap>)
-        ensures
-            self@.selector is Some == selector is Some,
-            selector is Some ==> selector->0@ == self@.selector->0,
+        ensures self@.selector == selector.deep_view()
     {
         match &self.inner.selector {
             Some(s) => Some(StringMap::from_rust_map(s.clone())),
@@ -107,9 +101,7 @@ impl ServiceSpec {
 
     #[verifier(external_body)]
     pub fn publish_not_ready_addresses(&self) -> (publish_not_ready_addresses: Option<bool>)
-        ensures
-            self@.publish_not_ready_addresses is Some == publish_not_ready_addresses is Some,
-            publish_not_ready_addresses is Some ==> publish_not_ready_addresses->0 == self@.publish_not_ready_addresses->0,
+        ensures self@.publish_not_ready_addresses == publish_not_ready_addresses.deep_view()
     {
         self.inner.publish_not_ready_addresses.clone()
     }

--- a/src/kubernetes_api_objects/exec/service.rs
+++ b/src/kubernetes_api_objects/exec/service.rs
@@ -8,6 +8,8 @@ use crate::kubernetes_api_objects::spec::{resource::*, service::*};
 use crate::vstd_ext::string_map::StringMap;
 use vstd::prelude::*;
 
+verus! {
+
 // Service is a type of API object used for exposing a network application
 // that is running as one or more Pods in your cluster.
 // A Service object can be used to assign stable IP addresses and DNS names to pods.
@@ -35,8 +37,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::core::v1::ServicePort,
     ServicePortView
 );
-
-verus! {
 
 impl Service {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/stateful_set.rs
+++ b/src/kubernetes_api_objects/exec/stateful_set.rs
@@ -115,7 +115,7 @@ impl StatefulSetSpec {
 
     #[verifier(external_body)]
     pub fn set_volume_claim_templates(&mut self, volume_claim_templates: Vec<PersistentVolumeClaim>)
-        ensures self@ == old(self)@.with_volume_claim_templates(volume_claim_templates@.map_values(|pvc: PersistentVolumeClaim| pvc@)),
+        ensures self@ == old(self)@.with_volume_claim_templates(volume_claim_templates.deep_view()),
     {
         self.inner.volume_claim_templates = Some(
             volume_claim_templates.into_iter().map(|pvc: PersistentVolumeClaim| pvc.into_kube()).collect()
@@ -179,7 +179,7 @@ impl StatefulSetSpec {
     pub fn volume_claim_templates(&self) -> (volume_claim_templates: Option<Vec<PersistentVolumeClaim>>)
         ensures
             self@.volume_claim_templates is Some == volume_claim_templates is Some,
-            volume_claim_templates is Some ==> volume_claim_templates->0@.map_values(|p: PersistentVolumeClaim| p@) == self@.volume_claim_templates->0,
+            volume_claim_templates is Some ==> volume_claim_templates->0.deep_view() == self@.volume_claim_templates->0,
     {
         match &self.inner.volume_claim_templates {
             Some(p) => Some(p.into_iter().map(|item| PersistentVolumeClaim::from_kube(item.clone())).collect()),

--- a/src/kubernetes_api_objects/exec/stateful_set.rs
+++ b/src/kubernetes_api_objects/exec/stateful_set.rs
@@ -8,6 +8,8 @@ use crate::kubernetes_api_objects::exec::{
 use crate::kubernetes_api_objects::spec::{resource::*, stateful_set::*};
 use vstd::prelude::*;
 
+verus! {
+
 // StatefulSet is a type of API object used for managing stateful applications,
 // mainly a group of Pods and PersistentVolumeClaims attached to the Pods.
 // A StatefulSet object allows different types of Volumes attached to the pods,
@@ -43,8 +45,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::apps::v1::StatefulSetPersistentVolumeClaimRetentionPolicy,
     StatefulSetPersistentVolumeClaimRetentionPolicyView
 );
-
-verus! {
 
 impl StatefulSet {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/toleration.rs
+++ b/src/kubernetes_api_objects/exec/toleration.rs
@@ -4,8 +4,6 @@ use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::toleration::*;
 use vstd::prelude::*;
 
-verus! {
-
 // The pod this Toleration is attached to tolerates any taint that matches
 //
 // This definition is a wrapper of Toleration defined at
@@ -14,16 +12,11 @@ verus! {
 //
 // More detailed information: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.
 
-#[verifier(external_body)]
-pub struct Toleration {
-    inner: deps_hack::k8s_openapi::api::core::v1::Toleration,
-}
-
-impl Toleration {
-    pub uninterp spec fn view(&self) -> TolerationView;
-}
-
-}
+implement_field_wrapper_type!(
+    Toleration,
+    deps_hack::k8s_openapi::api::core::v1::Toleration,
+    TolerationView
+);
 
 implement_resource_wrapper_trait!(
     Toleration,

--- a/src/kubernetes_api_objects/exec/volume.rs
+++ b/src/kubernetes_api_objects/exec/volume.rs
@@ -4,6 +4,8 @@ use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::volume::*;
 use vstd::prelude::*;
 
+verus! {
+
 implement_field_wrapper_type!(
     Volume,
     deps_hack::k8s_openapi::api::core::v1::Volume,
@@ -81,8 +83,6 @@ implement_field_wrapper_type!(
     deps_hack::k8s_openapi::api::core::v1::ObjectFieldSelector,
     ObjectFieldSelectorView
 );
-
-verus! {
 
 impl Volume {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/volume.rs
+++ b/src/kubernetes_api_objects/exec/volume.rs
@@ -4,32 +4,87 @@ use crate::kubernetes_api_objects::exec::resource::*;
 use crate::kubernetes_api_objects::spec::volume::*;
 use vstd::prelude::*;
 
+implement_field_wrapper_type!(
+    Volume,
+    deps_hack::k8s_openapi::api::core::v1::Volume,
+    VolumeView
+);
+
+implement_field_wrapper_type!(
+    EmptyDirVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::EmptyDirVolumeSource,
+    EmptyDirVolumeSourceView
+);
+
+implement_field_wrapper_type!(
+    HostPathVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource,
+    HostPathVolumeSourceView
+);
+
+implement_field_wrapper_type!(
+    ConfigMapVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource,
+    ConfigMapVolumeSourceView
+);
+
+implement_field_wrapper_type!(
+    SecretVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::SecretVolumeSource,
+    SecretVolumeSourceView
+);
+
+implement_field_wrapper_type!(
+    ProjectedVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::ProjectedVolumeSource,
+    ProjectedVolumeSourceView
+);
+
+implement_field_wrapper_type!(
+    VolumeProjection,
+    deps_hack::k8s_openapi::api::core::v1::VolumeProjection,
+    VolumeProjectionView
+);
+
+implement_field_wrapper_type!(
+    ConfigMapProjection,
+    deps_hack::k8s_openapi::api::core::v1::ConfigMapProjection,
+    ConfigMapProjectionView
+);
+
+implement_field_wrapper_type!(
+    SecretProjection,
+    deps_hack::k8s_openapi::api::core::v1::SecretProjection,
+    SecretProjectionView
+);
+
+implement_field_wrapper_type!(
+    KeyToPath,
+    deps_hack::k8s_openapi::api::core::v1::KeyToPath,
+    KeyToPathView
+);
+
+implement_field_wrapper_type!(
+    DownwardAPIVolumeSource,
+    deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeSource,
+    DownwardAPIVolumeSourceView
+);
+
+implement_field_wrapper_type!(
+    DownwardAPIVolumeFile,
+    deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeFile,
+    DownwardAPIVolumeFileView
+);
+
+implement_field_wrapper_type!(
+    ObjectFieldSelector,
+    deps_hack::k8s_openapi::api::core::v1::ObjectFieldSelector,
+    ObjectFieldSelectorView
+);
+
 verus! {
 
-#[verifier(external_body)]
-pub struct Volume {
-    inner: deps_hack::k8s_openapi::api::core::v1::Volume,
-}
-
 impl Volume {
-    pub uninterp spec fn view(&self) -> VolumeView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (volume: Volume)
-        ensures volume@ == VolumeView::default(),
-    {
-        Volume {
-            inner: deps_hack::k8s_openapi::api::core::v1::Volume::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (volume: Volume)
-        ensures volume@ == self@,
-    {
-        Volume { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_name(&mut self, name: String)
         ensures self@ == old(self)@.with_name(name@),
@@ -82,53 +137,7 @@ impl Volume {
     }
 }
 
-#[verifier(external_body)]
-pub struct EmptyDirVolumeSource {
-    inner: deps_hack::k8s_openapi::api::core::v1::EmptyDirVolumeSource,
-}
-
-impl EmptyDirVolumeSource {
-    pub uninterp spec fn view(&self) -> EmptyDirVolumeSourceView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (empty_dir_volum_source: EmptyDirVolumeSource)
-        ensures empty_dir_volum_source@ == EmptyDirVolumeSourceView::default(),
-    {
-        EmptyDirVolumeSource {
-            inner: deps_hack::k8s_openapi::api::core::v1::EmptyDirVolumeSource::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (empty_dir_volum_source: EmptyDirVolumeSource)
-        ensures empty_dir_volum_source@ == self@,
-    {
-        EmptyDirVolumeSource { inner: self.inner.clone() }
-    }
-}
-
-#[verifier(external_body)]
-pub struct HostPathVolumeSource {
-    inner: deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource,
-}
-
 impl HostPathVolumeSource {
-    pub uninterp spec fn view(&self) -> HostPathVolumeSourceView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (host_path_volume_source: HostPathVolumeSource)
-        ensures host_path_volume_source@ == HostPathVolumeSourceView::default(),
-    {
-        HostPathVolumeSource { inner: deps_hack::k8s_openapi::api::core::v1::HostPathVolumeSource::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (host_path_volume_source: HostPathVolumeSource)
-        ensures host_path_volume_source@ == self@,
-    {
-        HostPathVolumeSource { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_path(&mut self, path: String)
         ensures self@ == old(self)@.with_path(path@),
@@ -137,28 +146,7 @@ impl HostPathVolumeSource {
     }
 }
 
-#[verifier(external_body)]
-pub struct ConfigMapVolumeSource {
-    inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource,
-}
-
 impl ConfigMapVolumeSource {
-    pub uninterp spec fn view(&self) -> ConfigMapVolumeSourceView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (config_map_volume_source: ConfigMapVolumeSource)
-        ensures config_map_volume_source@ == ConfigMapVolumeSourceView::default(),
-    {
-        ConfigMapVolumeSource { inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapVolumeSource::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (config_map_volume_source: ConfigMapVolumeSource)
-        ensures config_map_volume_source@ == self@,
-    {
-        ConfigMapVolumeSource { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_name(&mut self, name: String)
         ensures self@ == old(self)@.with_name(name@),
@@ -167,30 +155,7 @@ impl ConfigMapVolumeSource {
     }
 }
 
-#[verifier(external_body)]
-pub struct SecretVolumeSource {
-    inner: deps_hack::k8s_openapi::api::core::v1::SecretVolumeSource,
-}
-
 impl SecretVolumeSource {
-    pub uninterp spec fn view(&self) -> SecretVolumeSourceView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (secret_volume_source: SecretVolumeSource)
-        ensures secret_volume_source@ == SecretVolumeSourceView::default(),
-    {
-        SecretVolumeSource {
-            inner: deps_hack::k8s_openapi::api::core::v1::SecretVolumeSource::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (secret_volume_source: SecretVolumeSource)
-        ensures secret_volume_source@ == self@,
-    {
-        SecretVolumeSource { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_secret_name(&mut self, secret_name: String)
         ensures self@ == old(self)@.with_secret_name(secret_name@),
@@ -199,51 +164,16 @@ impl SecretVolumeSource {
     }
 }
 
-#[verifier(external_body)]
-pub struct ProjectedVolumeSource {
-    inner: deps_hack::k8s_openapi::api::core::v1::ProjectedVolumeSource,
-}
-
 impl ProjectedVolumeSource {
-    pub uninterp spec fn view(&self) -> ProjectedVolumeSourceView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (projected_volume_source: ProjectedVolumeSource)
-        ensures projected_volume_source@ == ProjectedVolumeSourceView::default(),
-    {
-        ProjectedVolumeSource { inner: deps_hack::k8s_openapi::api::core::v1::ProjectedVolumeSource::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (projected_volume_source: ProjectedVolumeSource)
-        ensures projected_volume_source@ == self@,
-    {
-        ProjectedVolumeSource { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_sources(&mut self, sources: Vec<VolumeProjection>)
-        ensures self@ == old(self)@.with_sources(sources@.map_values(|v: VolumeProjection| v@)),
+        ensures self@ == old(self)@.with_sources(sources.deep_view()),
     {
         self.inner.sources = Some(sources.into_iter().map(|v: VolumeProjection| v.into_kube()).collect());
     }
 }
 
-#[verifier(external_body)]
-pub struct VolumeProjection {
-    inner: deps_hack::k8s_openapi::api::core::v1::VolumeProjection,
-}
-
 impl VolumeProjection {
-    pub uninterp spec fn view(&self) -> VolumeProjectionView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (volume_projection: VolumeProjection)
-        ensures volume_projection@ == VolumeProjectionView::default(),
-    {
-        VolumeProjection { inner: deps_hack::k8s_openapi::api::core::v1::VolumeProjection::default() }
-    }
-
     #[verifier(external_body)]
     pub fn set_config_map(&mut self, config_map: ConfigMapProjection)
         ensures self@ == old(self)@.with_config_map(config_map@),
@@ -259,28 +189,7 @@ impl VolumeProjection {
     }
 }
 
-#[verifier(external_body)]
-pub struct ConfigMapProjection {
-    inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapProjection,
-}
-
 impl ConfigMapProjection {
-    pub uninterp spec fn view(&self) -> ConfigMapProjectionView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (config_map_projection: ConfigMapProjection)
-        ensures config_map_projection@ == ConfigMapProjectionView::default(),
-    {
-        ConfigMapProjection { inner: deps_hack::k8s_openapi::api::core::v1::ConfigMapProjection::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (config_map_projection: ConfigMapProjection)
-        ensures config_map_projection@ == self@,
-    {
-        ConfigMapProjection { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_name(&mut self, name: String)
         ensures self@ == old(self)@.with_name(name@),
@@ -290,34 +199,13 @@ impl ConfigMapProjection {
 
     #[verifier(external_body)]
     pub fn set_items(&mut self, items: Vec<KeyToPath>)
-        ensures self@ == old(self)@.with_items(items@.map_values(|v: KeyToPath| v@)),
+        ensures self@ == old(self)@.with_items(items.deep_view()),
     {
         self.inner.items = Some(items.into_iter().map(|v: KeyToPath| v.into_kube()).collect());
     }
-}
-
-#[verifier(external_body)]
-pub struct SecretProjection {
-    inner: deps_hack::k8s_openapi::api::core::v1::SecretProjection,
 }
 
 impl SecretProjection {
-    pub uninterp spec fn view(&self) -> SecretProjectionView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (secret_projection: SecretProjection)
-        ensures secret_projection@ == SecretProjectionView::default(),
-    {
-        SecretProjection { inner: deps_hack::k8s_openapi::api::core::v1::SecretProjection::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (secret_projection: SecretProjection)
-        ensures secret_projection@ == self@,
-    {
-        SecretProjection { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_name(&mut self, name: String)
         ensures self@ == old(self)@.with_name(name@),
@@ -327,27 +215,13 @@ impl SecretProjection {
 
     #[verifier(external_body)]
     pub fn set_items(&mut self, items: Vec<KeyToPath>)
-        ensures self@ == old(self)@.with_items(items@.map_values(|v: KeyToPath| v@)),
+        ensures self@ == old(self)@.with_items(items.deep_view()),
     {
         self.inner.items = Some(items.into_iter().map(|v: KeyToPath| v.into_kube()).collect());
     }
 }
 
-#[verifier(external_body)]
-pub struct KeyToPath {
-    inner: deps_hack::k8s_openapi::api::core::v1::KeyToPath,
-}
-
 impl KeyToPath {
-    pub uninterp spec fn view(&self) -> KeyToPathView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (key_to_path: KeyToPath)
-        ensures key_to_path@ == KeyToPathView::default(),
-    {
-        KeyToPath { inner: deps_hack::k8s_openapi::api::core::v1::KeyToPath::default() }
-    }
-
     #[verifier(external_body)]
     pub fn set_key(&mut self, key: String)
         ensures self@ == old(self)@.with_key(key@),
@@ -363,51 +237,16 @@ impl KeyToPath {
     }
 }
 
-#[verifier(external_body)]
-pub struct DownwardAPIVolumeSource {
-    inner: deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeSource,
-}
-
 impl DownwardAPIVolumeSource {
-    pub uninterp spec fn view(&self) -> DownwardAPIVolumeSourceView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (downward_api_volume_source: DownwardAPIVolumeSource)
-        ensures downward_api_volume_source@ == DownwardAPIVolumeSourceView::default(),
-    {
-        DownwardAPIVolumeSource { inner: deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeSource::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (downward_api_volume_source: DownwardAPIVolumeSource)
-        ensures downward_api_volume_source@ == self@,
-    {
-        DownwardAPIVolumeSource { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_items(&mut self, items: Vec<DownwardAPIVolumeFile>)
-        ensures self@ == old(self)@.with_items(items@.map_values(|v: DownwardAPIVolumeFile| v@)),
+        ensures self@ == old(self)@.with_items(items.deep_view()),
     {
         self.inner.items = Some(items.into_iter().map(|v: DownwardAPIVolumeFile| v.into_kube()).collect());
     }
 }
 
-#[verifier(external_body)]
-pub struct DownwardAPIVolumeFile {
-    inner: deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeFile,
-}
-
 impl DownwardAPIVolumeFile {
-    pub uninterp spec fn view(&self) -> DownwardAPIVolumeFileView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (downward_api_volume_file: DownwardAPIVolumeFile)
-        ensures downward_api_volume_file@ == DownwardAPIVolumeFileView::default(),
-    {
-        DownwardAPIVolumeFile { inner: deps_hack::k8s_openapi::api::core::v1::DownwardAPIVolumeFile::default() }
-    }
-
     #[verifier(external_body)]
     pub fn set_field_ref(&mut self, field_ref: ObjectFieldSelector)
         ensures self@ == old(self)@.with_field_ref(field_ref@),
@@ -423,28 +262,7 @@ impl DownwardAPIVolumeFile {
     }
 }
 
-#[verifier(external_body)]
-pub struct ObjectFieldSelector {
-    inner: deps_hack::k8s_openapi::api::core::v1::ObjectFieldSelector,
-}
-
 impl ObjectFieldSelector {
-    pub uninterp spec fn view(&self) -> ObjectFieldSelectorView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (object_field_selector: ObjectFieldSelector)
-        ensures object_field_selector@ == ObjectFieldSelectorView::default(),
-    {
-        ObjectFieldSelector { inner: deps_hack::k8s_openapi::api::core::v1::ObjectFieldSelector::default() }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (object_field_selector: ObjectFieldSelector)
-        ensures object_field_selector@ == self@,
-    {
-        ObjectFieldSelector { inner: self.inner.clone() }
-    }
-
     pub fn new_with(api_version: String, field_path: String) -> (object_field_selector: ObjectFieldSelector)
         ensures object_field_selector@ == ObjectFieldSelectorView::default().with_api_version(api_version@).with_field_path(field_path@),
     {

--- a/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
@@ -5,13 +5,13 @@ use crate::kubernetes_api_objects::spec::volume_resource_requirements::*;
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
+verus! {
+
 implement_field_wrapper_type!(
     VolumeResourceRequirements,
     deps_hack::k8s_openapi::api::core::v1::VolumeResourceRequirements,
     VolumeResourceRequirementsView
 );
-
-verus! {
 
 impl VolumeResourceRequirements {
     #[verifier(external_body)]

--- a/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
+++ b/src/kubernetes_api_objects/exec/volume_resource_requirements.rs
@@ -5,32 +5,15 @@ use crate::kubernetes_api_objects::spec::volume_resource_requirements::*;
 use crate::vstd_ext::string_map::*;
 use vstd::prelude::*;
 
+implement_field_wrapper_type!(
+    VolumeResourceRequirements,
+    deps_hack::k8s_openapi::api::core::v1::VolumeResourceRequirements,
+    VolumeResourceRequirementsView
+);
+
 verus! {
 
-#[verifier(external_body)]
-pub struct VolumeResourceRequirements {
-    inner: deps_hack::k8s_openapi::api::core::v1::VolumeResourceRequirements
-}
-
 impl VolumeResourceRequirements {
-    pub uninterp spec fn view(&self) -> VolumeResourceRequirementsView;
-
-    #[verifier(external_body)]
-    pub fn default() -> (resource_requirements: VolumeResourceRequirements)
-        ensures resource_requirements@ == VolumeResourceRequirementsView::default(),
-    {
-        VolumeResourceRequirements {
-            inner: deps_hack::k8s_openapi::api::core::v1::VolumeResourceRequirements::default(),
-        }
-    }
-
-    #[verifier(external_body)]
-    pub fn clone(&self) -> (s: Self)
-        ensures s@ == self@,
-    {
-        VolumeResourceRequirements { inner: self.inner.clone() }
-    }
-
     #[verifier(external_body)]
     pub fn set_limits(&mut self, limits: StringMap)
         ensures self@ == old(self)@.with_limits(limits@),

--- a/src/kubernetes_api_objects/spec/affinity.rs
+++ b/src/kubernetes_api_objects/spec/affinity.rs
@@ -6,9 +6,12 @@ verus! {
 
 // AffinityView is the ghost type of Affinity.
 
-
 pub struct AffinityView {}
 
-impl AffinityView {}
+impl AffinityView {
+    pub open spec fn default() -> AffinityView {
+        AffinityView {}
+    }
+}
 
 }

--- a/src/kubernetes_api_objects/spec/container.rs
+++ b/src/kubernetes_api_objects/spec/container.rs
@@ -448,4 +448,10 @@ impl EnvVarSourceView {
 
 pub struct SecurityContextView {}
 
+impl SecurityContextView {
+    pub open spec fn default() -> SecurityContextView {
+        SecurityContextView {}
+    }
+}
+
 }

--- a/src/kubernetes_api_objects/spec/daemon_set.rs
+++ b/src/kubernetes_api_objects/spec/daemon_set.rs
@@ -164,4 +164,13 @@ pub struct DaemonSetStatusView {
     pub number_ready: int,
 }
 
+impl DaemonSetStatusView {
+    pub open spec fn default() -> DaemonSetStatusView {
+        DaemonSetStatusView {
+            number_ready: 0,
+        }
+    }
+}
+
+
 }

--- a/src/kubernetes_api_objects/spec/dynamic.rs
+++ b/src/kubernetes_api_objects/spec/dynamic.rs
@@ -8,7 +8,6 @@ verus! {
 
 // DynamicObjectView is the ghost type of DynamicObject.
 
-
 pub struct DynamicObjectView {
     pub kind: Kind,
     pub metadata: ObjectMetaView,

--- a/src/kubernetes_api_objects/spec/dynamic.rs
+++ b/src/kubernetes_api_objects/spec/dynamic.rs
@@ -86,8 +86,4 @@ impl DynamicObjectView {
     }
 }
 
-// This data type represents the entire cluster state that consists of
-// many different objects in the form of DynamicObjectView
-pub type StoredState = Map<ObjectRef, DynamicObjectView>;
-
 }

--- a/src/kubernetes_api_objects/spec/owner_reference.rs
+++ b/src/kubernetes_api_objects/spec/owner_reference.rs
@@ -17,6 +17,11 @@ pub struct OwnerReferenceView {
     pub uid: Uid,
 }
 
+impl OwnerReferenceView {
+    // default() isn't needed; this is just to make the macro implement_field_wrapper_type happy
+    pub uninterp spec fn default() -> OwnerReferenceView;
+}
+
 pub open spec fn owner_reference_to_object_reference(owner_reference: OwnerReferenceView, namespace: StringView) -> ObjectRef {
     ObjectRef {
         kind: owner_reference.kind,

--- a/src/kubernetes_api_objects/spec/pod.rs
+++ b/src/kubernetes_api_objects/spec/pod.rs
@@ -295,6 +295,18 @@ impl PodSpecView {
 
 pub struct PodSecurityContextView {}
 
+impl PodSecurityContextView {
+    pub open spec fn default() -> PodSecurityContextView {
+        PodSecurityContextView {}
+    }
+}
+
 pub struct LocalObjectReferenceView {}
+
+impl LocalObjectReferenceView {
+    pub open spec fn default() -> LocalObjectReferenceView {
+        LocalObjectReferenceView {}
+    }
+}
 
 }

--- a/src/kubernetes_api_objects/spec/resource.rs
+++ b/src/kubernetes_api_objects/spec/resource.rs
@@ -7,6 +7,11 @@ use vstd::prelude::*;
 
 verus! {
 
+// StoredState represents the entire cluster state that consists of
+// many different objects in the form of DynamicObjectView
+pub type StoredState = Map<ObjectRef, DynamicObjectView>;
+
+// Value represents the data that each object/field gets marshalled into
 pub type Value = StringView;
 
 pub trait Marshallable: Sized {

--- a/src/kubernetes_api_objects/spec/stateful_set.rs
+++ b/src/kubernetes_api_objects/spec/stateful_set.rs
@@ -265,4 +265,12 @@ pub struct StatefulSetStatusView {
     pub ready_replicas: Option<int>,
 }
 
+impl StatefulSetStatusView {
+    pub open spec fn default() -> StatefulSetStatusView {
+        StatefulSetStatusView {
+            ready_replicas: None,
+        }
+    }
+}
+
 }

--- a/src/kubernetes_api_objects/spec/toleration.rs
+++ b/src/kubernetes_api_objects/spec/toleration.rs
@@ -9,6 +9,10 @@ verus! {
 
 pub struct TolerationView {}
 
-impl TolerationView {}
+impl TolerationView {
+    pub open spec fn default() -> TolerationView {
+        TolerationView {}
+    }
+}
 
 }

--- a/src/kubernetes_cluster/proof/composition.rs
+++ b/src/kubernetes_cluster/proof/composition.rs
@@ -1,6 +1,5 @@
 use crate::kubernetes_cluster::spec::cluster::*;
 use crate::temporal_logic::defs::*;
-use crate::vstd_ext::map_lib::*;
 use vstd::prelude::*;
 
 verus! {
@@ -139,11 +138,11 @@ proof fn horizontal_composition<HC>(spec: TempPred<ClusterState>, cluster: Clust
         assert forall |i| #[trigger] composed.contains_key(i) implies (composed[i].membership)(cluster) by {
             assert(new_composed.contains_key(i));
         }
-        
+
         HC::safety_is_guaranteed(spec, cluster);
 
         if (forall |i| #[trigger] new_composed.contains_key(i) ==> spec.entails(new_composed[i].fairness))
-            && (forall |i| #[trigger] new_composed.contains_key(i) ==> 
+            && (forall |i| #[trigger] new_composed.contains_key(i) ==>
                     forall |j| #[trigger] others.contains_key(j) ==>
                         spec.entails((new_composed[i].safety_partial_rely)(j)))
         {
@@ -206,11 +205,11 @@ proof fn vertical_composition<VC>(spec: TempPred<ClusterState>, cluster: Cluster
         assert forall |i| #[trigger] composed.contains_key(i) implies (composed[i].membership)(cluster) by {
             assert(new_composed.contains_key(i));
         }
-        
+
         VC::safety_is_guaranteed(spec, cluster);
 
         if (forall |i| #[trigger] new_composed.contains_key(i) ==> spec.entails(new_composed[i].fairness))
-            && (forall |i| #[trigger] new_composed.contains_key(i) ==> 
+            && (forall |i| #[trigger] new_composed.contains_key(i) ==>
                     forall |j| #[trigger] others.contains_key(j) ==>
                         spec.entails((new_composed[i].safety_partial_rely)(j)))
         {

--- a/src/kubernetes_cluster/spec/api_server/state_machine.rs
+++ b/src/kubernetes_cluster/spec/api_server/state_machine.rs
@@ -3,7 +3,7 @@ use crate::kubernetes_api_objects::spec::prelude::*;
 use crate::kubernetes_cluster::spec::{api_server::types::*, message::*};
 use crate::state_machine::action::*;
 use crate::state_machine::state_machine::*;
-use crate::vstd_ext::{map_lib::*, string_view::*};
+use crate::vstd_ext::string_view::*;
 use vstd::{multiset::*, prelude::*};
 
 verus! {

--- a/src/unit_tests/kubernetes_api_objects/dynamic_object.rs
+++ b/src/unit_tests/kubernetes_api_objects/dynamic_object.rs
@@ -30,32 +30,6 @@ pub fn test_kube() {
 }
 
 #[test]
-pub fn test_kube_metadata_ref() {
-    let dynamic_object = DynamicObject::from_kube(deps_hack::kube::api::DynamicObject {
-        metadata: deps_hack::kube::api::ObjectMeta {
-            name: Some("name".to_string()),
-            namespace: Some("namespace".to_string()),
-            ..Default::default()
-        },
-        types: Some(deps_hack::kube::api::TypeMeta {
-            api_version: "api_version".to_string(),
-            kind: "kind".to_string(),
-        }),
-        data: deps_hack::serde_json::json!({
-            "key": "value",
-        }),
-    });
-    assert_eq!(
-        dynamic_object.kube_metadata_ref(),
-        &deps_hack::kube::api::ObjectMeta {
-            name: Some("name".to_string()),
-            namespace: Some("namespace".to_string()),
-            ..Default::default()
-        }
-    );
-}
-
-#[test]
 pub fn test_metadata() {
     let dynamic_object = DynamicObject::from_kube(deps_hack::kube::api::DynamicObject {
         metadata: deps_hack::kube::api::ObjectMeta {

--- a/src/vstd_ext/string_map.rs
+++ b/src/vstd_ext/string_map.rs
@@ -7,9 +7,21 @@ pub struct StringMap {
     inner: std::collections::BTreeMap<std::string::String, std::string::String>,
 }
 
-impl StringMap {
-    pub uninterp spec fn view(&self) -> Map<Seq<char>, Seq<char>>;
+impl View for StringMap {
+    type V = Map<Seq<char>, Seq<char>>;
 
+    uninterp spec fn view(&self) -> Map<Seq<char>, Seq<char>>;
+}
+
+impl DeepView for StringMap {
+    type V = Map<Seq<char>, Seq<char>>;
+
+    open spec fn deep_view(&self) -> Map<Seq<char>, Seq<char>> {
+        self@
+    }
+}
+
+impl StringMap {
     #[verifier(external_body)]
     pub fn new() -> (m: Self)
         ensures m@ == Map::<Seq<char>, Seq<char>>::empty(),


### PR DESCRIPTION
This PR does two things.

First, it simplifies the postconditions of the wrapper getter methods of Kubernetes API objects using `deep_view()`. For example,
(1)
```
    pub fn name(&self) -> (name: Option<String>)
        ensures
            self@.name is Some == name is Some,
            name is Some ==> name->0@ == self@.name->0,
```
is simplified to
```
    pub fn name(&self) -> (name: Option<String>)
        ensures self@.name == name.deep_view()
```
and (2)
```
    pub fn set_owner_references(&mut self, owner_references: Vec<OwnerReference>)
        ensures self@ == old(self)@.with_owner_references(owner_references@.map_values(|o: OwnerReference| o@)),
```
is simplified to
```
    pub fn set_owner_references(&mut self, owner_references: Vec<OwnerReference>)
        ensures self@ == old(self)@.with_owner_references(owner_references.deep_view()),
```

Second, it uses the `implement_x` macro to define the fields in Kubernetes API objects.