### PR TITLE
Fix bug in `resp_msg_is_ok_list_resp_containing_matched_vrs`

### DIFF
--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -673,6 +673,7 @@ ensures
     }
 }
 
+#[verifier(rlimit(100))]
 pub proof fn lemma_from_after_receive_list_vrs_resp_to_after_ensure_new_vrs(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, replicas: int, n: nat
 )
@@ -1216,6 +1217,7 @@ ensures
 }
 
 // same as lemma_from_receive_ok_resp_after_create_new_vrs_to_after_ensure_new_vrs
+#[verifier(rlimit(100))]
 pub proof fn lemma_from_receive_ok_resp_after_scale_new_vrs_to_after_ensure_new_vrs(
     vd: VDeploymentView, spec: TempPred<ClusterState>, cluster: Cluster, controller_id: int, resp_msg: Message, n: nat
 )

--- a/src/controllers/vdeployment_controller/trusted/liveness_theorem.rs
+++ b/src/controllers/vdeployment_controller/trusted/liveness_theorem.rs
@@ -21,11 +21,7 @@ pub open spec fn vd_eventually_stable_reconciliation_per_cr(vd: VDeploymentView)
 // TODO: add another version which talks about pods and derives from VRS ESR and this ESR
 pub open spec fn current_state_matches(vd: VDeploymentView) -> StatePred<ClusterState> {
     |s: ClusterState| {
-        // make it consistent with API server's handle_list_req
-        let objs = s.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq();
         let (new_vrs, old_vrs_list) = filter_old_and_new_vrs_on_etcd(vd, s.resources());
-        // this step may return None so we need to check here
-        &&& objects_to_vrs_list(objs) is Some
         &&& old_vrs_list.len() == 0
         &&& new_vrs is Some
         &&& match_template_without_hash(vd, new_vrs->0)


### PR DESCRIPTION
- Removed unused `resp_objs == s.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq()` from `resp_msg_is_ok_list_resp_containing_matched_vrs`
- It turned out to be an unnecessary requirement added to ESR, removed altogether
  ```rust
  let objs = s.resources().values().filter(list_vrs_obj_filter(vd.metadata.namespace)).to_seq();
  objects_to_vrs_list(objs) is Some
  ```
- Add comments explaining ownership of VRS by VD controller