### PR TITLE
Prove lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd

### DIFF
--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -117,6 +117,9 @@ ensures
     local_state_is_valid_and_coherent(vd, controller_id)(s_prime),
 {}
 
+// This lemma proves for all objects owned by vd (checked by namespace and owner_ref),
+// the API request msg does not change or delete the object
+// as the direct result of rely condition and non-interference property.
 pub proof fn lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd(
     s: ClusterState, s_prime: ClusterState, vd: VDeploymentView, cluster: Cluster, controller_id: int,
     key: ObjectRef, msg: Message
@@ -230,15 +233,12 @@ ensures
                                 }
                             }
                         },
-                        APIRequest::UpdateRequest(req) => {}, // vd controller doesn't send update req
                         _ => {},
                     }
                 }
             },
-            _ => {}, // somehow this branch is slow
+            _ => {},
         }
-        assert(s_prime.resources().contains_key(key));
-        assert(s_prime.resources()[key] == etcd_obj);
     }
 }
 

--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -8,13 +8,14 @@ use crate::kubernetes_cluster::spec::{
 };
 use crate::vreplicaset_controller::trusted::spec_types::*;
 use crate::vdeployment_controller::{
-    trusted::{spec_types::*, step::*, util::*, liveness_theorem::*},
+    trusted::{spec_types::*, step::*, util::*, liveness_theorem::*, rely_guarantee::*},
     model::{install::*, reconciler::*},
-    proof::predicate::*,
+    proof::{predicate::*, helper_invariants},
 };
 use crate::vdeployment_controller::trusted::step::VDeploymentReconcileStepView::*;
 use crate::reconciler::spec::io::*;
-use vstd::prelude::*;
+use vstd::{seq_lib::*, prelude::*};
+use crate::vstd_ext::seq_lib::*;
 
 verus! {
 
@@ -115,5 +116,133 @@ ensures
     objects_to_vrs_list(s_prime.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq()),
     local_state_is_valid_and_coherent(vd, controller_id)(s_prime),
 {}
+
+pub proof fn lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd(
+    s: ClusterState, s_prime: ClusterState, vd: VDeploymentView, cluster: Cluster, controller_id: int,
+    key: ObjectRef, msg: Message
+)
+requires
+    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
+    cluster.next_step(s, s_prime, Step::APIServerStep(Some(msg))),
+    cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
+    forall |vd| helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, vd)(s),
+    vd_rely_condition(vd, cluster, controller_id)(s),
+    // object in etcd is owned by vd
+    ({
+        let etcd_obj = s.resources()[key];
+        &&& s.resources().contains_key(key)
+        &&& VReplicaSetView::unmarshal(etcd_obj) is Ok
+        &&& etcd_obj.metadata.namespace == vd.metadata.namespace
+        &&& etcd_obj.metadata.owner_references is Some
+        &&& etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
+    }),
+    // equal to msg.src != HostId::Controller(controller_id, vd.object_ref())
+    (!Cluster::pending_req_msg_is(controller_id, s, vd.object_ref(), msg)
+        || !s.ongoing_reconciles(controller_id).contains_key(vd.object_ref())),
+ensures
+    ({
+        let etcd_obj = s.resources()[key];
+        &&& s_prime.resources().contains_key(key)
+        &&& etcd_obj == s_prime.resources()[key]
+    }),
+{
+    assert(s.resources().contains_key(key));
+    let etcd_obj = s.resources()[key];
+    assert(VReplicaSetView::unmarshal(etcd_obj) is Ok);
+    VReplicaSetView::marshal_preserves_integrity();
+    // trigger rely condition,
+    // rule out cases when etcd_obj get deleted with rely_delete and handle_delete_eq checks
+    assert(etcd_obj.metadata.owner_references->0.contains(vd.controller_owner_ref())) by {
+        broadcast use group_seq_properties;
+        assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]);
+        seq_filter_contains_implies_seq_contains(etcd_obj.metadata.owner_references->0, controller_owner_filter(), vd.controller_owner_ref());
+    }
+    if msg.content.is_APIRequest() && msg.dst.is_APIServer() {
+        match msg.src {
+            HostId::Controller(id, cr_key) => {
+                if id == controller_id {
+                    assert(cr_key != vd.object_ref());
+                    // same controller, other vd
+                    // every_msg_from_vd_controller_carries_vd_key
+                    let cr_key = msg.src.get_Controller_1();
+                    let other_vd = VDeploymentView {
+                        metadata: ObjectMetaView {
+                            name: Some(cr_key.name),
+                            namespace: Some(cr_key.namespace),
+                            ..make_vd().metadata
+                        },
+                        ..make_vd()
+                    };
+                    // so msg can only be list, create or get_then_update
+                    assert(helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, other_vd)(s));
+                    match msg.content.get_APIRequest_0() {
+                        APIRequest::DeleteRequest(req) => assert(false), // vd controller doesn't send delete req
+                        APIRequest::GetThenDeleteRequest(req) => assert(false),
+                        APIRequest::GetThenUpdateRequest(req) => {
+                            assert(helper_invariants::no_other_pending_get_then_update_request_interferes_with_vd_reconcile(req, vd)(s));
+                            assert(helper_invariants::vd_reconcile_get_then_update_request_only_interferes_with_itself(req, other_vd)(s));
+                            // controller_owner_ref does not carry namespace, while object_ref does
+                            // so object_ref != is not enough to prove controller_owner_ref !=
+                            if cr_key.namespace == vd.metadata.namespace->0 {
+                                assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
+                                    if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
+                                        assert(req.owner_ref != vd.controller_owner_ref());
+                                        assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
+                                    }
+                                }
+                            } // or else, namespace is different, so should not be touched at all
+                        },
+                        _ => {},
+                    }
+                    VDeploymentReconcileState::marshal_preserves_integrity();
+                } else {
+                    let other_id = msg.src.get_Controller_0();
+                    // by every_in_flight_req_msg_from_controller_has_valid_controller_id, used by vd_rely
+                    assert(cluster.controller_models.contains_key(other_id));
+                    assert(vd_rely(other_id)(s)); // trigger vd_rely_condition
+                    VDeploymentReconcileState::marshal_preserves_integrity();
+                    match msg.content.get_APIRequest_0() {
+                        APIRequest::DeleteRequest(req) => {},
+                        APIRequest::GetThenDeleteRequest(req) => {
+                            if req.key.kind == VReplicaSetView::kind() {
+                                assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
+                                    if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
+                                        assert(req.owner_ref != vd.controller_owner_ref());
+                                        assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
+                                    }
+                                }
+                            }
+                        },
+                        APIRequest::GetThenUpdateRequest(req) => {
+                            if req.obj.kind == VReplicaSetView::kind() {
+                                // rely condition
+                                assert({
+                                    &&& req.owner_ref.controller is Some
+                                    &&& req.owner_ref.controller->0
+                                    &&& req.owner_ref.kind != VDeploymentView::kind()
+                                });
+                                assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
+                                    if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
+                                        assert(req.owner_ref != vd.controller_owner_ref());
+                                        assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
+                                    }
+                                }
+                            }
+                        },
+                        APIRequest::UpdateRequest(req) => {}, // vd controller doesn't send update req
+                        _ => {},
+                    }
+                }
+            },
+            _ => {}, // somehow this branch is slow
+        }
+        assert(s_prime.resources().contains_key(key));
+        assert(s_prime.resources()[key] == etcd_obj);
+    }
+}
+
+// Havoc function for VDeploymentView.
+uninterp spec fn make_vd() -> VDeploymentView;
 
 }


### PR DESCRIPTION
Prove `lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd`. This lemma picks out the proof at https://github.com/anvil-verifier/anvil/blob/e5d5c53b8c7330183d2014370a849de4a355bcc3/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs#L1517-L1596

And is helpful to prove other API action lemmas