### PR TITLE
Weaken at_vd_step_with_vd to not talk about vd RV

### DIFF
--- a/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
+++ b/src/controllers/vdeployment_controller/proof/liveness/resource_match.rs
@@ -534,7 +534,6 @@ ensures
     VReplicaSetView::marshal_preserves_integrity();
     broadcast use group_seq_properties;
     let triggering_cr = VDeploymentView::unmarshal(s.ongoing_reconciles(controller_id)[vd.object_ref()].triggering_cr).unwrap();
-    assert(triggering_cr.metadata == vd.metadata);
     assert(triggering_cr.object_ref() == vd.object_ref());
     let resp_objs = resp_msg.content.get_list_response().res.unwrap();
     let vrs_list_or_none = objects_to_vrs_list(resp_objs);
@@ -632,8 +631,8 @@ ensures
         None => {
             &&& new_vrs is None
             &&& vds_prime.reconcile_step == AfterCreateNewVRS
-            &&& vds_prime.new_vrs == Some(make_replica_set(vd))
-            &&& pending_create_new_vrs_req_in_flight(vd, controller_id)(s_prime)
+            &&& vds_prime.new_vrs == Some(make_replica_set(triggering_cr))
+            &&& pending_create_new_vrs_req_in_flight(triggering_cr, controller_id)(s_prime)
         },
         Some(replicas) => {
             &&& new_vrs is Some
@@ -661,11 +660,11 @@ ensures
     assert(0 <= vds_prime.old_vrs_index <= vds_prime.old_vrs_list.len());
     assert(vds_prime.old_vrs_list.map_values(|vrs: VReplicaSetView| vrs.object_ref()).no_duplicates());
     if replicas_or_not_exist is None {
-        make_replica_set_makes_valid_owned_object(vd);
-        assert(vds_prime.new_vrs == Some(make_replica_set(vd)));
+        make_replica_set_makes_valid_owned_object(triggering_cr);
+        assert(vds_prime.new_vrs == Some(make_replica_set(triggering_cr)));
         let new_vrs = vds_prime.new_vrs->0;
-        let vd_ref_seq = make_owner_references(vd);
-        assert(vd_ref_seq == Seq::empty().push(vd.controller_owner_ref()));
+        let vd_ref_seq = make_owner_references(triggering_cr);
+        assert(vd_ref_seq == Seq::empty().push(triggering_cr.controller_owner_ref()));
         assert(vd_ref_seq.filter(controller_owner_filter()) == vd_ref_seq) by {
             reveal(Seq::filter);
         }


### PR DESCRIPTION
This is a simpler workaround compared to weaken `vd.well_formed` requirement for utility functions or adapt `generate_name`