### PR TITLE
Prove VDeployment controller transition lemmas

### DIFF
--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -233,13 +233,17 @@ ensures
                             }
                         },
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
                         APIRequest::UpdateRequest(req) => {}, // vd controller doesn't send update req
 >>>>>>> fe223b4 (prove lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd)
+=======
+>>>>>>> 98fff03 (unmask lemma_from_after_send_create_pod_req_to_receive_ok_resp)
                         _ => {},
                     }
                 }
             },
+<<<<<<< HEAD
 <<<<<<< HEAD
             _ => {},
         }
@@ -249,6 +253,10 @@ ensures
         assert(s_prime.resources().contains_key(key));
         assert(s_prime.resources()[key] == etcd_obj);
 >>>>>>> fe223b4 (prove lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd)
+=======
+            _ => {},
+        }
+>>>>>>> 98fff03 (unmask lemma_from_after_send_create_pod_req_to_receive_ok_resp)
     }
 }
 

--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -233,12 +233,23 @@ ensures
                                 }
                             }
                         },
+<<<<<<< HEAD
+=======
+                        APIRequest::UpdateRequest(req) => {}, // vd controller doesn't send update req
+>>>>>>> fe223b4 (prove lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd)
                         _ => {},
                     }
                 }
             },
+<<<<<<< HEAD
             _ => {},
         }
+=======
+            _ => {}, // somehow this branch is slow
+        }
+        assert(s_prime.resources().contains_key(key));
+        assert(s_prime.resources()[key] == etcd_obj);
+>>>>>>> fe223b4 (prove lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd)
     }
 }
 

--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -232,31 +232,12 @@ ensures
                                 }
                             }
                         },
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-                        APIRequest::UpdateRequest(req) => {}, // vd controller doesn't send update req
->>>>>>> fe223b4 (prove lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd)
-=======
->>>>>>> 98fff03 (unmask lemma_from_after_send_create_pod_req_to_receive_ok_resp)
                         _ => {},
                     }
                 }
             },
-<<<<<<< HEAD
-<<<<<<< HEAD
             _ => {},
         }
-=======
-            _ => {}, // somehow this branch is slow
-        }
-        assert(s_prime.resources().contains_key(key));
-        assert(s_prime.resources()[key] == etcd_obj);
->>>>>>> fe223b4 (prove lemma_api_request_other_than_pending_req_msg_maintains_objects_owned_by_vd)
-=======
-            _ => {},
-        }
->>>>>>> 98fff03 (unmask lemma_from_after_send_create_pod_req_to_receive_ok_resp)
     }
 }
 

--- a/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/api_actions.rs
@@ -106,7 +106,6 @@ requires
     cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
     (!Cluster::pending_req_msg_is(controller_id, s, vd.object_ref(), msg)
         || !s.ongoing_reconciles(controller_id).contains_key(vd.object_ref())),
-    local_state_is_valid_and_coherent(vd, controller_id)(s),
 ensures
     filter_old_and_new_vrs_on_etcd(vd, s.resources()) ==
     filter_old_and_new_vrs_on_etcd(vd, s_prime.resources()),
@@ -114,7 +113,7 @@ ensures
     s_prime.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq(),
     objects_to_vrs_list(s.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq()) ==
     objects_to_vrs_list(s_prime.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq()),
-    local_state_is_valid_and_coherent(vd, controller_id)(s_prime),
+    local_state_is_valid_and_coherent(vd, controller_id)(s) ==> local_state_is_valid_and_coherent(vd, controller_id)(s_prime),
 {}
 
 // This lemma proves for all objects owned by vd (checked by namespace and owner_ref),

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -502,6 +502,162 @@ ensures
     );
 }
 
+// this lemma specifies how VD controller construct the internal cache from list response
+proof fn lemma_from_list_resp_to_next_state(
+    s: ClusterState, s_prime: ClusterState, vd: VDeploymentView, cluster: Cluster, controller_id: int, resp_msg: Message, replicas_or_not_exist: Option<int>, n: nat
+)
+requires
+    cluster.type_is_installed_in_cluster::<VDeploymentView>(),
+    cluster.controller_models.contains_pair(controller_id, vd_controller_model()),
+    cluster.next_step(s, s_prime, Step::ControllerStep((controller_id, Some(resp_msg), Some(vd.object_ref())))),
+    cluster_invariants_since_reconciliation(cluster, vd, controller_id)(s),
+    at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS])(s),
+    resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg)(s),
+    etcd_state_is(vd, controller_id, replicas_or_not_exist, n)(s),
+ensures
+    local_state_is_valid_and_coherent(vd, controller_id)(s_prime),
+    etcd_state_is(vd, controller_id, replicas_or_not_exist, n)(s_prime),
+    (replicas_or_not_exist == Some(vd.spec.replicas.unwrap_or(int1!())) ==> {
+        &&& at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))])(s_prime)
+        &&& no_pending_req_in_cluster(vd, controller_id)(s_prime)
+    }),
+    (replicas_or_not_exist is Some && replicas_or_not_exist->0 != vd.spec.replicas.unwrap_or(int1!()) ==> {
+        &&& at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(replicas_or_not_exist, n))])(s_prime)
+        &&& pending_get_then_update_new_vrs_req_in_flight(vd, controller_id)(s_prime)
+    }),
+    (replicas_or_not_exist is None ==> {
+        &&& at_vd_step_with_vd(vd, controller_id, at_step![(AfterCreateNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))])(s_prime)
+        &&& pending_create_new_vrs_req_in_flight(vd, controller_id)(s_prime)
+    }),
+{
+    VDeploymentReconcileState::marshal_preserves_integrity();
+    VReplicaSetView::marshal_preserves_integrity();
+    broadcast use group_seq_properties;
+    let triggering_cr = VDeploymentView::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].triggering_cr).unwrap();
+    // TODO: fix this
+    assume(triggering_cr == vd);
+    let resp_objs = resp_msg.content.get_list_response().res.unwrap();
+    let vrs_list_or_none = objects_to_vrs_list(resp_objs);
+    assert(resp_msg.content.is_list_response());
+    assert(resp_msg.content.get_list_response().res is Ok);
+    assert(vrs_list_or_none is Some);
+    assert(resp_objs.map_values(|obj: DynamicObjectView| obj.object_ref()).no_duplicates());
+    assert(resp_objs == s.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq());
+    assert(filter_old_and_new_vrs(vd, vrs_list_or_none->0.filter(|vrs| valid_owned_object(vrs, vd))) == filter_old_and_new_vrs_on_etcd(vd, s.resources()));
+    let (new_vrs, old_vrs_list) = filter_old_and_new_vrs(vd, vrs_list_or_none->0.filter(|vrs| valid_owned_object(vrs, vd)));
+    assert(new_vrs is Some);
+    assert(match_replicas(vd, new_vrs->0));
+    assert(old_vrs_list.len() == n);
+    let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
+    let vds_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
+    assert(vds_prime == VDeploymentReconcileState {
+        reconcile_step: VDeploymentReconcileStepView::AfterEnsureNewVRS,
+        new_vrs: new_vrs,
+        old_vrs_list: old_vrs_list,
+        old_vrs_index: old_vrs_list.len()
+    });
+    assert(forall |obj| #[trigger] resp_objs.contains(obj) ==> VReplicaSetView::unmarshal(obj) is Ok);
+    assert(forall |obj| #[trigger] resp_objs.contains(obj) ==> {
+        &&& obj.metadata.namespace == vd.metadata.namespace
+        &&& obj.metadata.owner_references is Some
+        &&& obj.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
+        &&& s.resources().contains_key(obj.object_ref())
+    });
+    assert(at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))])(s_prime));
+    let vrs_list = vrs_list_or_none->0;
+    let valid_owned_object_filter = |vrs: VReplicaSetView| valid_owned_object(vrs, vd);
+    assert(valid_owned_object_filter == (|vrs: VReplicaSetView| valid_owned_object(vrs, triggering_cr)));
+    let filtered_vrs_list = vrs_list.filter(valid_owned_object_filter);
+    assert(filter_old_and_new_vrs(vd, filtered_vrs_list) == filter_old_and_new_vrs_on_etcd(vd, s.resources()));
+    let old_vrs_list_filter_with_new_vrs = |vrs: VReplicaSetView| {
+        &&& new_vrs is None || vrs.metadata.uid != new_vrs->0.metadata.uid
+        &&& vrs.spec.replicas is None || vrs.spec.replicas->0 > 0
+    };
+    assert(old_vrs_list == filtered_vrs_list.filter(old_vrs_list_filter_with_new_vrs));
+    let map_key = |vrs: VReplicaSetView| vrs.object_ref();
+    assert(old_vrs_list.map_values(map_key).no_duplicates()) by {
+        assume(false);
+        assert(old_vrs_list.map_values(map_key).no_duplicates()) by {
+            assert(resp_objs.map_values(|obj: DynamicObjectView| obj.object_ref()) == vrs_list.map_values(map_key)) by {
+                assert forall |i| 0 <= i < vrs_list.len() implies vrs_list[i].object_ref() == #[trigger] resp_objs[i].object_ref() by {
+                    assert(resp_objs.contains(resp_objs[i]));
+                }
+            }
+            map_values_weakens_no_duplicates(vrs_list, map_key);
+            seq_filter_preserves_no_duplicates(vrs_list, valid_owned_object_filter);
+            seq_filter_preserves_no_duplicates(filtered_vrs_list, old_vrs_list_filter_with_new_vrs);
+            assert(old_vrs_list.no_duplicates());
+            assert forall |vrs| #[trigger] old_vrs_list.contains(vrs) implies vrs_list.contains(vrs) by {
+                seq_filter_contains_implies_seq_contains(filtered_vrs_list, old_vrs_list_filter_with_new_vrs, vrs);
+                seq_filter_contains_implies_seq_contains(vrs_list, valid_owned_object_filter, vrs);
+            }
+            assert forall |i, j| 0 <= i < old_vrs_list.len() && 0 <= j < old_vrs_list.len() && i != j && old_vrs_list.no_duplicates() implies
+                #[trigger] old_vrs_list[i].object_ref() != #[trigger] old_vrs_list[j].object_ref() by {
+                assert(old_vrs_list.contains(old_vrs_list[i]) ==> vrs_list.contains(old_vrs_list[i]));
+                assert(old_vrs_list.contains(old_vrs_list[j]) ==> vrs_list.contains(old_vrs_list[j]));
+                let m = choose |m| 0 <= m < vrs_list.len() && vrs_list[m] == old_vrs_list[i];
+                let n = choose |n| 0 <= n < vrs_list.len() && vrs_list[n] == old_vrs_list[j];
+                assert(old_vrs_list[i].object_ref() != old_vrs_list[j].object_ref()) by {
+                    if m == n {
+                        assert(old_vrs_list[i] == old_vrs_list[j]);
+                        assert(false);
+                    } else {
+                        assert(vrs_list[m].object_ref() != vrs_list[n].object_ref()) by {
+                            assert(vrs_list.map_values(map_key)[m] == vrs_list[m].object_ref());
+                            assert(vrs_list.map_values(map_key)[n] == vrs_list[n].object_ref());
+                            assert(vrs_list.map_values(map_key).no_duplicates());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert forall |vrs| #[trigger] vrs_list.contains(vrs) implies {
+        &&& s_prime.resources().contains_key(vrs.object_ref())
+        &&& VReplicaSetView::unmarshal(s_prime.resources()[vrs.object_ref()])->Ok_0 == vrs
+    } by {
+        assert(resp_objs.map_values(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).unwrap()).contains(vrs));
+        let obj = choose |o: DynamicObjectView| #[trigger] resp_objs.contains(o) && VReplicaSetView::unmarshal(o).unwrap() == vrs;
+        assert(vrs.object_ref() == obj.object_ref()) by {
+            assert(obj.kind == VReplicaSetView::kind());
+            assert(vrs.metadata == obj.metadata);
+        }
+        assert(s.resources()[obj.object_ref()] == obj);
+        assert(s_prime.resources() == s.resources());
+    }
+    assume(false);
+    assert forall |vrs: VReplicaSetView| #[trigger] old_vrs_list.contains(vrs) implies {
+        &&& valid_owned_object(vrs, vd)
+        &&& s_prime.resources().contains_key(vrs.object_ref())
+        &&& VReplicaSetView::unmarshal(s_prime.resources()[vrs.object_ref()])->Ok_0 == vrs
+        &&& vrs_list.contains(vrs)
+    } by {
+        // seq_filter_is_a_subset_of_original_seq cannot be replaced with broadcast use group_seq_properties
+        assert(filtered_vrs_list.contains(vrs)) by {
+            seq_filter_is_a_subset_of_original_seq(filtered_vrs_list, old_vrs_list_filter_with_new_vrs);
+        }
+        assert(vrs_list.contains(vrs) && valid_owned_object(vrs, vd)) by {
+            seq_filter_is_a_subset_of_original_seq(vrs_list, valid_owned_object_filter);
+        }
+        assert(valid_owned_object(vrs, vd));
+    }
+    assert(forall |i| #![trigger vds_prime.old_vrs_list[i]] 0 <= i < vds_prime.old_vrs_index ==> old_vrs_list.contains(vds_prime.old_vrs_list[i]));
+    assert(local_state_is_valid_and_coherent(vd, controller_id)(s_prime)) by {
+        let vds_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
+        assert(forall |i| #![trigger vds_prime.old_vrs_list[i]] 0 <= i < vds_prime.old_vrs_index ==> {
+            let vrs = vds_prime.old_vrs_list[i];
+            let key = vrs.object_ref();
+            &&& s_prime.resources().contains_key(key)
+            &&& valid_owned_object(vrs, vd)
+            &&& vrs.metadata.owner_references is Some
+            &&& vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
+            &&& filter_old_and_new_vrs_on_etcd(vd, s_prime.resources()).1.contains(vrs)
+            &&& VReplicaSetView::unmarshal(s_prime.resources()[key]) is Ok
+            &&& VReplicaSetView::unmarshal(s_prime.resources()[key])->Ok_0 == vrs
+        });
+    }
+}
+
 pub proof fn lemma_from_after_receive_list_vrs_resp_to_after_ensure_new_vrs(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, replicas: int, n: nat
 )
@@ -589,6 +745,7 @@ ensures
                         &&& obj.metadata.namespace == vd.metadata.namespace
                         &&& obj.metadata.owner_references is Some
                         &&& obj.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
+                        &&& s.resources().contains_key(obj.object_ref())
                     });
                     assert(at_vd_step_with_vd(vd, controller_id, at_step![(AfterEnsureNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))])(s_prime));
                     let vrs_list = vrs_list_or_none->0;
@@ -639,6 +796,20 @@ ensures
                             }
                         }
                     }
+                    assert forall |vrs| #[trigger] vrs_list.contains(vrs) implies {
+                        &&& s_prime.resources().contains_key(vrs.object_ref())
+                        &&& VReplicaSetView::unmarshal(s_prime.resources()[vrs.object_ref()])->Ok_0 == vrs
+                    } by {
+                        assert(resp_objs.map_values(|o: DynamicObjectView| VReplicaSetView::unmarshal(o).unwrap()).contains(vrs));
+                        let obj = choose |o: DynamicObjectView| #[trigger] resp_objs.contains(o) && VReplicaSetView::unmarshal(o).unwrap() == vrs;
+                        assert(vrs.object_ref() == obj.object_ref()) by {
+                            assert(obj.kind == VReplicaSetView::kind());
+                            assert(vrs.metadata == obj.metadata);
+                        }
+                        assert(s.resources()[obj.object_ref()] == obj);
+                        assert(s_prime.resources() == s.resources());
+                    }
+                    assume(false);
                     assert forall |vrs: VReplicaSetView| #[trigger] old_vrs_list.contains(vrs) implies {
                         &&& valid_owned_object(vrs, vd)
                         &&& s_prime.resources().contains_key(vrs.object_ref())
@@ -653,15 +824,11 @@ ensures
                             seq_filter_is_a_subset_of_original_seq(vrs_list, valid_owned_object_filter);
                         }
                         assert(valid_owned_object(vrs, vd));
-                        //
-                        assert(s_prime.resources().contains_key(vrs.object_ref()));
-                        //
-                        assert(VReplicaSetView::unmarshal(s_prime.resources()[vrs.object_ref()])->Ok_0 == vrs);
-                        assert(vrs_list.contains(vrs));
                     }
+                    assert(forall |i| #![trigger vds_prime.old_vrs_list[i]] 0 <= i < vds_prime.old_vrs_index ==> old_vrs_list.contains(vds_prime.old_vrs_list[i]));
                     assert(local_state_is_valid_and_coherent(vd, controller_id)(s_prime)) by {
-                        assert(0 <= vds_prime.old_vrs_index <= vds_prime.old_vrs_list.len());
-                        assert forall |i| #![trigger vds_prime.old_vrs_list[i]] 0 <= i < vds_prime.old_vrs_index implies {
+                        let vds_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
+                        assert(forall |i| #![trigger vds_prime.old_vrs_list[i]] 0 <= i < vds_prime.old_vrs_index ==> {
                             let vrs = vds_prime.old_vrs_list[i];
                             let key = vrs.object_ref();
                             &&& s_prime.resources().contains_key(key)
@@ -671,43 +838,7 @@ ensures
                             &&& filter_old_and_new_vrs_on_etcd(vd, s_prime.resources()).1.contains(vrs)
                             &&& VReplicaSetView::unmarshal(s_prime.resources()[key]) is Ok
                             &&& VReplicaSetView::unmarshal(s_prime.resources()[key])->Ok_0 == vrs
-                        } by {
-                            let vrs = vds_prime.old_vrs_list[i];
-                            let key = vrs.object_ref();
-                            assert(s_prime.resources().contains_key(key));
-                            assert(valid_owned_object(vrs, vd));
-                            assert(vrs.metadata.owner_references is Some);
-                            assert(vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]);
-                            assert(filter_old_and_new_vrs_on_etcd(vd, s_prime.resources()).1.contains(vrs));
-                            assert(VReplicaSetView::unmarshal(s_prime.resources()[key]) is Ok);
-                            assert(VReplicaSetView::unmarshal(s_prime.resources()[key])->Ok_0 == vrs);
-                        }
-                        assert(vds_prime.old_vrs_list.map_values(|vrs: VReplicaSetView| vrs.object_ref()).no_duplicates());
-                        assert(vds_prime.new_vrs is Some);
-                        assert({
-                            let new_vrs = vds_prime.new_vrs->0;
-                            &&& valid_owned_object(new_vrs, vd)
-                            &&& new_vrs.metadata.owner_references is Some
-                            &&& new_vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
-                            &&& !pending_create_new_vrs_req_in_flight(vd, controller_id)(s_prime) ==> {
-                                &&& s_prime.resources().contains_key(new_vrs.object_ref())
-                                &&& filter_old_and_new_vrs_on_etcd(vd, s_prime.resources()).0 is Some
-                                &&& vrs_eq_for_vd((filter_old_and_new_vrs_on_etcd(vd, s_prime.resources()).0)->0, new_vrs)
-                                &&& VReplicaSetView::unmarshal(s_prime.resources()[new_vrs.object_ref()]) is Ok
-                                &&& vrs_eq_for_vd(new_vrs, VReplicaSetView::unmarshal(s_prime.resources()[new_vrs.object_ref()]).unwrap())
-                            }
-                        }) by {
-                            let new_vrs = vds_prime.new_vrs->0;
-                            assert(valid_owned_object(new_vrs, vd));
-                            assert(new_vrs.metadata.owner_references is Some);
-                            assert(new_vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]);
-                            assert(!pending_create_new_vrs_req_in_flight(vd, controller_id)(s_prime));
-                            assert(s_prime.resources().contains_key(new_vrs.object_ref()));
-                            assert(filter_old_and_new_vrs_on_etcd(vd, s_prime.resources()).0 is Some);
-                            assert(vrs_eq_for_vd((filter_old_and_new_vrs_on_etcd(vd, s_prime.resources()).0)->0, new_vrs));
-                            assert(VReplicaSetView::unmarshal(s_prime.resources()[new_vrs.object_ref()]) is Ok);
-                            assert(vrs_eq_for_vd(new_vrs, VReplicaSetView::unmarshal(s_prime.resources()[new_vrs.object_ref()]).unwrap()));
-                        }
+                        });
                     }
                 }
             },

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -157,7 +157,7 @@ ensures
                     local_state_is_valid_and_coherent(vd, controller_id)
                 ));
                 assert forall |msg: Message| spec.entails(#[trigger] create_vrs_req_msg(msg).leads_to(create_vrs_resp)) by {
-                    lemma_from_after_send_create_pod_req_to_receive_ok_resp(vd, spec, cluster, controller_id, msg, n);
+                    lemma_from_after_send_create_new_vrs_req_to_receive_ok_resp(vd, spec, cluster, controller_id, msg, n);
                 }
                 leads_to_exists_intro(spec, |msg| create_vrs_req_msg(msg), create_vrs_resp);
                 let create_vrs_resp_msg = |msg: Message| lift_state(and!(
@@ -937,7 +937,7 @@ ensures
     );
 }
 
-pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
+pub proof fn lemma_from_after_send_create_new_vrs_req_to_receive_ok_resp(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, req_msg: Message, n: nat
 )
 requires

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -820,7 +820,6 @@ ensures
     );
 }
 
-#[verifier(external_body)]
 // need a step from exists to instantitated resp
 pub proof fn lemma_from_receive_ok_resp_after_create_new_vrs_to_after_ensure_new_vrs(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -1260,7 +1260,6 @@ ensures
     );
 }
 
-#[verifier(external_body)]
 pub proof fn lemma_from_after_send_get_then_update_req_to_receive_get_then_update_resp_on_old_vrs_of_n(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, req_msg: Message, n: nat
 )
@@ -1324,9 +1323,101 @@ ensures
                     lemma_api_request_other_than_pending_req_msg_maintains_local_state_coherence(
                         s, s_prime, vd, cluster, controller_id, msg
                     );
-                    // just to improve the stability
-                    if msg.src.is_controller_id(controller_id) {
-                    } else {}
+                    // TODO: we need a sililar structure to prove pending message is not changed in s_prime
+                    use crate::vdeployment_controller::proof::helper_invariants;
+                    // trigger
+                    assert(s.in_flight().contains(msg));
+                    let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
+                    let vds_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
+                    let new_vrs = vds.new_vrs->0;
+                    let etcd_obj = s.resources()[new_vrs.object_ref()];
+                    assert(etcd_obj.metadata.namespace == vd.metadata.namespace);
+                    assert(new_vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]);
+                    assert(!pending_create_new_vrs_req_in_flight(vd, controller_id)(s));
+                    assert(s.resources().contains_key(new_vrs.object_ref()));
+                    // rule out cases etcd_obj get deleted with rely_delete and handle_delete_eq checks
+                    assert(etcd_obj.metadata.owner_references->0.contains(vd.controller_owner_ref()));
+                    if msg.content.is_APIRequest() && msg.dst.is_APIServer() {
+                        match msg.src {
+                            HostId::Controller(id, cr_key) => {
+                                if id == controller_id {
+                                    if cr_key != vd.object_ref() {
+                                        // same controller, other vd
+                                        // every_msg_from_vd_controller_carries_vd_key
+                                        let cr_key = msg.src.get_Controller_1();
+                                        let other_vd = VDeploymentView {
+                                            metadata: ObjectMetaView {
+                                                name: Some(cr_key.name),
+                                                namespace: Some(cr_key.namespace),
+                                                ..make_vd().metadata
+                                            },
+                                            ..make_vd()
+                                        };
+                                        // so msg can only be list, create or get_then_update
+                                        assert(helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, other_vd)(s));
+                                        match msg.content.get_APIRequest_0() {
+                                            APIRequest::DeleteRequest(req) => assert(false), // vd controller doesn't send delete req
+                                            APIRequest::GetThenDeleteRequest(req) => assert(false),
+                                            APIRequest::GetThenUpdateRequest(req) => {
+                                                assert(no_other_pending_get_then_update_request_interferes_with_vd_reconcile(req, vd)(s));
+                                                assert(vd_reconcile_get_then_update_request_only_interferes_with_itself(req, other_vd)(s));
+                                                // controller_owner_ref does not carry namespace, while object_ref does
+                                                // so object_ref != is not enough to prove controller_owner_ref !=
+                                                if cr_key.namespace == vd.metadata.namespace->0 {
+                                                    assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
+                                                        if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
+                                                            assert(req.owner_ref != vd.controller_owner_ref());
+                                                            assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
+                                                        }
+                                                    }
+                                                } // or else, namespace is different, so should not be touched at all
+                                            },
+                                            _ => {},
+                                        }
+                                        VDeploymentReconcileState::marshal_preserves_integrity();
+                                    }
+                                } else {
+                                    let other_id = msg.src.get_Controller_0();
+                                    // by every_in_flight_req_msg_from_controller_has_valid_controller_id, used by vd_rely
+                                    assert(cluster.controller_models.contains_key(other_id));
+                                    assert(vd_rely(other_id)(s)); // trigger vd_rely_condition
+                                    VDeploymentReconcileState::marshal_preserves_integrity();
+                                    match msg.content.get_APIRequest_0() {
+                                        APIRequest::DeleteRequest(req) => {},
+                                        APIRequest::GetThenDeleteRequest(req) => {
+                                            if req.key.kind == VReplicaSetView::kind() {
+                                                assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
+                                                    if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
+                                                        assert(req.owner_ref != vd.controller_owner_ref());
+                                                        assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        APIRequest::GetThenUpdateRequest(req) => {
+                                            if req.obj.kind == VReplicaSetView::kind() {
+                                                // rely condition
+                                                assert({
+                                                    &&& req.owner_ref.controller is Some
+                                                    &&& req.owner_ref.controller->0
+                                                    &&& req.owner_ref.kind != VDeploymentView::kind()
+                                                });
+                                                assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
+                                                    if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
+                                                        assert(req.owner_ref != vd.controller_owner_ref());
+                                                        assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        APIRequest::UpdateRequest(req) => {}, // vd controller doesn't send update req
+                                        _ => {},
+                                    }
+                                }
+                            },
+                            _ => {}, // somehow this branch is slow
+                        }
+                    }
                 }
             },
             _ => {}
@@ -1346,7 +1437,6 @@ ensures
     );
 }
 
-#[verifier(external_body)]
 pub proof fn lemma_from_n_to_n_minus_one_on_old_vrs_len(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, n: nat
 )
@@ -1380,7 +1470,7 @@ ensures
     ));
     let scale_resp_msg = |msg: Message, n: nat| lift_state(and!(
         at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleDownOldVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-        exists_resp_msg_is_ok_get_then_update_resp(vd, controller_id),
+        resp_msg_is_ok_get_then_update_resp(vd, controller_id, msg),
         etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
         local_state_is_valid_and_coherent(vd, controller_id)
     ));
@@ -1504,97 +1594,6 @@ ensures
                 );
                 // trigger
                 assert(s.in_flight().contains(msg));
-                let vds = VDeploymentReconcileState::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
-                let vds_prime = VDeploymentReconcileState::unmarshal(s_prime.ongoing_reconciles(controller_id)[vd.object_ref()].local_state).unwrap();
-                let new_vrs = vds.new_vrs->0;
-                let etcd_obj = s.resources()[new_vrs.object_ref()];
-                assert(etcd_obj.metadata.namespace == vd.metadata.namespace);
-                assert(new_vrs.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]);
-                assert(!pending_create_new_vrs_req_in_flight(vd, controller_id)(s));
-                assert(s.resources().contains_key(new_vrs.object_ref()));
-                // rule out cases etcd_obj get deleted with rely_delete and handle_delete_eq checks
-                assert(etcd_obj.metadata.owner_references->0.contains(vd.controller_owner_ref()));
-                if msg.content.is_APIRequest() && msg.dst.is_APIServer() {
-                    match msg.src {
-                        HostId::Controller(id, cr_key) => {
-                            if id == controller_id {
-                                if cr_key != vd.object_ref() {
-                                    // same controller, other vd
-                                    // every_msg_from_vd_controller_carries_vd_key
-                                    let cr_key = msg.src.get_Controller_1();
-                                    let other_vd = VDeploymentView {
-                                        metadata: ObjectMetaView {
-                                            name: Some(cr_key.name),
-                                            namespace: Some(cr_key.namespace),
-                                            ..make_vd().metadata
-                                        },
-                                        ..make_vd()
-                                    };
-                                    // so msg can only be list, create or get_then_update
-                                    assert(helper_invariants::vd_reconcile_request_only_interferes_with_itself(controller_id, other_vd)(s));
-                                    match msg.content.get_APIRequest_0() {
-                                        APIRequest::DeleteRequest(req) => assert(false), // vd controller doesn't send delete req
-                                        APIRequest::GetThenDeleteRequest(req) => assert(false),
-                                        APIRequest::GetThenUpdateRequest(req) => {
-                                            assert(no_other_pending_get_then_update_request_interferes_with_vd_reconcile(req, vd)(s));
-                                            assert(vd_reconcile_get_then_update_request_only_interferes_with_itself(req, other_vd)(s));
-                                            // controller_owner_ref does not carry namespace, while object_ref does
-                                            // so object_ref != is not enough to prove controller_owner_ref !=
-                                            if cr_key.namespace == vd.metadata.namespace->0 {
-                                                assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
-                                                    if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
-                                                        assert(req.owner_ref != vd.controller_owner_ref());
-                                                        assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
-                                                    }
-                                                }
-                                            } // or else, namespace is different, so should not be touched at all
-                                        },
-                                        _ => {},
-                                    }
-                                    VDeploymentReconcileState::marshal_preserves_integrity();
-                                }
-                            } else {
-                                let other_id = msg.src.get_Controller_0();
-                                // by every_in_flight_req_msg_from_controller_has_valid_controller_id, used by vd_rely
-                                assert(cluster.controller_models.contains_key(other_id));
-                                assert(vd_rely(other_id)(s)); // trigger vd_rely_condition
-                                VDeploymentReconcileState::marshal_preserves_integrity();
-                                match msg.content.get_APIRequest_0() {
-                                    APIRequest::DeleteRequest(req) => {},
-                                    APIRequest::GetThenDeleteRequest(req) => {
-                                        if req.key.kind == VReplicaSetView::kind() {
-                                            assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
-                                                if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
-                                                    assert(req.owner_ref != vd.controller_owner_ref());
-                                                    assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
-                                                }
-                                            }
-                                        }
-                                    },
-                                    APIRequest::GetThenUpdateRequest(req) => {
-                                        if req.obj.kind == VReplicaSetView::kind() {
-                                            // rely condition
-                                            assert({
-                                                &&& req.owner_ref.controller is Some
-                                                &&& req.owner_ref.controller->0
-                                                &&& req.owner_ref.kind != VDeploymentView::kind()
-                                            });
-                                            assert(!etcd_obj.metadata.owner_references_contains(req.owner_ref)) by {
-                                                if etcd_obj.metadata.owner_references_contains(req.owner_ref) {
-                                                    assert(req.owner_ref != vd.controller_owner_ref());
-                                                    assert(etcd_obj.metadata.owner_references->0.filter(controller_owner_filter()).contains(req.owner_ref));
-                                                }
-                                            }
-                                        }
-                                    },
-                                    APIRequest::UpdateRequest(req) => {}, // vd controller doesn't send update req
-                                    _ => {},
-                                }
-                            }
-                        },
-                        _ => {}, // somehow this branch is slow
-                    }
-                }
             },
             Step::ControllerStep(input) => {
                 if input.0 == controller_id && input.1 == None::<Message> && input.2 == Some(vd.object_ref()) {

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -739,7 +739,6 @@ ensures
     );
 }
 
-#[verifier(external_body)]
 pub proof fn lemma_from_after_send_create_pod_req_to_receive_ok_resp(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, req_msg: Message, n: nat
 )

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -892,7 +892,7 @@ ensures
     );
 }
 
-#[verifier(external_body)]
+#[verifier(rlimit(100))]
 pub proof fn lemma_from_after_receive_list_vrs_resp_to_pending_scale_new_vrs_req_in_flight(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, replicas: int, n: nat
 )
@@ -919,8 +919,7 @@ ensures
     let pre = and!(
         at_vd_step_with_vd(vd, controller_id, at_step![AfterListVRS]),
         resp_msg_is_pending_list_resp_in_flight_and_match_req(vd, controller_id, resp_msg),
-        etcd_state_is(vd, controller_id, Some(replicas), n),
-        local_state_is_valid_and_coherent(vd, controller_id)
+        etcd_state_is(vd, controller_id, Some(replicas), n)
     );
     let post = and!(
         at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
@@ -949,6 +948,7 @@ ensures
             },
             Step::ControllerStep(input) => {
                 if input.0 == controller_id && input.1 == Some(resp_msg) && input.2 == Some(vd.object_ref()) {
+                    assume(false);
                     VDeploymentReconcileState::marshal_preserves_integrity();
                     // the request should carry the update of replicas, which requires reasoning over unmarshalling vrs
                     VReplicaSetView::marshal_preserves_integrity();

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -1047,7 +1047,6 @@ ensures
 }
 
 // same as lemma_from_receive_ok_resp_after_create_new_vrs_to_after_ensure_new_vrs
-#[verifier(external_body)]
 pub proof fn lemma_from_receive_ok_resp_after_scale_new_vrs_to_after_ensure_new_vrs(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
 )
@@ -1073,7 +1072,7 @@ ensures
 {
     let pre = and!(
         at_vd_step_with_vd(vd, controller_id, at_step![(AfterScaleNewVRS, local_state_is(Some(vd.spec.replicas.unwrap_or(int1!())), n))]),
-        resp_msg_is_ok_create_new_vrs_resp(vd, controller_id, resp_msg),
+        resp_msg_is_ok_get_then_update_resp(vd, controller_id, resp_msg),
         etcd_state_is(vd, controller_id, Some(vd.spec.replicas.unwrap_or(int1!())), n),
         local_state_is_valid_and_coherent(vd, controller_id)
     );

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -1352,6 +1352,8 @@ requires
     spec.entails(always(lift_action(cluster.next()))),
     spec.entails(tla_forall(|i: (Option<Message>, Option<ObjectRef>)| cluster.controller_next().weak_fairness((controller_id, i.0, i.1)))),
     spec.entails(tla_forall(|i| cluster.api_server_next().weak_fairness(i))),
+    spec.entails(always(lifted_vd_rely_condition_action(cluster, controller_id))),
+    spec.entails(always(lifted_vd_reconcile_request_only_interferes_with_itself_action(controller_id))),
     n > 0
 ensures
     spec.entails(lift_state(and!(

--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -693,6 +693,7 @@ ensures
         match step {
             Step::APIServerStep(input) => {
                 let msg = input->0;
+                let msg = input->0;
                 if msg == req_msg {
                     let resp_msg = lemma_create_new_vrs_request_returns_ok_after_ensure_new_vrs(
                         s, s_prime, vd, cluster, controller_id, msg, n
@@ -702,6 +703,11 @@ ensures
                         &&& s_prime.in_flight().contains(resp_msg)
                         &&& resp_msg_matches_req_msg(resp_msg, req_msg)
                     });
+                } else {
+                    let msg = input->0;
+                    lemma_api_request_other_than_pending_req_msg_maintains_local_state_coherence(
+                        s, s_prime, vd, cluster, controller_id, msg
+                    );
                 }
             },
             _ => {}
@@ -723,7 +729,7 @@ ensures
     );
 }
 
-// need a step from exists to instantitated resp
+#[verifier(rlimit(100))]
 pub proof fn lemma_from_receive_ok_resp_after_create_new_vrs_to_after_ensure_new_vrs(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
 )

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -130,6 +130,8 @@ pub open spec fn resp_msg_is_ok_list_resp_containing_matched_vrs(
         &&& obj.metadata.namespace == vd.metadata.namespace
         &&& obj.metadata.owner_references is Some
         &&& obj.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]
+        &&& s.resources().contains_key(obj.object_ref())
+        &&& s.resources()[obj.object_ref()] == obj
     }
 }
 

--- a/src/controllers/vdeployment_controller/proof/predicate.rs
+++ b/src/controllers/vdeployment_controller/proof/predicate.rs
@@ -125,8 +125,9 @@ pub open spec fn resp_msg_is_ok_list_resp_containing_matched_vrs(
     &&& resp_objs.map_values(|obj: DynamicObjectView| obj.object_ref()).no_duplicates()
     &&& resp_objs == s.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq()
     &&& filter_old_and_new_vrs(vd, vrs_list.filter(|vrs| valid_owned_object(vrs, vd))) == filter_old_and_new_vrs_on_etcd(vd, s.resources())
-    &&& forall |obj| #[trigger] resp_objs.contains(obj) ==> VReplicaSetView::unmarshal(obj) is Ok
     &&& forall |obj| #[trigger] resp_objs.contains(obj) ==> {
+        &&& VReplicaSetView::unmarshal(obj) is Ok
+        &&& obj.kind == VReplicaSetView::kind()
         &&& obj.metadata.namespace == vd.metadata.namespace
         &&& obj.metadata.owner_references is Some
         &&& obj.metadata.owner_references->0.filter(controller_owner_filter()) == seq![vd.controller_owner_ref()]


### PR DESCRIPTION
 - Prove **all** transition lemmas in `src/controllers/vdeployment_controller/proof/liveness/resource_match.rs`
 - Fix multiple bugs in `src/controllers/vdeployment_controller/proof/predicate.rs`
 - Move `local_state_is_valid_and_coherent` to post-conditions of `lemma_api_request_other_than_pending_req_msg_maintains_local_state_coherence` to make it more general